### PR TITLE
fix: Dragonhunter F1 showing wrong skill (closes #11)

### DIFF
--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -108,11 +108,14 @@ export function getSkillOptionsByType(catalog, specializationSelections, underwa
   const profMechanics = allSkills
     .filter((skill) => PROFESSION_SLOT_RE.test(skill.slot || ""))
     .filter((skill) => !exitLeavePattern.test(skill.name || ""))
-    // Exclude flip targets unless they are explicitly in the profession endpoint.
-    // Using inProfessionEndpoint (not flipParentIds) as the gate because mutual flip pairs
-    // like Deadeye's Mark (43390) ↔ Steal Time would both pass a flipParentIds check, yet
-    // "Steal Time" is a transient post-activation state that must not show as a permanent slot.
-    .filter((skill) => !flipSkillIds.has(skill.id) || skill.inProfessionEndpoint)
+    // Exclude flip targets unless they are explicitly in the profession endpoint OR they are
+    // elite-spec profession mechanics that themselves flip to another skill (i.e. a "base" state
+    // in a flip chain). Example: Dragonhunter's Spear of Justice (29887) is a flip target of
+    // Virtue of Justice AND flips to Hunter's Verdict — it's the permanent F1 mechanic.
+    // Hunter's Verdict (33134) is also a flip target but has flipSkill=0 — it's the transient
+    // "activated" state and should remain excluded.
+    .filter((skill) => !flipSkillIds.has(skill.id) || skill.inProfessionEndpoint
+      || (PROFESSION_SLOT_RE.test(skill.slot || "") && Number(skill.specialization) > 0 && skill.flipSkill > 0))
     // Exclude skills that are not tied to any profession, unless they are explicitly listed
     // in the profession endpoint (inProfessionEndpoint). Some legitimate F-slot mechanics
     // (e.g. Chant of Freedom 77155) have professions:[] in /v2/skills due to an API bug

--- a/tests/fixtures/gw2Api.js
+++ b/tests/fixtures/gw2Api.js
@@ -106,9 +106,9 @@ const MOCK_PROFESSIONS = {
       // Luminary Radiant Forge
       { id: 77073, slot: "Profession_1",  specialization: 81,   type: "Profession" }, // Enter Radiant Forge
       // Virtues (core)
-      { id: 29887, slot: "Profession_1",  specialization: null, type: "Profession" }, // DH F1 (from trait)
-      { id: 30783, slot: "Profession_2",  specialization: null, type: "Profession" }, // DH F2 (from trait)
-      { id: 30029, slot: "Profession_3",  specialization: null, type: "Profession" }, // DH F3 (from trait)
+      { id: 29887, slot: "Profession_1",  specialization: 27,   type: "Profession" }, // DH F1 (from trait)
+      { id: 30783, slot: "Profession_2",  specialization: 27,   type: "Profession" }, // DH F2 (from trait)
+      { id: 30029, slot: "Profession_3",  specialization: 27,   type: "Profession" }, // DH F3 (from trait)
       { id: 9,     slot: "Elite",         specialization: null, type: "Elite" },
     ],
     weapons: {
@@ -476,6 +476,26 @@ function makeSkill(id, overrides = {}) {
 }
 
 const MOCK_SKILLS = {
+  // ---- Guardian ----
+  9083:  makeSkill(9083,  { name: "Shelter",          slot: "Heal",         type: "Heal",       professions: ["Guardian"] }),
+  9168:  makeSkill(9168,  { name: "Bane Signet",      slot: "Utility",      type: "Utility",    professions: ["Guardian"] }),
+  9:     makeSkill(9,     { name: "Renewed Focus",    slot: "Elite",        type: "Elite",      professions: ["Guardian"] }),
+  // Core Guardian virtues — Virtue of Justice flips to Spear of Justice (DH)
+  9115:  makeSkill(9115,  { name: "Virtue of Justice",  slot: "Profession_1", type: "Profession", professions: ["Guardian"], flip_skill: 29887 }),
+  9120:  makeSkill(9120,  { name: "Virtue of Resolve",  slot: "Profession_2", type: "Profession", professions: ["Guardian"], flip_skill: 30783 }),
+  9107:  makeSkill(9107,  { name: "Virtue of Courage",  slot: "Profession_3", type: "Profession", professions: ["Guardian"], flip_skill: 30029 }),
+  // Dragonhunter F1-F3 (flip targets of core virtues, spec 27)
+  29887: makeSkill(29887, { name: "Spear of Justice",   slot: "Profession_1", type: "Profession", specialization: 27, professions: ["Guardian"], flip_skill: 33134 }),
+  30783: makeSkill(30783, { name: "Wings of Resolve",   slot: "Profession_2", type: "Profession", specialization: 27, professions: ["Guardian"] }),
+  30029: makeSkill(30029, { name: "Shield of Courage",  slot: "Profession_3", type: "Profession", specialization: 27, professions: ["Guardian"] }),
+  33134: makeSkill(33134, { name: "Hunter's Verdict",   slot: "Profession_1", type: "Profession", specialization: 27, professions: ["Guardian"] }),
+  // Firebrand tomes (spec 62)
+  44364: makeSkill(44364, { name: "Tome of Justice",  slot: "Profession_1", type: "Profession", specialization: 62, professions: ["Guardian"] }),
+  41780: makeSkill(41780, { name: "Tome of Resolve",  slot: "Profession_2", type: "Profession", specialization: 62, professions: ["Guardian"] }),
+  42259: makeSkill(42259, { name: "Tome of Courage",  slot: "Profession_3", type: "Profession", specialization: 62, professions: ["Guardian"] }),
+  // Luminary (spec 81)
+  77073: makeSkill(77073, { name: "Enter Radiant Forge", slot: "Profession_1", type: "Profession", specialization: 81, professions: ["Guardian"] }),
+
   // ---- Warrior ----
   14402: makeSkill(14402, { name: "Mending",      slot: "Heal",    type: "Heal",    professions: ["Warrior"], flags: [] }),
   14516: makeSkill(14516, { name: "Balanced Stance", slot: "Utility", type: "Utility", professions: ["Warrior"], flags: ["NoUnderwater"] }),


### PR DESCRIPTION
## Summary

Dragonhunter's F1 showed core Virtue of Justice instead of Spear of Justice. The root cause was the flip-target filter in `getSkillOptionsByType()` — Spear of Justice (29887) is a flip target of Virtue of Justice (9115) and wasn't in the profession endpoint, so it was excluded. The fix allows elite-spec profession mechanics that are flip targets but also have their own `flipSkill` (indicating they're a permanent base state, not a transient activated state like Hunter's Verdict).

Closes #11