### PR TITLE
fix: F5 Untamed toggle (closes #9, closes #8)

### DIFF
--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -537,6 +537,29 @@ export function buildMechanicSlotsForRender({
           isF5AboveOrb: true,
         });
       }
+    } else if (eliteSpecId === 72) {
+      // Untamed: default state is Unleash Pet (normal pet bar: attack / pet F2 / return).
+      // Toggling F5 activates Unleash Ranger (activeKit=63147), which gives the pet empowered
+      // commands at F1-F3 (Venomous Outburst, Rending Vines, Enveloping Haze).
+      const unleashRangerActive = activeKit === 63147;
+      if (unleashRangerActive) {
+        // Unleash Ranger active: pet gets empowered commands
+        const venomousOutburst = catalog.skillById.get(63209) || null;
+        const rendingVines = catalog.skillById.get(63258) || null;
+        const envHaze = catalog.skillById.get(63094) || null;
+        mechSlots.push({ skill: venomousOutburst, sourceId: venomousOutburst?.id || 0, isStatic: true, isSelectable: false });
+        mechSlots.push({ skill: rendingVines, sourceId: rendingVines?.id || 0, isStatic: true, isSelectable: false });
+        mechSlots.push({ skill: envHaze, sourceId: envHaze?.id || 0, isStatic: true, isSelectable: false });
+      } else {
+        // Unleash Pet active (default): normal pet controls (attack / pet F2 / return)
+        mechSlots.push({ skill: null, sourceId: 0, isStatic: true, isSelectable: false, fakeCommand: "attack" });
+        const petSkills = activePet?.skills || [];
+        const isAquaticSlot = activePetSlotKey === "aquatic1" || activePetSlotKey === "aquatic2";
+        const f2SkillIdx = isAquaticSlot && petSkills.length > 1 ? 1 : 0;
+        const f2Skill = petSkills[f2SkillIdx] || null;
+        mechSlots.push({ skill: f2Skill, sourceId: f2Skill?.id || 0, isStatic: true, isSelectable: false });
+        mechSlots.push({ skill: null, sourceId: 0, isStatic: true, isSelectable: false, fakeCommand: "return" });
+      }
     } else {
       mechSlots.push({ skill: null, sourceId: 0, isStatic: true, isSelectable: false, fakeCommand: "attack" });
       const petSkills = activePet?.skills || [];
@@ -544,17 +567,30 @@ export function buildMechanicSlotsForRender({
       const f2SkillIdx = isAquaticSlot && petSkills.length > 1 ? 1 : 0;
       const f2Skill = petSkills[f2SkillIdx] || null;
       mechSlots.push({ skill: f2Skill, sourceId: f2Skill?.id || 0, isStatic: true, isSelectable: false });
-      if (eliteSpecId === 72) {
-        const envHaze = catalog.skillById.get(63094) || null;
-        mechSlots.push({ skill: envHaze, sourceId: envHaze?.id || 0, isStatic: true, isSelectable: false });
-      } else {
-        mechSlots.push({ skill: null, sourceId: 0, isStatic: true, isSelectable: false, fakeCommand: "return" });
-      }
+      mechSlots.push({ skill: null, sourceId: 0, isStatic: true, isSelectable: false, fakeCommand: "return" });
     }
     if (eliteSpecId !== 55) {
-      const p5Skill = (nextOptions.profession || []).find((s) => s.slot === "Profession_5") || null;
-      if (p5Skill) {
-        mechSlots.push({ skill: p5Skill, sourceId: p5Skill.id, isStatic: true, isSelectable: false, fKeyLabel: "F5", isF5AboveOrb: true });
+      if (eliteSpecId === 72) {
+        // Untamed: F5 is a toggle between "Unleash Ranger" (63147) and "Unleash Pet" (63344).
+        const unleashRanger = catalog.skillById.get(63147) || null;
+        const unleashPet = catalog.skillById.get(63344) || null;
+        const unleashRangerActive = activeKit === 63147;
+        // Show current state: default = Unleash Pet, toggled = Unleash Ranger
+        const displaySkill = unleashRangerActive ? unleashRanger : unleashPet;
+        if (displaySkill) {
+          mechSlots.push({
+            skill: displaySkill, sourceId: displaySkill.id, isStatic: true, isSelectable: false,
+            isUnleashToggle: true,
+            leaveIcon: unleashRanger?.icon || "",
+            fKeyLabel: "F5",
+            isF5AboveOrb: true,
+          });
+        }
+      } else {
+        const p5Skill = (nextOptions.profession || []).find((s) => s.slot === "Profession_5") || null;
+        if (p5Skill) {
+          mechSlots.push({ skill: p5Skill, sourceId: p5Skill.id, isStatic: true, isSelectable: false, fKeyLabel: "F5", isF5AboveOrb: true });
+        }
       }
     }
   } else {
@@ -1029,14 +1065,15 @@ export function renderSkills() {
       Number(skillSource?.eliteId) || 0,
     ].filter(Boolean));
     const isEquippedSlotKit = (kitSkill?.bundleSkills?.length ?? 0) > 0 && equippedIds.has(activeKit);
-    // Soulbeast Beastmode has no bundle_skills in the API; allow it to persist via isBeastmodeToggle.
+    // Soulbeast Beastmode / Untamed Unleash have no bundle_skills in the API; allow them to persist.
     const isBeastmodeKit = mechSlots.some((s) => s.isBeastmodeToggle && s.skill?.id === activeKit);
+    const isUnleashKit = mechSlots.some((s) => s.isUnleashToggle) && activeKit === 63147;
     const isBerserkKit = mechSlots.some((s) => s.isBerserkToggle && s.skill?.id === activeKit);
     // Bladesworn: Gunsaber (62745) and Dragon Trigger (62803) are both valid active kits; the
     // displayed skill changes to the flip variant when active so we can't match by skill.id.
     const isBladeswornKit = (mechSlots.some((s) => s.isGunsaberToggle) || mechSlots.some((s) => s.isDragonTriggerToggle))
       && (activeKit === 62745 || activeKit === 62803);
-    if (!isStaticBundle && !isToolbeltSource && !isEquippedSlotKit && !isBeastmodeKit && !isBerserkKit && !isBladeswornKit) {
+    if (!isStaticBundle && !isToolbeltSource && !isEquippedSlotKit && !isBeastmodeKit && !isUnleashKit && !isBerserkKit && !isBladeswornKit) {
       state.editor.activeKit = 0;
     }
   }
@@ -1116,7 +1153,7 @@ export function renderSkills() {
     mechBar.className = "profession-mechanics-bar";
 
     for (let fIdx = 0; fIdx < mechSlots.length; fIdx++) {
-      const { skill, sourceId, sourceSkill, isStatic, isSelectable, morphIndex, mechIconOverride, fakeCommand, isBeastmodeToggle, isBerserkToggle, isGunsaberToggle, isDragonTriggerToggle, leaveIcon, fKeyLabel, isF5AboveOrb, isAllianceTactics, isAntiquarySkritSwipe } = mechSlots[fIdx];
+      const { skill, sourceId, sourceSkill, isStatic, isSelectable, morphIndex, mechIconOverride, fakeCommand, isBeastmodeToggle, isBerserkToggle, isGunsaberToggle, isDragonTriggerToggle, isUnleashToggle, leaveIcon, fKeyLabel, isF5AboveOrb, isAllianceTactics, isAntiquarySkritSwipe } = mechSlots[fIdx];
       const slotEl = document.createElement("div");
       slotEl.className = "skill-slot";
       const iconBtn = document.createElement("button");
@@ -1128,7 +1165,7 @@ export function renderSkills() {
       const srcSkillForKit = (!isStatic && isToolbelt) ? catalog.skillById.get(sourceId) : null;
       const isKit = !isStatic && isToolbelt
         ? (srcSkillForKit?.bundleSkills?.length ?? 0) > 0
-        : isStatic && ((skill?.bundleSkills?.length ?? 0) > 0 || !!isBeastmodeToggle || !!isBerserkToggle || !!isGunsaberToggle || !!isDragonTriggerToggle);
+        : isStatic && ((skill?.bundleSkills?.length ?? 0) > 0 || !!isBeastmodeToggle || !!isUnleashToggle || !!isBerserkToggle || !!isGunsaberToggle || !!isDragonTriggerToggle);
 
       let isActive = false;
       if (isSelectable) {
@@ -1141,7 +1178,7 @@ export function renderSkills() {
         isActive = resolvedKit === 62745;
       } else if (isDragonTriggerToggle) {
         isActive = resolvedKit === 62803;
-      } else if (isStatic && ((skill?.bundleSkills?.length ?? 0) > 0 || isBeastmodeToggle || isBerserkToggle)) {
+      } else if (isStatic && ((skill?.bundleSkills?.length ?? 0) > 0 || isBeastmodeToggle || isUnleashToggle || isBerserkToggle)) {
         // Static bundle skills: shroud, celestial avatar, Photon Forge, beastmode, Berserk, etc.
         isActive = resolvedKit === skill?.id;
       } else if (isStatic && !isToolbelt) {
@@ -1314,12 +1351,15 @@ export function renderSkills() {
             if (skill) selectDetail("skill", skill);
             return;
           }
-          if (isStatic && ((skill?.bundleSkills?.length ?? 0) > 0 || isBeastmodeToggle || isGunsaberToggle || isDragonTriggerToggle)) {
-            // Static bundle skill (shroud, Photon Forge, beastmode, Gunsaber, Dragon Trigger, etc.): toggle active state.
+          if (isStatic && ((skill?.bundleSkills?.length ?? 0) > 0 || isBeastmodeToggle || isUnleashToggle || isGunsaberToggle || isDragonTriggerToggle)) {
+            // Static bundle skill (shroud, Photon Forge, beastmode, Unleash, Gunsaber, Dragon Trigger, etc.): toggle active state.
             if (isGunsaberToggle) {
               state.editor.activeKit = resolvedKit === 62745 ? 0 : 62745;
             } else if (isDragonTriggerToggle) {
               state.editor.activeKit = resolvedKit === 62803 ? 0 : 62803;
+            } else if (isUnleashToggle) {
+              // Toggle between Unleash Ranger active (63147) and inactive (0)
+              state.editor.activeKit = activeKit === 63147 ? 0 : 63147;
             } else {
               state.editor.activeKit = resolvedKit === skill.id ? 0 : skill.id;
             }

--- a/tests/fixtures/gw2Api.js
+++ b/tests/fixtures/gw2Api.js
@@ -146,6 +146,12 @@ const MOCK_PROFESSIONS = {
       { id: 5503, slot: "Heal",        specialization: 0,  type: "Heal" },
       { id: 12489, slot: "Utility",    specialization: 0,  type: "Utility" },
       { id: 12540, slot: "Elite",      specialization: 0,  type: "Elite" },
+      // Untamed profession skills
+      { id: 63209, slot: "Profession_1", specialization: 72, type: "Profession" },
+      { id: 63258, slot: "Profession_2", specialization: 72, type: "Profession" },
+      { id: 63094, slot: "Profession_3", specialization: 72, type: "Profession" },
+      { id: 63147, slot: "Profession_5", specialization: 72, type: "Profession" },
+      { id: 63344, slot: "Profession_5", specialization: 72, type: "Profession" },
     ],
     weapons: {
       Longbow: {
@@ -594,6 +600,13 @@ const MOCK_SKILLS = {
   12489: makeSkill(12489, { name: "Muddy Terrain", slot: "Utility", type: "Utility", professions: ["Ranger"] }),
   12540: makeSkill(12540, { name: "Entangle",      slot: "Elite",   type: "Elite",   professions: ["Ranger"] }),
   12466: makeSkill(12466, { name: "Long Range Shot", slot: "Weapon_1", type: "Weapon", weapon_type: "Longbow" }),
+  // Untamed profession skills — empowered pet commands (F1-F3 when Unleash Pet active)
+  63209: makeSkill(63209, { name: "Venomous Outburst", slot: "Profession_1", type: "Profession", specialization: 72, professions: ["Ranger"] }),
+  63258: makeSkill(63258, { name: "Rending Vines",     slot: "Profession_2", type: "Profession", specialization: 72, professions: ["Ranger"] }),
+  63094: makeSkill(63094, { name: "Enveloping Haze",   slot: "Profession_3", type: "Profession", specialization: 72, professions: ["Ranger"] }),
+  // Untamed F5 toggle
+  63147: makeSkill(63147, { name: "Unleash Ranger", slot: "Profession_5", type: "Profession", specialization: 72, professions: ["Ranger"] }),
+  63344: makeSkill(63344, { name: "Unleash Pet",    slot: "Profession_5", type: "Profession", specialization: 72, professions: ["Ranger"] }),
 
   // ---- Thief ----
   13050: makeSkill(13050, { name: "Channeled Vigor", slot: "Heal", type: "Heal", professions: ["Thief"] }),

--- a/tests/integration/professions/ranger.test.js
+++ b/tests/integration/professions/ranger.test.js
@@ -68,15 +68,18 @@ describe("Ranger — end-to-end profession mechanics", () => {
   test("Untamed (spec 72) replaces F3 Return command with an empty profession skill slot", async () => {
     const catalog = await h.loadCatalog();
     const untamed = h.resolveMechSlots(catalog, 72);
-    expect(untamed).toEqual(["fake:attack", "12478", "empty"]);
-    expect(untamed[2]).not.toBe("fake:return");
+    // Default Untamed: Unleash Pet active → normal pet bar F1-F3 + Unleash Ranger F5
+    expect(untamed).toEqual(["fake:attack", "12478", "fake:return", "63344"]);
+    expect(untamed[2]).toBe("fake:return");
   });
 
-  test("Untamed F3 differs from core and Soulbeast F3", async () => {
+  test("Untamed default has same F1-F3 as core (normal pet bar), but adds F5 Unleash", async () => {
     const catalog = await h.loadCatalog();
     const core = h.resolveMechSlots(catalog, 0);
     const untamed = h.resolveMechSlots(catalog, 72);
-    expect(untamed[2]).not.toBe(core[2]);
+    // Default Untamed (Unleash Pet) has normal pet bar like core, plus F5
+    expect(untamed.slice(0, 3)).toEqual(core);
+    expect(untamed[3]).toBe("63344"); // Unleash Pet F5 (default state)
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/renderer/ranger.test.js
+++ b/tests/unit/renderer/ranger.test.js
@@ -5,7 +5,7 @@ const { createMechanicsSuite, setupMechanicsHarness } = require("./mechanicsSuit
 createMechanicsSuite("Ranger", [
   { specId: 0, expected: ["fake:attack", "12478", "fake:return"] },
   { specId: 55, expected: ["fake:attack", "12478", "fake:return"] },
-  { specId: 72, expected: ["fake:attack", "12478", "empty"] },
+  { specId: 72, expected: ["fake:attack", "12478", "fake:return", "63344"] },
 ]);
 
 describe("renderer mechanics selection — Ranger core vs elite F skills", () => {
@@ -22,10 +22,49 @@ describe("renderer mechanics selection — Ranger core vs elite F skills", () =>
     expect(soulbeast.signatures).toEqual(core.signatures);
   });
 
-  test("Untamed replaces F3 return command with a profession skill slot", async () => {
+  test("Untamed default (Unleash Pet) shows normal pet bar at F1-F3", async () => {
     const untamed = await resolve({ specId: 72 });
-    expect(untamed.signatures).toEqual(["fake:attack", "12478", "empty"]);
-    expect(untamed.signatures[2]).not.toBe("fake:return");
+    expect(untamed.signatures).toEqual(["fake:attack", "12478", "fake:return", "63344"]);
+  });
+});
+
+describe("renderer mechanics selection — Untamed F5 Unleash toggle", () => {
+  const resolve = setupMechanicsHarness("Ranger");
+
+  test("Untamed has F5 Unleash skill as a toggleable slot", async () => {
+    const untamed = await resolve({ specId: 72 });
+    const f5Slot = untamed.result.mechSlots.find((s) => s.fKeyLabel === "F5");
+    expect(f5Slot).toBeDefined();
+    expect(f5Slot.skill).toBeDefined();
+    expect(f5Slot.isUnleashToggle).toBe(true);
+  });
+
+  test("F5 shows Unleash Pet by default (current state)", async () => {
+    const defaultState = await resolve({ specId: 72 });
+    const f5 = defaultState.result.mechSlots.find((s) => s.fKeyLabel === "F5");
+    expect(f5.skill.id).toBe(63344); // Unleash Pet (current state)
+  });
+
+  test("F5 shows Unleash Ranger when toggled", async () => {
+    const unleashed = await resolve({ specId: 72, activeKit: 63147 });
+    const f5 = unleashed.result.mechSlots.find((s) => s.fKeyLabel === "F5");
+    expect(f5.skill.id).toBe(63147); // Unleash Ranger (current state)
+  });
+
+  test("Unleash Ranger active shows empowered pet commands at F1-F3", async () => {
+    const unleashed = await resolve({ specId: 72, activeKit: 63147 });
+    const sigs = unleashed.signatures;
+    expect(sigs[0]).toBe("63209"); // Venomous Outburst
+    expect(sigs[1]).toBe("63258"); // Rending Vines
+    expect(sigs[2]).toBe("63094"); // Enveloping Haze
+  });
+
+  test("Default state (Unleash Pet) shows normal pet commands at F1-F3", async () => {
+    const untamed = await resolve({ specId: 72 });
+    const sigs = untamed.signatures;
+    expect(sigs[0]).toBe("fake:attack");
+    expect(sigs[1]).toBe("12478");
+    expect(sigs[2]).toBe("fake:return");
   });
 });
 
@@ -72,13 +111,15 @@ describe("renderer mechanics selection — Ranger aquatic pets underwater", () =
     expect(underwater.signatures).toEqual(["fake:attack", "empty", "fake:return"]);
   });
 
-  test("Untamed underwater still replaces F3 return with profession skill", async () => {
+  test("Untamed underwater has F5 Unleash toggle", async () => {
     const underwater = await resolve({
       specId: 72,
       underwaterMode: true,
       selectedPets: aquaticPets,
       activePetSlot: "aquatic1",
     });
-    expect(underwater.signatures[2]).not.toBe("fake:return");
+    const f5 = underwater.result.mechSlots.find((s) => s.fKeyLabel === "F5");
+    expect(f5).toBeDefined();
+    expect(f5.isUnleashToggle).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

The Untamed F5 (Unleash) mechanic was rendered as a static, non-clickable button. This implements it as a proper toggle:

- **Default state (Unleash Pet):** Shows normal pet bar (Attack / Pet F2 / Return) with F5 displaying "Unleash Pet"
- **Toggled state (Unleash Ranger):** F1-F3 swap to empowered pet commands (Venomous Outburst, Rending Vines, Enveloping Haze) and F5 shows "Unleash Ranger"

Implementation follows the existing Soulbeast Beastmode toggle pattern — uses `activeKit` to track the toggle state and `isUnleashToggle` flag for the renderer.

Added mock fixture data for Untamed skills (63209, 63258, 63094, 63147, 63344) and 7 new tests covering both toggle states.

Closes #9
Closes #8