### PR TITLE
feat: boon & condition coverage display on skill bar

### DIFF
--- a/docs/superpowers/plans/2026-03-14-boon-condition-coverage.md
+++ b/docs/superpowers/plans/2026-03-14-boon-condition-coverage.md
@@ -1,0 +1,773 @@
+# Boon & Condition Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Display boon and condition coverage icons above the utility skill bar, computed from all skills and traits in the current build.
+
+**Architecture:** A new `boon-coverage.js` module computes coverage data from skill/trait facts. The `renderSkills()` function in `skills.js` calls this and renders two icon rows (boons + conditions) above the utility group inside a new flex-column wrapper. New constants define boon/condition name sets and display ordering.
+
+**Tech Stack:** Vanilla JS (ES modules), CSS, Jest for tests
+
+---
+
+## Chunk 1: Constants and Computation Module
+
+### Task 1: Add boon/condition constants
+
+**Files:**
+- Modify: `src/renderer/modules/constants.js:451` (after `BUFF_FACT_TYPES`)
+
+- [ ] **Step 1: Add the new constants after `BUFF_FACT_TYPES` (line 451)**
+
+```js
+export const BOON_NAMES = new Set([
+  "Aegis", "Alacrity", "Fury", "Might", "Protection", "Quickness",
+  "Regeneration", "Resistance", "Resolution", "Stability", "Swiftness", "Vigor",
+]);
+
+export const CONDITION_NAMES = new Set([
+  "Bleeding", "Blind", "Blinded", "Burning", "Chill", "Chilled",
+  "Confusion", "Cripple", "Crippled", "Fear", "Immobile", "Immobilize", "Immobilized",
+  "Poison", "Poisoned", "Slow", "Taunt", "Torment",
+  "Vulnerability", "Weakness",
+]);
+
+export const CONDITION_NAME_NORMALIZE = {
+  Blind: "Blinded", Chill: "Chilled", Cripple: "Crippled",
+  Immobilize: "Immobile", Immobilized: "Immobile", Poison: "Poisoned",
+};
+
+export const BOON_DISPLAY_ORDER = [
+  "Aegis", "Alacrity", "Fury", "Might", "Protection", "Quickness",
+  "Regeneration", "Resistance", "Resolution", "Stability", "Swiftness", "Vigor",
+];
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/renderer/modules/constants.js
+git commit -m "feat: add boon/condition name constants and display order"
+```
+
+---
+
+### Task 2: Write failing tests for `computeBoonCoverage`
+
+**Files:**
+- Create: `tests/unit/renderer/boon-coverage.test.js`
+
+- [ ] **Step 1: Write the test file**
+
+```js
+"use strict";
+
+const { computeBoonCoverage } = require("../../../src/renderer/modules/boon-coverage");
+
+function makeCatalog(overrides = {}) {
+  return {
+    skillById: overrides.skillById || new Map(),
+    traitById: overrides.traitById || new Map(),
+    weaponSkillById: overrides.weaponSkillById || new Map(),
+    professionWeapons: overrides.professionWeapons || {},
+    ...overrides,
+  };
+}
+
+function makeEditor(overrides = {}) {
+  return {
+    skills: { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 },
+    specializations: [],
+    equipment: { weapons: {} },
+    underwaterMode: false,
+    ...overrides,
+  };
+}
+
+function makeSkill(id, name, facts = [], extra = {}) {
+  return { id, name, description: "", facts, type: "Utility", ...extra };
+}
+
+function makeTrait(id, name, facts = [], extra = {}) {
+  return { id, name, description: "", facts, ...extra };
+}
+
+function buffFact(status, duration = 0, applyCount = 0) {
+  return { type: "Buff", status, duration, apply_count: applyCount };
+}
+
+describe("computeBoonCoverage", () => {
+  test("returns empty arrays when no skills or traits have buff facts", () => {
+    const catalog = makeCatalog();
+    const editor = makeEditor();
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toEqual([]);
+    expect(result.conditions).toEqual([]);
+  });
+
+  test("extracts boon from a heal skill", () => {
+    const skill = makeSkill(100, "Healing Breeze", [buffFact("Regeneration", 5)]);
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].name).toBe("Regeneration");
+    expect(result.boons[0].sources).toHaveLength(1);
+    expect(result.boons[0].sources[0]).toMatchObject({ type: "skill", name: "Healing Breeze" });
+  });
+
+  test("extracts condition from a utility skill", () => {
+    const skill = makeSkill(200, "Torch Throw", [buffFact("Burning", 3, 2)]);
+    const catalog = makeCatalog({ skillById: new Map([[200, skill]]) });
+    const editor = makeEditor({ skills: { healId: 0, utilityIds: [200, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.conditions).toHaveLength(1);
+    expect(result.conditions[0].name).toBe("Burning");
+    expect(result.conditions[0].sources[0]).toMatchObject({ stacks: 2, duration: 3 });
+  });
+
+  test("normalizes condition name variants", () => {
+    const skill = makeSkill(300, "Blind Throw", [buffFact("Blind", 4)]);
+    const catalog = makeCatalog({ skillById: new Map([[300, skill]]) });
+    const editor = makeEditor({ skills: { healId: 0, utilityIds: [300, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.conditions).toHaveLength(1);
+    expect(result.conditions[0].name).toBe("Blinded");
+  });
+
+  test("groups multiple sources for the same boon", () => {
+    const s1 = makeSkill(100, "Skill A", [buffFact("Might", 6, 3)]);
+    const s2 = makeSkill(200, "Skill B", [buffFact("Might", 8, 1)]);
+    const catalog = makeCatalog({ skillById: new Map([[100, s1], [200, s2]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [200, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].name).toBe("Might");
+    expect(result.boons[0].sources).toHaveLength(2);
+  });
+
+  test("extracts boons from selected traits", () => {
+    const trait = makeTrait(500, "Radiant Power", [buffFact("Fury", 3)]);
+    const catalog = makeCatalog({ traitById: new Map([[500, trait]]) });
+    const editor = makeEditor({
+      specializations: [{ specializationId: 42, majorChoices: { 1: 500, 2: 0, 3: 0 } }],
+    });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].sources[0]).toMatchObject({ type: "trait", name: "Radiant Power" });
+  });
+
+  test("follows flipSkill one level deep", () => {
+    const flip = makeSkill(101, "Flip Skill", [buffFact("Might", 5, 2)]);
+    const base = makeSkill(100, "Base Skill", [], { flipSkill: 101 });
+    const catalog = makeCatalog({ skillById: new Map([[100, base], [101, flip]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].sources[0].name).toBe("Flip Skill");
+  });
+
+  test("does not follow flipSkill beyond one level", () => {
+    const flip2 = makeSkill(102, "Double Flip", [buffFact("Fury", 3)]);
+    const flip1 = makeSkill(101, "Flip Skill", [buffFact("Might", 5)], { flipSkill: 102 });
+    const base = makeSkill(100, "Base Skill", [], { flipSkill: 101 });
+    const catalog = makeCatalog({ skillById: new Map([[100, base], [101, flip1], [102, flip2]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    // Should have Might from flip1, but NOT Fury from flip2
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].name).toBe("Might");
+  });
+
+  test("marks ally-only boons when all sources have ally description", () => {
+    const skill = makeSkill(100, "Grant Allies Might", [buffFact("Might", 5, 3)], {
+      description: "Grant nearby allies might.",
+    });
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons[0].allyOnly).toBe(true);
+  });
+
+  test("marks boon as self when any source lacks ally description", () => {
+    const s1 = makeSkill(100, "Self Might", [buffFact("Might", 5)], { description: "Gain might." });
+    const s2 = makeSkill(200, "Ally Might", [buffFact("Might", 5)], { description: "Grant allies might." });
+    const catalog = makeCatalog({ skillById: new Map([[100, s1], [200, s2]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [200, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons[0].allyOnly).toBe(false);
+  });
+
+  test("boons are sorted in GW2 display order", () => {
+    const s1 = makeSkill(100, "S1", [buffFact("Vigor", 3)]);
+    const s2 = makeSkill(200, "S2", [buffFact("Aegis", 3)]);
+    const s3 = makeSkill(300, "S3", [buffFact("Might", 3)]);
+    const catalog = makeCatalog({ skillById: new Map([[100, s1], [200, s2], [300, s3]]) });
+    const editor = makeEditor({ skills: { healId: 0, utilityIds: [100, 200, 300], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons.map((b) => b.name)).toEqual(["Aegis", "Might", "Vigor"]);
+  });
+
+  test("conditions are sorted alphabetically", () => {
+    const s1 = makeSkill(100, "S1", [buffFact("Vulnerability", 3)]);
+    const s2 = makeSkill(200, "S2", [buffFact("Bleeding", 3)]);
+    const catalog = makeCatalog({ skillById: new Map([[100, s1], [200, s2]]) });
+    const editor = makeEditor({ skills: { healId: 0, utilityIds: [100, 200, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.conditions.map((c) => c.name)).toEqual(["Bleeding", "Vulnerability"]);
+  });
+
+  test("includes icon URL from BOON_CONDITION_ICONS", () => {
+    const skill = makeSkill(100, "Might Skill", [buffFact("Might", 5)]);
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons[0].icon).toContain("render.guildwars2.com");
+  });
+
+  test("ignores non-buff fact types", () => {
+    const skill = makeSkill(100, "Damage Skill", [
+      { type: "Damage", value: 500 },
+      { type: "Duration", value: 10 },
+    ]);
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toEqual([]);
+    expect(result.conditions).toEqual([]);
+  });
+
+  test("handles ApplyBuffCondition and PrefixedBuff fact types", () => {
+    const skill = makeSkill(100, "Multi", [
+      { type: "ApplyBuffCondition", status: "Burning", duration: 3, apply_count: 1 },
+      { type: "PrefixedBuff", status: "Might", duration: 5, apply_count: 2 },
+    ]);
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.conditions).toHaveLength(1);
+  });
+
+  test("extracts boons from profession mechanic skills (F1-F5)", () => {
+    const mechSkill = makeSkill(600, "F1 Virtue", [buffFact("Aegis", 3)], {
+      type: "Profession", slot: "Profession_1", specialization: 0,
+    });
+    const catalog = makeCatalog({
+      skillById: new Map([[600, mechSkill]]),
+      skills: [mechSkill],
+    });
+    const editor = makeEditor();
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].name).toBe("Aegis");
+    expect(result.boons[0].sources[0]).toMatchObject({ type: "skill", name: "F1 Virtue" });
+  });
+
+  test("skips profession mechanics requiring unselected elite spec", () => {
+    const mechSkill = makeSkill(700, "Elite F1", [buffFact("Quickness", 5)], {
+      type: "Profession", slot: "Profession_1", specialization: 27,
+    });
+    const catalog = makeCatalog({
+      skillById: new Map([[700, mechSkill]]),
+      skills: [mechSkill],
+    });
+    const editor = makeEditor({ specializations: [] });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toEqual([]);
+  });
+
+  test("handles missing or zero apply_count and duration gracefully", () => {
+    const skill = makeSkill(100, "Passive Skill", [{ type: "Buff", status: "Might" }]);
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].sources[0]).toMatchObject({ stacks: 0, duration: 0 });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest tests/unit/renderer/boon-coverage.test.js --no-coverage`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/renderer/boon-coverage.test.js
+git commit -m "test: add failing tests for computeBoonCoverage"
+```
+
+---
+
+### Task 3: Implement `computeBoonCoverage`
+
+**Files:**
+- Create: `src/renderer/modules/boon-coverage.js`
+
+- [ ] **Step 1: Create the module**
+
+```js
+import {
+  BOON_NAMES, CONDITION_NAMES, CONDITION_NAME_NORMALIZE,
+  BOON_DISPLAY_ORDER, BUFF_FACT_TYPES, BOON_CONDITION_ICONS,
+} from "./constants.js";
+
+const ALLY_PATTERNS = /\b(allies|ally)\b/i;
+
+function normalizeName(status) {
+  return CONDITION_NAME_NORMALIZE[status] || status;
+}
+
+function isAllyDescription(description) {
+  return ALLY_PATTERNS.test(description || "");
+}
+
+function extractBuffFacts(entity, sourceType) {
+  const results = [];
+  const facts = entity.facts || [];
+  const isAlly = isAllyDescription(entity.description);
+  for (const fact of facts) {
+    if (!BUFF_FACT_TYPES.has(fact.type)) continue;
+    const rawStatus = fact.status;
+    if (!rawStatus) continue;
+    const name = normalizeName(rawStatus);
+    if (!BOON_NAMES.has(name) && !CONDITION_NAMES.has(name)) continue;
+    results.push({
+      name,
+      sourceType,
+      sourceName: entity.name || "",
+      stacks: fact.apply_count || 0,
+      duration: fact.duration || 0,
+      isAlly,
+    });
+  }
+  return results;
+}
+
+function collectSkillIds(editor, catalog) {
+  const ids = new Set();
+  const skills = editor.skills || {};
+  if (skills.healId) ids.add(Number(skills.healId));
+  if (skills.eliteId) ids.add(Number(skills.eliteId));
+  for (const uid of skills.utilityIds || []) {
+    if (uid) ids.add(Number(uid));
+  }
+  // Profession mechanic skill IDs (F1-F5) — resolve from catalog profession skills
+  const profSkills = catalog?.skills || [];
+  const selectedSpecIds = new Set(
+    (editor.specializations || []).map((s) => Number(s?.specializationId) || 0).filter(Boolean)
+  );
+  for (const s of profSkills) {
+    if ((s.type || "").toLowerCase() !== "profession") continue;
+    const reqSpec = Number(s.specialization) || 0;
+    if (reqSpec && !selectedSpecIds.has(reqSpec)) continue;
+    if (/^Profession_[1-5]$/.test(s.slot || "")) ids.add(s.id);
+  }
+  return ids;
+}
+
+function collectTraitIds(editor) {
+  const ids = new Set();
+  for (const spec of editor.specializations || []) {
+    const choices = spec?.majorChoices || {};
+    for (const tier of [1, 2, 3]) {
+      const traitId = Number(choices[tier]) || 0;
+      if (traitId) ids.add(traitId);
+    }
+  }
+  return ids;
+}
+
+export function computeBoonCoverage(catalog, editor) {
+  if (!catalog) return { boons: [], conditions: [] };
+
+  const allFacts = [];
+
+  // Collect from skills (heal, utility, elite, profession mechanics)
+  const skillIds = collectSkillIds(editor, catalog);
+  for (const id of skillIds) {
+    const skill = catalog.skillById?.get(id);
+    if (!skill) continue;
+    allFacts.push(...extractBuffFacts(skill, "skill"));
+    // Follow flipSkill one level
+    if (skill.flipSkill) {
+      const flip = catalog.skillById?.get(skill.flipSkill);
+      if (flip) allFacts.push(...extractBuffFacts(flip, "skill"));
+    }
+  }
+
+  // Collect from traits
+  const traitIds = collectTraitIds(editor);
+  for (const id of traitIds) {
+    const trait = catalog.traitById?.get(id);
+    if (!trait) continue;
+    allFacts.push(...extractBuffFacts(trait, "trait"));
+  }
+
+  // Group by normalized name
+  const grouped = new Map();
+  for (const f of allFacts) {
+    const canonical = normalizeName(f.name);
+    if (!grouped.has(canonical)) {
+      grouped.set(canonical, { sources: [], hasAnySelf: false });
+    }
+    const entry = grouped.get(canonical);
+    entry.sources.push({
+      type: f.sourceType,
+      name: f.sourceName,
+      stacks: f.stacks,
+      duration: f.duration,
+    });
+    if (!f.isAlly) entry.hasAnySelf = true;
+  }
+
+  // Build output arrays
+  const boons = [];
+  const conditions = [];
+  for (const [name, data] of grouped) {
+    const entry = {
+      name,
+      icon: BOON_CONDITION_ICONS[name] || "",
+      allyOnly: !data.hasAnySelf,
+      sources: data.sources,
+    };
+    if (BOON_NAMES.has(name)) {
+      boons.push(entry);
+    } else {
+      conditions.push(entry);
+    }
+  }
+
+  // Sort boons by GW2 display order, conditions alphabetically
+  const boonOrder = new Map(BOON_DISPLAY_ORDER.map((b, i) => [b, i]));
+  boons.sort((a, b) => (boonOrder.get(a.name) ?? 99) - (boonOrder.get(b.name) ?? 99));
+  conditions.sort((a, b) => a.name.localeCompare(b.name));
+
+  return { boons, conditions };
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx jest tests/unit/renderer/boon-coverage.test.js --no-coverage`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/modules/boon-coverage.js
+git commit -m "feat: implement computeBoonCoverage module"
+```
+
+---
+
+## Chunk 2: CSS Styles and Rendering Integration
+
+### Task 4: Add CSS styles for boon coverage
+
+**Files:**
+- Modify: `src/renderer/styles/skills.css` (append at end of file)
+
+- [ ] **Step 1: Append the boon coverage styles**
+
+```css
+/* Boon & Condition Coverage */
+.skills-bar__util-col {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.boon-coverage {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.boon-coverage__boons,
+.boon-coverage__conditions {
+  display: flex;
+  gap: 3px;
+  align-items: center;
+}
+
+.boon-coverage__icon {
+  position: relative;
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+  background: rgba(2, 8, 16, 0.5);
+  border: 1px solid rgba(180, 180, 180, 0.25);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.boon-coverage__icon:hover {
+  border-color: rgba(255, 220, 100, 0.7);
+  box-shadow: 0 0 6px rgba(255, 200, 50, 0.3);
+}
+
+.boon-coverage__icon img {
+  width: 18px;
+  height: 18px;
+  border-radius: 2px;
+  display: block;
+}
+
+.boon-coverage__ally-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(100, 180, 255, 0.9);
+  display: grid;
+  place-items: center;
+  font-size: 6px;
+  color: #fff;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.boon-coverage__tooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(12, 18, 32, 0.96);
+  border: 1px solid rgba(100, 140, 200, 0.3);
+  border-radius: 6px;
+  padding: 8px 12px;
+  min-width: 200px;
+  max-width: 320px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  z-index: 100;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.boon-coverage__tooltip-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 5px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(100, 140, 200, 0.15);
+}
+
+.boon-coverage__tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  font-size: 11px;
+}
+
+.boon-coverage__tooltip-tag {
+  font-size: 9px;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.boon-coverage__tooltip-tag--skill {
+  color: rgba(100, 180, 255, 0.9);
+  background: rgba(100, 180, 255, 0.15);
+}
+
+.boon-coverage__tooltip-tag--trait {
+  color: rgba(255, 180, 80, 0.9);
+  background: rgba(255, 180, 80, 0.15);
+}
+
+.boon-coverage__tooltip-name {
+  color: rgba(220, 220, 240, 0.9);
+}
+
+.boon-coverage__tooltip-detail {
+  color: rgba(180, 200, 230, 0.5);
+  margin-left: auto;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/renderer/styles/skills.css
+git commit -m "feat: add boon coverage CSS styles"
+```
+
+---
+
+### Task 5: Integrate rendering into `skills.js`
+
+**Files:**
+- Modify: `src/renderer/modules/skills.js:1` (add import)
+- Modify: `src/renderer/modules/skills.js:1562-1572` (wrap utility group with coverage)
+
+- [ ] **Step 1: Add import at top of skills.js**
+
+Add after the existing `import { computeEquipmentStats } from "./stats.js";` line (line 17):
+
+```js
+import { computeBoonCoverage } from "./boon-coverage.js";
+```
+
+- [ ] **Step 2: Add the rendering helper function**
+
+Add between the `_renderUnderwaterToggle()` function and the `renderSkills()` function declaration (insert just before the `export function renderSkills()` line at line 1002). This function creates the boon/condition coverage DOM from the computed data:
+
+```js
+function _renderBoonCoverage(catalog, editor) {
+  const coverage = computeBoonCoverage(catalog, editor);
+  const hasBoons = coverage.boons.length > 0;
+  const hasConditions = coverage.conditions.length > 0;
+  if (!hasBoons && !hasConditions) return null;
+
+  const container = document.createElement("div");
+  container.className = "boon-coverage";
+
+  function makeIconRow(items, className) {
+    if (items.length === 0) return null;
+    const row = document.createElement("div");
+    row.className = className;
+    for (const item of items) {
+      const icon = document.createElement("div");
+      icon.className = "boon-coverage__icon";
+
+      const img = document.createElement("img");
+      img.src = item.icon;
+      img.alt = item.name;
+      img.width = 18;
+      img.height = 18;
+      icon.append(img);
+
+      if (item.allyOnly) {
+        const badge = document.createElement("div");
+        badge.className = "boon-coverage__ally-badge";
+        badge.textContent = "⇧";
+        icon.append(badge);
+      }
+
+      // Tooltip on hover
+      icon.addEventListener("mouseenter", () => {
+        const tooltip = document.createElement("div");
+        tooltip.className = "boon-coverage__tooltip";
+
+        const title = document.createElement("div");
+        title.className = "boon-coverage__tooltip-title";
+        title.textContent = item.name;
+        tooltip.append(title);
+
+        for (const src of item.sources) {
+          const row = document.createElement("div");
+          row.className = "boon-coverage__tooltip-row";
+
+          const tag = document.createElement("span");
+          tag.className = `boon-coverage__tooltip-tag boon-coverage__tooltip-tag--${src.type}`;
+          tag.textContent = src.type === "skill" ? "Skill" : "Trait";
+          row.append(tag);
+
+          const name = document.createElement("span");
+          name.className = "boon-coverage__tooltip-name";
+          name.textContent = src.name;
+          row.append(name);
+
+          const detail = document.createElement("span");
+          detail.className = "boon-coverage__tooltip-detail";
+          if (src.duration > 0) {
+            const parts = [];
+            if (src.stacks > 0) parts.push(`${src.stacks}×`);
+            parts.push(`${src.duration}s`);
+            detail.textContent = parts.join(" ");
+          } else {
+            detail.textContent = "passive";
+          }
+          row.append(detail);
+
+          tooltip.append(row);
+        }
+
+        icon.append(tooltip);
+      });
+
+      icon.addEventListener("mouseleave", () => {
+        const tooltip = icon.querySelector(".boon-coverage__tooltip");
+        if (tooltip) tooltip.remove();
+      });
+
+      row.append(icon);
+    }
+    return row;
+  }
+
+  const boonRow = makeIconRow(coverage.boons, "boon-coverage__boons");
+  const condRow = makeIconRow(coverage.conditions, "boon-coverage__conditions");
+  if (boonRow) container.append(boonRow);
+  if (condRow) container.append(condRow);
+
+  return container;
+}
+```
+
+- [ ] **Step 3: Modify `renderSkills()` to use the wrapper**
+
+Replace the final assembly at the end of `renderSkills()` (around lines 1562–1572). Change:
+
+```js
+  bar.append(weaponCol, orbCol, utilityGroup);
+```
+
+to:
+
+```js
+  const utilCol = document.createElement("div");
+  utilCol.className = "skills-bar__util-col";
+  const coverageEl = _renderBoonCoverage(catalog, state.editor);
+  if (coverageEl) utilCol.append(coverageEl);
+  utilCol.append(utilityGroup);
+  bar.append(weaponCol, orbCol, utilCol);
+```
+
+- [ ] **Step 4: Run all tests to verify nothing is broken**
+
+Run: `npx jest --no-coverage`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/modules/skills.js
+git commit -m "feat: render boon/condition coverage above utility skills"
+```
+
+---
+
+### Task 6: Manual verification
+
+- [ ] **Step 1: Start the app and verify the feature**
+
+Run: `npm start`
+
+Verify:
+1. Open a build with skills that grant boons (e.g. Guardian with Might-granting skills)
+2. Boon icons appear above the heal/utility/elite row
+3. Condition icons appear below the boon row
+4. Hovering an icon shows the tooltip with source breakdown
+5. Ally-only boons show the blue badge
+6. Changing skills/traits updates the coverage icons
+7. Empty rows are hidden when no boons/conditions found
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npx jest --no-coverage`
+Expected: All tests PASS
+
+- [ ] **Step 3: Final commit if any adjustments were needed**

--- a/docs/superpowers/plans/2026-03-14-boon-condition-coverage.md
+++ b/docs/superpowers/plans/2026-03-14-boon-condition-coverage.md
@@ -146,6 +146,16 @@ describe("computeBoonCoverage", () => {
     expect(result.boons[0].sources).toHaveLength(2);
   });
 
+  test("extracts boons from weapon skills passed as third argument", () => {
+    const ws = makeSkill(400, "Sword Strike", [buffFact("Might", 4, 1)]);
+    const catalog = makeCatalog();
+    const editor = makeEditor();
+    const result = computeBoonCoverage(catalog, editor, [ws, null, null, null, null]);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].name).toBe("Might");
+    expect(result.boons[0].sources[0]).toMatchObject({ type: "skill", name: "Sword Strike" });
+  });
+
   test("extracts boons from selected traits", () => {
     const trait = makeTrait(500, "Radiant Power", [buffFact("Fury", 3)]);
     const catalog = makeCatalog({ traitById: new Map([[500, trait]]) });
@@ -381,10 +391,20 @@ function collectTraitIds(editor) {
   return ids;
 }
 
-export function computeBoonCoverage(catalog, editor) {
+export function computeBoonCoverage(catalog, editor, weaponSkills = []) {
   if (!catalog) return { boons: [], conditions: [] };
 
   const allFacts = [];
+
+  // Collect from weapon skills (passed in by caller, already resolved)
+  for (const ws of weaponSkills) {
+    if (!ws) continue;
+    allFacts.push(...extractBuffFacts(ws, "skill"));
+    if (ws.flipSkill) {
+      const flip = catalog.skillById?.get(ws.flipSkill) || catalog.weaponSkillById?.get(ws.flipSkill);
+      if (flip) allFacts.push(...extractBuffFacts(flip, "skill"));
+    }
+  }
 
   // Collect from skills (heal, utility, elite, profession mechanics)
   const skillIds = collectSkillIds(editor, catalog);
@@ -407,14 +427,13 @@ export function computeBoonCoverage(catalog, editor) {
     allFacts.push(...extractBuffFacts(trait, "trait"));
   }
 
-  // Group by normalized name
+  // Group by name (already normalized in extractBuffFacts)
   const grouped = new Map();
   for (const f of allFacts) {
-    const canonical = normalizeName(f.name);
-    if (!grouped.has(canonical)) {
-      grouped.set(canonical, { sources: [], hasAnySelf: false });
+    if (!grouped.has(f.name)) {
+      grouped.set(f.name, { sources: [], hasAnySelf: false });
     }
-    const entry = grouped.get(canonical);
+    const entry = grouped.get(f.name);
     entry.sources.push({
       type: f.sourceType,
       name: f.sourceName,
@@ -625,8 +644,8 @@ import { computeBoonCoverage } from "./boon-coverage.js";
 Add between the `_renderUnderwaterToggle()` function and the `renderSkills()` function declaration (insert just before the `export function renderSkills()` line at line 1002). This function creates the boon/condition coverage DOM from the computed data:
 
 ```js
-function _renderBoonCoverage(catalog, editor) {
-  const coverage = computeBoonCoverage(catalog, editor);
+function _renderBoonCoverage(catalog, editor, weaponSkills = []) {
+  const coverage = computeBoonCoverage(catalog, editor, weaponSkills);
   const hasBoons = coverage.boons.length > 0;
   const hasConditions = coverage.conditions.length > 0;
   if (!hasBoons && !hasConditions) return null;
@@ -730,7 +749,7 @@ to:
 ```js
   const utilCol = document.createElement("div");
   utilCol.className = "skills-bar__util-col";
-  const coverageEl = _renderBoonCoverage(catalog, state.editor);
+  const coverageEl = _renderBoonCoverage(catalog, state.editor, weaponSkills);
   if (coverageEl) utilCol.append(coverageEl);
   utilCol.append(utilityGroup);
   bar.append(weaponCol, orbCol, utilCol);

--- a/docs/superpowers/specs/2026-03-14-boon-condition-coverage-design.md
+++ b/docs/superpowers/specs/2026-03-14-boon-condition-coverage-design.md
@@ -1,0 +1,173 @@
+# Boon & Condition Coverage Design
+
+## Summary
+
+Display boon and condition coverage icons above the heal/utility/elite skill group in the skill bar. The system scans all skills (weapon, heal, utility, elite, profession mechanics, flip/chain variants) and selected traits for boon/condition output, then renders two rows of icons — boons on top, conditions below — with hover tooltips showing the source breakdown. Ally-only boons/conditions are marked with a small blue badge.
+
+## Layout
+
+Two rows inserted above the utility skill group (between the profession mechanics bar and the heal/utility/elite slots):
+
+```
+[F1] [F2] [F3]                    [Might][Fury][Quickness↑][Regen][Swiftness]   ← boons row
+[⇄][W1][W2][W3][W4][W5]  (orb)   [Burning][Bleeding][Vulnerability↑]           ← conditions row
+                                   [Heal] [U1] [U2] [U3] [Elite]               ← existing utility row
+```
+
+- Boons row on top, conditions row below
+- Rows are hidden when empty (no boons or no conditions found)
+- Icons are 22×22px using images from the existing `BOON_CONDITION_ICONS` map in constants.js
+- Ally-only boons/conditions get a small blue circle badge (10px) in the top-right corner
+- If a boon/condition has both self and ally sources, it shows as self (no badge)
+
+## Boon/Condition Ordering
+
+Boons follow standard GW2 buff bar order: Aegis, Alacrity, Fury, Might, Protection, Quickness, Regeneration, Resistance, Resolution, Stability, Swiftness, Vigor.
+
+Conditions follow alphabetical order: Bleeding, Blinded, Burning, Chilled, Confusion, Crippled, Fear, Immobile, Poisoned, Slow, Taunt, Torment, Vulnerability, Weakness.
+
+## Data Sources
+
+All of the following are scanned for boon/condition output:
+
+1. **Weapon skills** — both weapon sets (active + inactive), resolved from current weapon selections
+2. **Heal / Utility / Elite skills** — from `editor.skills.{healId, utilityIds, eliteId}`
+3. **Profession mechanics (F1–F5)** — resolved profession skill slots
+4. **Flip/chain skills** — if a skill has a `flipSkill` property, the flip target is also scanned
+5. **Selected traits** — from `editor.specializations[].majorChoices`, resolved via `catalog.traitById`
+
+For each source, extract facts where:
+- `fact.type` is in `BUFF_FACT_TYPES` (`"Buff"`, `"ApplyBuffCondition"`, `"PrefixedBuff"`)
+- `fact.status` matches a known boon or condition name
+
+## Self vs Ally Detection
+
+The GW2 API fact data includes a `target` field on some buff facts. Detection logic:
+
+- If `fact.target === "self"` or no target field → self-applied
+- If `fact.target` is present and not `"self"` → ally-applied
+- A boon/condition is marked "ally-only" if **all** sources for it are ally-targeted
+- If **any** source is self-targeted, the icon shows as self (no badge)
+
+## Tooltip
+
+On hover, show a tooltip listing all sources for that boon/condition:
+
+```
+┌─────────────────────────────────────┐
+│ Might                               │
+│─────────────────────────────────────│
+│ [Skill]  Mantra of Potence   3×, 6s│
+│ [Trait]  Radiant Power       1×, 8s│
+│ [Skill]  Signet of Wrath    5×, 10s│
+└─────────────────────────────────────┘
+```
+
+Each row shows:
+- **Source type tag** — `[Skill]` (blue) or `[Trait]` (orange)
+- **Source name** — skill or trait name
+- **Stacks × Duration** — from `fact.apply_count` and `fact.duration`
+
+## Computation
+
+Create a new module `src/renderer/modules/boon-coverage.js` with:
+
+### `computeBoonCoverage(catalog, editor)`
+
+Collects all skill IDs and trait IDs from the current build state, extracts buff facts, and returns a structured result:
+
+```js
+{
+  boons: [
+    {
+      name: "Might",
+      icon: "https://render.guildwars2.com/...",
+      allyOnly: false,
+      sources: [
+        { type: "skill", name: "Mantra of Potence", stacks: 3, duration: 6 },
+        { type: "trait", name: "Radiant Power", stacks: 1, duration: 8 },
+      ]
+    },
+    // ...
+  ],
+  conditions: [
+    // same shape
+  ]
+}
+```
+
+The function:
+1. Gathers all active skill IDs (weapon skills from both sets, heal/utility/elite, profession mechanics)
+2. For each skill, also includes its `flipSkill` target if present
+3. Gathers all selected trait IDs from specialization major choices
+4. Looks up each skill/trait in the catalog, extracts facts matching `BUFF_FACT_TYPES`
+5. Groups by boon/condition name, classifies as boon or condition using a known-boons set
+6. Determines ally-only status per boon/condition
+7. Returns sorted arrays (boons in GW2 order, conditions alphabetical)
+
+### Recalculation Triggers
+
+`computeBoonCoverage()` is called during `renderSkills()` — the same function that already re-renders on any skill, trait, specialization, weapon, legend, or attunement change. No new event wiring needed.
+
+## Rendering
+
+### In `skills.js`
+
+In the `renderSkills()` function, after building the utility group and before appending it to the bar:
+
+1. Call `computeBoonCoverage(catalog, state.editor)`
+2. Create a container div (`.boon-coverage`) with two child rows (`.boon-coverage__boons`, `.boon-coverage__conditions`)
+3. For each boon/condition, render a 22×22 icon with the image from `BOON_CONDITION_ICONS`
+4. If ally-only, append a small badge element
+5. Attach mouseenter/mouseleave handlers for tooltip
+6. Prepend the container to the utility column (above the existing skill slots)
+
+### In `skills.css`
+
+New styles for:
+- `.boon-coverage` — flex column container with small gap
+- `.boon-coverage__boons`, `.boon-coverage__conditions` — flex row with 3px gap
+- `.boon-coverage__icon` — 22×22px, border-radius 3px, with subtle background tint
+- `.boon-coverage__icon img` — 18×18px icon image
+- `.boon-coverage__ally-badge` — 10px blue circle, absolute positioned top-right
+- `.boon-coverage__tooltip` — dark panel with source list, positioned above the icon
+
+## Constants
+
+Add to `constants.js`:
+
+```js
+export const BOON_NAMES = new Set([
+  "Aegis", "Alacrity", "Fury", "Might", "Protection", "Quickness",
+  "Regeneration", "Resistance", "Resolution", "Stability", "Swiftness", "Vigor"
+]);
+
+export const CONDITION_NAMES = new Set([
+  "Bleeding", "Blinded", "Burning", "Chilled", "Confusion", "Crippled",
+  "Fear", "Immobile", "Poisoned", "Slow", "Taunt", "Torment",
+  "Vulnerability", "Weakness"
+]);
+
+export const BOON_DISPLAY_ORDER = [
+  "Aegis", "Alacrity", "Fury", "Might", "Protection", "Quickness",
+  "Regeneration", "Resistance", "Resolution", "Stability", "Swiftness", "Vigor"
+];
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/renderer/modules/boon-coverage.js` | **New** — `computeBoonCoverage()` function |
+| `src/renderer/modules/skills.js` | Import and call `computeBoonCoverage()`, render coverage rows above utility group |
+| `src/renderer/modules/constants.js` | Add `BOON_NAMES`, `CONDITION_NAMES`, `BOON_DISPLAY_ORDER` |
+| `src/renderer/styles/skills.css` | Add `.boon-coverage*` styles |
+
+## Edge Cases
+
+- **No boons/conditions** — rows are hidden, no empty state shown
+- **Revenant legends** — scan skills from both active and inactive legend slots
+- **Engineer kits** — scan the equipped kit skill, not individual kit weapon skills (those aren't selectable)
+- **Attunement skills** — scan weapon skills for all attunements, not just the active one
+- **Underwater mode** — when underwater toggle is active, scan underwater skills instead of land skills
+- **WvW splits** — use base facts (not WvW-split facts) since this is a general coverage indicator

--- a/docs/superpowers/specs/2026-03-14-boon-condition-coverage-design.md
+++ b/docs/superpowers/specs/2026-03-14-boon-condition-coverage-design.md
@@ -38,16 +38,20 @@ All of the following are scanned for boon/condition output:
 
 For each source, extract facts where:
 - `fact.type` is in `BUFF_FACT_TYPES` (`"Buff"`, `"ApplyBuffCondition"`, `"PrefixedBuff"`)
-- `fact.status` matches a known boon or condition name
+- `fact.status` matches a known boon or condition name (accounting for API spelling variants like "Blind"/"Blinded", "Chill"/"Chilled" etc. — normalize to canonical display name for grouping)
+
+Flip skill traversal is single-level only — if skill A has `flipSkill` → B, scan B but do not follow B's `flipSkill` further.
 
 ## Self vs Ally Detection
 
-The GW2 API fact data includes a `target` field on some buff facts. Detection logic:
+The GW2 API buff facts do not have a reliable `target` field for self vs ally detection. Instead, use the skill/trait `description` text to infer targeting:
 
-- If `fact.target === "self"` or no target field → self-applied
-- If `fact.target` is present and not `"self"` → ally-applied
+- If the description contains phrases like "Grant allies", "nearby allies gain", "to allies" → ally-applied
+- Otherwise → assume self-applied (conservative default)
 - A boon/condition is marked "ally-only" if **all** sources for it are ally-targeted
 - If **any** source is self-targeted, the icon shows as self (no badge)
+
+The matching uses a simple keyword check on the description string. This is a heuristic — edge cases will default to "self" which is the safer assumption.
 
 ## Tooltip
 
@@ -66,7 +70,7 @@ On hover, show a tooltip listing all sources for that boon/condition:
 Each row shows:
 - **Source type tag** — `[Skill]` (blue) or `[Trait]` (orange)
 - **Source name** — skill or trait name
-- **Stacks × Duration** — from `fact.apply_count` and `fact.duration`
+- **Stacks × Duration** — from `fact.apply_count` and `fact.duration`. If `apply_count` is 0 or absent, omit the stacks display. If `duration` is 0 or absent (e.g. passive traits), show "passive" instead of a duration.
 
 ## Computation
 
@@ -97,8 +101,8 @@ Collects all skill IDs and trait IDs from the current build state, extracts buff
 ```
 
 The function:
-1. Gathers all active skill IDs (weapon skills from both sets, heal/utility/elite, profession mechanics)
-2. For each skill, also includes its `flipSkill` target if present
+1. Gathers all skill IDs from the build — weapon skills from both weapon sets (and for Elementalist, all four attunement variants per weapon set), heal/utility/elite, profession mechanics (F1–F5)
+2. For each skill, also includes its `flipSkill` target if present (single level only)
 3. Gathers all selected trait IDs from specialization major choices
 4. Looks up each skill/trait in the catalog, extracts facts matching `BUFF_FACT_TYPES`
 5. Groups by boon/condition name, classifies as boon or condition using a known-boons set
@@ -120,11 +124,17 @@ In the `renderSkills()` function, after building the utility group and before ap
 3. For each boon/condition, render a 22×22 icon with the image from `BOON_CONDITION_ICONS`
 4. If ally-only, append a small badge element
 5. Attach mouseenter/mouseleave handlers for tooltip
-6. Prepend the container to the utility column (above the existing skill slots)
+6. Wrap the boon-coverage container and the existing `utilityGroup` in a new flex-column wrapper (`.skills-bar__util-col`), since `utilityGroup` is a flex row and cannot have the coverage rows prepended directly. The wrapper becomes the element appended to the bar in place of `utilityGroup`:
+   ```
+   .skills-bar__util-col (flex column)
+     ├── .boon-coverage (boons row + conditions row)
+     └── .skill-group--utilities (existing heal/util/elite row)
+   ```
 
 ### In `skills.css`
 
 New styles for:
+- `.skills-bar__util-col` — flex column wrapper for coverage + utility group
 - `.boon-coverage` — flex column container with small gap
 - `.boon-coverage__boons`, `.boon-coverage__conditions` — flex row with 3px gap
 - `.boon-coverage__icon` — 22×22px, border-radius 3px, with subtle background tint
@@ -143,8 +153,9 @@ export const BOON_NAMES = new Set([
 ]);
 
 export const CONDITION_NAMES = new Set([
-  "Bleeding", "Blinded", "Burning", "Chilled", "Confusion", "Crippled",
-  "Fear", "Immobile", "Poisoned", "Slow", "Taunt", "Torment",
+  "Bleeding", "Blind", "Blinded", "Burning", "Chill", "Chilled",
+  "Confusion", "Cripple", "Crippled", "Fear", "Immobile", "Immobilize", "Immobilized",
+  "Poison", "Poisoned", "Slow", "Taunt", "Torment",
   "Vulnerability", "Weakness"
 ]);
 

--- a/docs/superpowers/specs/2026-03-14-boon-condition-coverage-design.md
+++ b/docs/superpowers/specs/2026-03-14-boon-condition-coverage-design.md
@@ -159,6 +159,12 @@ export const CONDITION_NAMES = new Set([
   "Vulnerability", "Weakness"
 ]);
 
+// Maps API spelling variants to canonical display names for grouping
+export const CONDITION_NAME_NORMALIZE = {
+  "Blind": "Blinded", "Chill": "Chilled", "Cripple": "Crippled",
+  "Immobilize": "Immobile", "Immobilized": "Immobile", "Poison": "Poisoned",
+};
+
 export const BOON_DISPLAY_ORDER = [
   "Aegis", "Alacrity", "Fury", "Might", "Protection", "Quickness",
   "Regeneration", "Resistance", "Resolution", "Stability", "Swiftness", "Vigor"

--- a/src/renderer/modules/boon-coverage.js
+++ b/src/renderer/modules/boon-coverage.js
@@ -68,13 +68,20 @@ function collectSkillIds(editor, catalog) {
   return ids;
 }
 
-function collectTraitIds(editor) {
+function collectTraitIds(editor, catalog) {
   const ids = new Set();
   for (const spec of editor.specializations || []) {
+    // Selected major traits
     const choices = spec?.majorChoices || {};
     for (const tier of [1, 2, 3]) {
       const traitId = Number(choices[tier]) || 0;
       if (traitId) ids.add(traitId);
+    }
+    // Minor traits (always active when spec line is equipped)
+    const specId = Number(spec?.specializationId) || 0;
+    const specData = specId ? catalog?.specializationById?.get(specId) : null;
+    for (const minorId of specData?.minorTraits || []) {
+      if (minorId) ids.add(Number(minorId));
     }
   }
   return ids;
@@ -108,7 +115,7 @@ export function computeBoonCoverage(catalog, editor, weaponSkills = []) {
   }
 
   // Collect from traits
-  const traitIds = collectTraitIds(editor);
+  const traitIds = collectTraitIds(editor, catalog);
   for (const id of traitIds) {
     const trait = catalog.traitById?.get(id);
     if (!trait) continue;

--- a/src/renderer/modules/boon-coverage.js
+++ b/src/renderer/modules/boon-coverage.js
@@ -157,7 +157,7 @@ export function computeBoonCoverage(catalog, editor, weaponSkills = []) {
   const grouped = new Map();
   for (const f of allFacts) {
     if (!grouped.has(f.name)) {
-      grouped.set(f.name, { sources: [], hasAnySelf: false });
+      grouped.set(f.name, { sources: [], hasAnyAlly: false });
     }
     const entry = grouped.get(f.name);
     entry.sources.push({
@@ -166,7 +166,7 @@ export function computeBoonCoverage(catalog, editor, weaponSkills = []) {
       stacks: f.stacks,
       duration: f.duration,
     });
-    if (!f.isAlly) entry.hasAnySelf = true;
+    if (f.isAlly) entry.hasAnyAlly = true;
   }
 
   // Build output arrays
@@ -176,7 +176,7 @@ export function computeBoonCoverage(catalog, editor, weaponSkills = []) {
     const entry = {
       name,
       icon: BOON_CONDITION_ICONS[name] || "",
-      allyOnly: !data.hasAnySelf,
+      hasAllySource: data.hasAnyAlly,
       sources: data.sources,
     };
     if (BOON_NAMES.has(name)) {

--- a/src/renderer/modules/boon-coverage.js
+++ b/src/renderer/modules/boon-coverage.js
@@ -3,25 +3,56 @@ import {
   BOON_DISPLAY_ORDER, BUFF_FACT_TYPES, BOON_CONDITION_ICONS,
 } from "./constants.js";
 
+const ALL_KNOWN_NAMES = [...BOON_NAMES, ...CONDITION_NAMES];
+
 function normalizeName(status) {
   return CONDITION_NAME_NORMALIZE[status] || status;
 }
 
 // Check whether a specific boon/condition is described as ally-targeted in the description.
-// Looks for the boon name appearing in a sentence that also contains "allies" or "ally".
-// Falls back to false (self-applied) when uncertain.
-function isAllyTargeted(description, statusName) {
+// Strategy:
+// 1. If the boon name appears in a sentence with "allies/ally" → ally.
+// 2. If the boon name appears in description but NOT in an ally sentence → self.
+// 3. If the boon is NOT named in the description at all:
+//    a. If the description mentions allies generically (no other boon names appear
+//       near "allies" either) → ally (e.g. "grant boons to allies").
+//    b. If other specific boons ARE named with allies → self (the ally mention
+//       is about those specific boons, not this unnamed one).
+// 4. No allies mentioned → self.
+function isAllyTargeted(description, statusName, allBoonNames) {
   if (!description) return false;
   const desc = description.toLowerCase();
   const name = statusName.toLowerCase();
-  // Split into sentences (roughly) and check if any sentence mentions both the boon and allies
+  const hasAllyWord = /\b(allies|ally)\b/.test(desc);
+  if (!hasAllyWord) return false;
+
   const sentences = desc.split(/[.!;]/);
+
+  // If the boon name appears in the description, check per-sentence
+  if (desc.includes(name)) {
+    for (const sentence of sentences) {
+      if (sentence.includes(name) && /\b(allies|ally)\b/.test(sentence)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Boon not named in description — check if the ally mentions are generic or specific
+  // If any other known boon/condition name appears in an ally sentence, the ally
+  // mention is specific to those boons → this unnamed boon defaults to self
+  const knownNames = allBoonNames || [];
   for (const sentence of sentences) {
-    if (sentence.includes(name) && /\b(allies|ally)\b/.test(sentence)) {
-      return true;
+    if (!/\b(allies|ally)\b/.test(sentence)) continue;
+    for (const known of knownNames) {
+      if (sentence.includes(known.toLowerCase())) {
+        // Ally mention is about a specific named boon, not generic
+        return false;
+      }
     }
   }
-  return false;
+  // Ally mentions are generic (no specific boon named) → ally
+  return true;
 }
 
 function extractBuffFacts(entity, sourceType) {
@@ -40,7 +71,7 @@ function extractBuffFacts(entity, sourceType) {
       sourceName: entity.name || "",
       stacks: fact.apply_count || 0,
       duration: fact.duration || 0,
-      isAlly: isAllyTargeted(desc, rawStatus),
+      isAlly: isAllyTargeted(desc, rawStatus, ALL_KNOWN_NAMES),
     });
   }
   return results;

--- a/src/renderer/modules/boon-coverage.js
+++ b/src/renderer/modules/boon-coverage.js
@@ -3,20 +3,31 @@ import {
   BOON_DISPLAY_ORDER, BUFF_FACT_TYPES, BOON_CONDITION_ICONS,
 } from "./constants.js";
 
-const ALLY_PATTERNS = /\b(allies|ally)\b/i;
-
 function normalizeName(status) {
   return CONDITION_NAME_NORMALIZE[status] || status;
 }
 
-function isAllyDescription(description) {
-  return ALLY_PATTERNS.test(description || "");
+// Check whether a specific boon/condition is described as ally-targeted in the description.
+// Looks for the boon name appearing in a sentence that also contains "allies" or "ally".
+// Falls back to false (self-applied) when uncertain.
+function isAllyTargeted(description, statusName) {
+  if (!description) return false;
+  const desc = description.toLowerCase();
+  const name = statusName.toLowerCase();
+  // Split into sentences (roughly) and check if any sentence mentions both the boon and allies
+  const sentences = desc.split(/[.!;]/);
+  for (const sentence of sentences) {
+    if (sentence.includes(name) && /\b(allies|ally)\b/.test(sentence)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function extractBuffFacts(entity, sourceType) {
   const results = [];
   const facts = entity.facts || [];
-  const isAlly = isAllyDescription(entity.description);
+  const desc = entity.description || "";
   for (const fact of facts) {
     if (!BUFF_FACT_TYPES.has(fact.type)) continue;
     const rawStatus = fact.status;
@@ -29,7 +40,7 @@ function extractBuffFacts(entity, sourceType) {
       sourceName: entity.name || "",
       stacks: fact.apply_count || 0,
       duration: fact.duration || 0,
-      isAlly,
+      isAlly: isAllyTargeted(desc, rawStatus),
     });
   }
   return results;

--- a/src/renderer/modules/boon-coverage.js
+++ b/src/renderer/modules/boon-coverage.js
@@ -173,16 +173,19 @@ export function computeBoonCoverage(catalog, editor, weaponSkills = []) {
   const boons = [];
   const conditions = [];
   for (const [name, data] of grouped) {
-    const entry = {
-      name,
-      icon: BOON_CONDITION_ICONS[name] || "",
-      hasAllySource: data.hasAnyAlly,
-      sources: data.sources,
-    };
     if (BOON_NAMES.has(name)) {
-      boons.push(entry);
+      boons.push({
+        name,
+        icon: BOON_CONDITION_ICONS[name] || "",
+        hasAllySource: data.hasAnyAlly,
+        sources: data.sources,
+      });
     } else {
-      conditions.push(entry);
+      conditions.push({
+        name,
+        icon: BOON_CONDITION_ICONS[name] || "",
+        sources: data.sources,
+      });
     }
   }
 

--- a/src/renderer/modules/boon-coverage.js
+++ b/src/renderer/modules/boon-coverage.js
@@ -1,0 +1,146 @@
+import {
+  BOON_NAMES, CONDITION_NAMES, CONDITION_NAME_NORMALIZE,
+  BOON_DISPLAY_ORDER, BUFF_FACT_TYPES, BOON_CONDITION_ICONS,
+} from "./constants.js";
+
+const ALLY_PATTERNS = /\b(allies|ally)\b/i;
+
+function normalizeName(status) {
+  return CONDITION_NAME_NORMALIZE[status] || status;
+}
+
+function isAllyDescription(description) {
+  return ALLY_PATTERNS.test(description || "");
+}
+
+function extractBuffFacts(entity, sourceType) {
+  const results = [];
+  const facts = entity.facts || [];
+  const isAlly = isAllyDescription(entity.description);
+  for (const fact of facts) {
+    if (!BUFF_FACT_TYPES.has(fact.type)) continue;
+    const rawStatus = fact.status;
+    if (!rawStatus) continue;
+    const name = normalizeName(rawStatus);
+    if (!BOON_NAMES.has(name) && !CONDITION_NAMES.has(name)) continue;
+    results.push({
+      name,
+      sourceType,
+      sourceName: entity.name || "",
+      stacks: fact.apply_count || 0,
+      duration: fact.duration || 0,
+      isAlly,
+    });
+  }
+  return results;
+}
+
+function collectSkillIds(editor, catalog) {
+  const ids = new Set();
+  const skills = editor.skills || {};
+  if (skills.healId) ids.add(Number(skills.healId));
+  if (skills.eliteId) ids.add(Number(skills.eliteId));
+  for (const uid of skills.utilityIds || []) {
+    if (uid) ids.add(Number(uid));
+  }
+  // Profession mechanic skill IDs (F1-F5)
+  const profSkills = catalog?.skills || [];
+  const selectedSpecIds = new Set(
+    (editor.specializations || []).map((s) => Number(s?.specializationId) || 0).filter(Boolean)
+  );
+  for (const s of profSkills) {
+    if ((s.type || "").toLowerCase() !== "profession") continue;
+    const reqSpec = Number(s.specialization) || 0;
+    if (reqSpec && !selectedSpecIds.has(reqSpec)) continue;
+    if (/^Profession_[1-5]$/.test(s.slot || "")) ids.add(s.id);
+  }
+  return ids;
+}
+
+function collectTraitIds(editor) {
+  const ids = new Set();
+  for (const spec of editor.specializations || []) {
+    const choices = spec?.majorChoices || {};
+    for (const tier of [1, 2, 3]) {
+      const traitId = Number(choices[tier]) || 0;
+      if (traitId) ids.add(traitId);
+    }
+  }
+  return ids;
+}
+
+export function computeBoonCoverage(catalog, editor, weaponSkills = []) {
+  if (!catalog) return { boons: [], conditions: [] };
+
+  const allFacts = [];
+
+  // Collect from weapon skills (passed in by caller, already resolved)
+  for (const ws of weaponSkills) {
+    if (!ws) continue;
+    allFacts.push(...extractBuffFacts(ws, "skill"));
+    if (ws.flipSkill) {
+      const flip = catalog.skillById?.get(ws.flipSkill) || catalog.weaponSkillById?.get(ws.flipSkill);
+      if (flip) allFacts.push(...extractBuffFacts(flip, "skill"));
+    }
+  }
+
+  // Collect from skills (heal, utility, elite, profession mechanics)
+  const skillIds = collectSkillIds(editor, catalog);
+  for (const id of skillIds) {
+    const skill = catalog.skillById?.get(id);
+    if (!skill) continue;
+    allFacts.push(...extractBuffFacts(skill, "skill"));
+    if (skill.flipSkill) {
+      const flip = catalog.skillById?.get(skill.flipSkill);
+      if (flip) allFacts.push(...extractBuffFacts(flip, "skill"));
+    }
+  }
+
+  // Collect from traits
+  const traitIds = collectTraitIds(editor);
+  for (const id of traitIds) {
+    const trait = catalog.traitById?.get(id);
+    if (!trait) continue;
+    allFacts.push(...extractBuffFacts(trait, "trait"));
+  }
+
+  // Group by name (already normalized in extractBuffFacts)
+  const grouped = new Map();
+  for (const f of allFacts) {
+    if (!grouped.has(f.name)) {
+      grouped.set(f.name, { sources: [], hasAnySelf: false });
+    }
+    const entry = grouped.get(f.name);
+    entry.sources.push({
+      type: f.sourceType,
+      name: f.sourceName,
+      stacks: f.stacks,
+      duration: f.duration,
+    });
+    if (!f.isAlly) entry.hasAnySelf = true;
+  }
+
+  // Build output arrays
+  const boons = [];
+  const conditions = [];
+  for (const [name, data] of grouped) {
+    const entry = {
+      name,
+      icon: BOON_CONDITION_ICONS[name] || "",
+      allyOnly: !data.hasAnySelf,
+      sources: data.sources,
+    };
+    if (BOON_NAMES.has(name)) {
+      boons.push(entry);
+    } else {
+      conditions.push(entry);
+    }
+  }
+
+  // Sort boons by GW2 display order, conditions alphabetically
+  const boonOrder = new Map(BOON_DISPLAY_ORDER.map((b, i) => [b, i]));
+  boons.sort((a, b) => (boonOrder.get(a.name) ?? 99) - (boonOrder.get(b.name) ?? 99));
+  conditions.sort((a, b) => a.name.localeCompare(b.name));
+
+  return { boons, conditions };
+}

--- a/src/renderer/modules/constants.js
+++ b/src/renderer/modules/constants.js
@@ -450,6 +450,28 @@ export const BOON_CONDITION_ICONS = {
 // Fact types where the icon represents the boon/condition being applied.
 export const BUFF_FACT_TYPES = new Set(["Buff", "ApplyBuffCondition", "PrefixedBuff"]);
 
+export const BOON_NAMES = new Set([
+  "Aegis", "Alacrity", "Fury", "Might", "Protection", "Quickness",
+  "Regeneration", "Resistance", "Resolution", "Stability", "Swiftness", "Vigor",
+]);
+
+export const CONDITION_NAMES = new Set([
+  "Bleeding", "Blind", "Blinded", "Burning", "Chill", "Chilled",
+  "Confusion", "Cripple", "Crippled", "Fear", "Immobile", "Immobilize", "Immobilized",
+  "Poison", "Poisoned", "Slow", "Taunt", "Torment",
+  "Vulnerability", "Weakness",
+]);
+
+export const CONDITION_NAME_NORMALIZE = {
+  Blind: "Blinded", Chill: "Chilled", Cripple: "Crippled",
+  Immobilize: "Immobile", Immobilized: "Immobile", Poison: "Poisoned",
+};
+
+export const BOON_DISPLAY_ORDER = [
+  "Aegis", "Alacrity", "Fury", "Might", "Protection", "Quickness",
+  "Regeneration", "Resistance", "Resolution", "Stability", "Swiftness", "Vigor",
+];
+
 // Fallback icons keyed by GW2 API fact type, for facts missing fact.icon.
 // Icons sourced from render.guildwars2.com via /v2/skills API responses.
 export const FACT_TYPE_ICONS = {

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -1020,8 +1020,8 @@ function _renderBoonCoverage(catalog, editor, weaponSkills = []) {
       const img = document.createElement("img");
       img.src = item.icon;
       img.alt = item.name;
-      img.width = 18;
-      img.height = 18;
+      img.width = 24;
+      img.height = 24;
       icon.append(img);
 
       if (item.hasAllySource) {

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -15,6 +15,7 @@ import {
 import { escapeHtml, parseWeaponSlotNum } from "./utils.js";
 import { bindHoverPreview, selectDetail, buildSkillCard, showHoverPreview } from "./detail-panel.js";
 import { computeEquipmentStats } from "./stats.js";
+import { computeBoonCoverage } from "./boon-coverage.js";
 import { renderCustomSelect } from "./custom-select.js";
 
 // DOM refs injected by the entry point via initSkills() to keep this module
@@ -999,6 +1000,97 @@ function _renderUnderwaterToggle() {
   return container;
 }
 
+function _renderBoonCoverage(catalog, editor, weaponSkills = []) {
+  const coverage = computeBoonCoverage(catalog, editor, weaponSkills);
+  const hasBoons = coverage.boons.length > 0;
+  const hasConditions = coverage.conditions.length > 0;
+  if (!hasBoons && !hasConditions) return null;
+
+  const container = document.createElement("div");
+  container.className = "boon-coverage";
+
+  function makeIconRow(items, className) {
+    if (items.length === 0) return null;
+    const row = document.createElement("div");
+    row.className = className;
+    for (const item of items) {
+      const icon = document.createElement("div");
+      icon.className = "boon-coverage__icon";
+
+      const img = document.createElement("img");
+      img.src = item.icon;
+      img.alt = item.name;
+      img.width = 18;
+      img.height = 18;
+      icon.append(img);
+
+      if (item.allyOnly) {
+        const badge = document.createElement("div");
+        badge.className = "boon-coverage__ally-badge";
+        badge.textContent = "⇧";
+        icon.append(badge);
+      }
+
+      // Tooltip on hover
+      icon.addEventListener("mouseenter", () => {
+        const tooltip = document.createElement("div");
+        tooltip.className = "boon-coverage__tooltip";
+
+        const title = document.createElement("div");
+        title.className = "boon-coverage__tooltip-title";
+        title.textContent = item.name;
+        tooltip.append(title);
+
+        for (const src of item.sources) {
+          const row = document.createElement("div");
+          row.className = "boon-coverage__tooltip-row";
+
+          const tag = document.createElement("span");
+          tag.className = `boon-coverage__tooltip-tag boon-coverage__tooltip-tag--${src.type}`;
+          tag.textContent = src.type === "skill" ? "Skill" : "Trait";
+          row.append(tag);
+
+          const name = document.createElement("span");
+          name.className = "boon-coverage__tooltip-name";
+          name.textContent = src.name;
+          row.append(name);
+
+          const detail = document.createElement("span");
+          detail.className = "boon-coverage__tooltip-detail";
+          if (src.duration > 0) {
+            const parts = [];
+            if (src.stacks > 0) parts.push(`${src.stacks}×`);
+            parts.push(`${src.duration}s`);
+            detail.textContent = parts.join(" ");
+          } else {
+            detail.textContent = "passive";
+          }
+          row.append(detail);
+
+          tooltip.append(row);
+        }
+
+        icon.append(tooltip);
+      });
+
+      icon.addEventListener("mouseleave", () => {
+        const tooltip = icon.querySelector(".boon-coverage__tooltip");
+        if (tooltip) tooltip.remove();
+      });
+
+      row.append(icon);
+    }
+    return row;
+  }
+
+  const boonRow = makeIconRow(coverage.boons, "boon-coverage__boons");
+  const condRow = makeIconRow(coverage.conditions, "boon-coverage__conditions");
+  if (boonRow) container.append(boonRow);
+  if (condRow) container.append(condRow);
+
+  return container;
+}
+
 export function renderSkills() {
   const catalog = state.activeCatalog;
   _el.skillsHost.innerHTML = "";
@@ -1569,7 +1661,12 @@ export function renderSkills() {
   } else {
     orbCol.append(orbEl);
   }
-  bar.append(weaponCol, orbCol, utilityGroup);
+  const utilCol = document.createElement("div");
+  utilCol.className = "skills-bar__util-col";
+  const coverageEl = _renderBoonCoverage(catalog, state.editor, weaponSkills);
+  if (coverageEl) utilCol.append(coverageEl);
+  utilCol.append(utilityGroup);
+  bar.append(weaponCol, orbCol, utilCol);
   _el.skillsHost.append(bar);
   state.renderedSkillIconIds = nextRenderedSkillIconIds;
 }

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -1042,18 +1042,18 @@ function _renderBoonCoverage(catalog, editor, weaponSkills = []) {
         tooltip.append(title);
 
         for (const src of item.sources) {
-          const row = document.createElement("div");
-          row.className = "boon-coverage__tooltip-row";
+          const sourceRow = document.createElement("div");
+          sourceRow.className = "boon-coverage__tooltip-row";
 
           const tag = document.createElement("span");
           tag.className = `boon-coverage__tooltip-tag boon-coverage__tooltip-tag--${src.type}`;
           tag.textContent = src.type === "skill" ? "Skill" : "Trait";
-          row.append(tag);
+          sourceRow.append(tag);
 
-          const name = document.createElement("span");
-          name.className = "boon-coverage__tooltip-name";
-          name.textContent = src.name;
-          row.append(name);
+          const srcName = document.createElement("span");
+          srcName.className = "boon-coverage__tooltip-name";
+          srcName.textContent = src.name;
+          sourceRow.append(srcName);
 
           const detail = document.createElement("span");
           detail.className = "boon-coverage__tooltip-detail";
@@ -1065,9 +1065,9 @@ function _renderBoonCoverage(catalog, editor, weaponSkills = []) {
           } else {
             detail.textContent = "passive";
           }
-          row.append(detail);
+          sourceRow.append(detail);
 
-          tooltip.append(row);
+          tooltip.append(sourceRow);
         }
 
         icon.append(tooltip);

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -1024,7 +1024,7 @@ function _renderBoonCoverage(catalog, editor, weaponSkills = []) {
       img.height = 18;
       icon.append(img);
 
-      if (item.allyOnly) {
+      if (item.hasAllySource) {
         const badge = document.createElement("div");
         badge.className = "boon-coverage__ally-badge";
         badge.textContent = "⇧";

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -1655,7 +1655,6 @@ export function renderSkills() {
 
   const orbCol = document.createElement("div");
   orbCol.className = "skills-bar__orb-col";
-  orbCol.append(_renderUnderwaterToggle());
   if (f5SlotEl) {
     orbCol.append(f5SlotEl, orbEl);
   } else {
@@ -1667,7 +1666,7 @@ export function renderSkills() {
   if (coverageEl) utilCol.append(coverageEl);
   utilCol.append(utilityGroup);
   bar.append(weaponCol, orbCol, utilCol);
-  _el.skillsHost.append(bar);
+  _el.skillsHost.append(_renderUnderwaterToggle(), bar);
   state.renderedSkillIconIds = nextRenderedSkillIconIds;
 }
 

--- a/src/renderer/styles/skills.css
+++ b/src/renderer/styles/skills.css
@@ -378,7 +378,7 @@
 .skills-bar__orb-col {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   gap: 4px;
 }
 

--- a/src/renderer/styles/skills.css
+++ b/src/renderer/styles/skills.css
@@ -682,8 +682,8 @@
 
 .boon-coverage__icon {
   position: relative;
-  width: 22px;
-  height: 22px;
+  width: 28px;
+  height: 28px;
   border-radius: 3px;
   background: rgba(2, 8, 16, 0.5);
   border: 1px solid rgba(180, 180, 180, 0.25);
@@ -699,8 +699,8 @@
 }
 
 .boon-coverage__icon img {
-  width: 18px;
-  height: 18px;
+  width: 24px;
+  height: 24px;
   border-radius: 2px;
   display: block;
 }

--- a/src/renderer/styles/skills.css
+++ b/src/renderer/styles/skills.css
@@ -663,6 +663,7 @@
 .skills-bar__util-col {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 4px;
 }
 

--- a/src/renderer/styles/skills.css
+++ b/src/renderer/styles/skills.css
@@ -378,7 +378,7 @@
 .skills-bar__orb-col {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: 4px;
 }
 

--- a/src/renderer/styles/skills.css
+++ b/src/renderer/styles/skills.css
@@ -658,3 +658,125 @@
   color: #fff;
   cursor: default;
 }
+
+/* Boon & Condition Coverage */
+.skills-bar__util-col {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.boon-coverage {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.boon-coverage__boons,
+.boon-coverage__conditions {
+  display: flex;
+  gap: 3px;
+  align-items: center;
+}
+
+.boon-coverage__icon {
+  position: relative;
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+  background: rgba(2, 8, 16, 0.5);
+  border: 1px solid rgba(180, 180, 180, 0.25);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.boon-coverage__icon:hover {
+  border-color: rgba(255, 220, 100, 0.7);
+  box-shadow: 0 0 6px rgba(255, 200, 50, 0.3);
+}
+
+.boon-coverage__icon img {
+  width: 18px;
+  height: 18px;
+  border-radius: 2px;
+  display: block;
+}
+
+.boon-coverage__ally-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(100, 180, 255, 0.9);
+  display: grid;
+  place-items: center;
+  font-size: 6px;
+  color: #fff;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.boon-coverage__tooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(12, 18, 32, 0.96);
+  border: 1px solid rgba(100, 140, 200, 0.3);
+  border-radius: 6px;
+  padding: 8px 12px;
+  min-width: 200px;
+  max-width: 320px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  z-index: 100;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.boon-coverage__tooltip-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 5px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(100, 140, 200, 0.15);
+}
+
+.boon-coverage__tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  font-size: 11px;
+}
+
+.boon-coverage__tooltip-tag {
+  font-size: 9px;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.boon-coverage__tooltip-tag--skill {
+  color: rgba(100, 180, 255, 0.9);
+  background: rgba(100, 180, 255, 0.15);
+}
+
+.boon-coverage__tooltip-tag--trait {
+  color: rgba(255, 180, 80, 0.9);
+  background: rgba(255, 180, 80, 0.15);
+}
+
+.boon-coverage__tooltip-name {
+  color: rgba(220, 220, 240, 0.9);
+}
+
+.boon-coverage__tooltip-detail {
+  color: rgba(180, 200, 230, 0.5);
+  margin-left: auto;
+}

--- a/tests/unit/renderer/boon-coverage.test.js
+++ b/tests/unit/renderer/boon-coverage.test.js
@@ -105,6 +105,21 @@ describe("computeBoonCoverage", () => {
     expect(result.boons[0].sources[0]).toMatchObject({ type: "trait", name: "Radiant Power" });
   });
 
+  test("extracts boons from minor traits (always active on equipped spec)", () => {
+    const minorTrait = makeTrait(600, "Protector's Restoration", [buffFact("Protection", 3)]);
+    const catalog = makeCatalog({
+      traitById: new Map([[600, minorTrait]]),
+      specializationById: new Map([[42, { minorTraits: [600] }]]),
+    });
+    const editor = makeEditor({
+      specializations: [{ specializationId: 42, majorChoices: { 1: 0, 2: 0, 3: 0 } }],
+    });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].name).toBe("Protection");
+    expect(result.boons[0].sources[0]).toMatchObject({ type: "trait", name: "Protector's Restoration" });
+  });
+
   test("follows flipSkill one level deep", () => {
     const flip = makeSkill(101, "Flip Skill", [buffFact("Might", 5, 2)]);
     const base = makeSkill(100, "Base Skill", [], { flipSkill: 101 });

--- a/tests/unit/renderer/boon-coverage.test.js
+++ b/tests/unit/renderer/boon-coverage.test.js
@@ -145,6 +145,28 @@ describe("computeBoonCoverage", () => {
     expect(result.boons[0].allyOnly).toBe(false);
   });
 
+  test("per-fact ally detection: only marks the specific boon mentioned with allies", () => {
+    // Simulates Tempestuous Aria: "Using a shout grants allies might. Granting an aura..."
+    // Might should be ally, but Stability from same trait should NOT be ally
+    const trait = makeTrait(500, "Tempestuous Aria", [
+      buffFact("Might", 6, 3),
+      buffFact("Stability", 3, 1),
+    ], {
+      description: "Using a shout grants allies might. Granting an aura to an ally increases your outgoing damage.",
+    });
+    const catalog = makeCatalog({ traitById: new Map([[500, trait]]) });
+    const editor = makeEditor({
+      specializations: [{ specializationId: 42, majorChoices: { 1: 500, 2: 0, 3: 0 } }],
+    });
+    const result = computeBoonCoverage(catalog, editor);
+    const might = result.boons.find((b) => b.name === "Might");
+    const stab = result.boons.find((b) => b.name === "Stability");
+    expect(might).toBeDefined();
+    expect(stab).toBeDefined();
+    expect(might.allyOnly).toBe(true);
+    expect(stab.allyOnly).toBe(false);
+  });
+
   test("boons are sorted in GW2 display order", () => {
     const s1 = makeSkill(100, "S1", [buffFact("Vigor", 3)]);
     const s2 = makeSkill(200, "S2", [buffFact("Aegis", 3)]);

--- a/tests/unit/renderer/boon-coverage.test.js
+++ b/tests/unit/renderer/boon-coverage.test.js
@@ -151,6 +151,19 @@ describe("computeBoonCoverage", () => {
     expect(result.boons[0].allyOnly).toBe(true);
   });
 
+  test("marks as ally when description mentions allies but not the specific boon name", () => {
+    // Generic: "Grant boons to nearby allies." without naming Protection
+    const trait = makeTrait(500, "Protective Ward", [buffFact("Protection", 3)], {
+      description: "Grant boons to nearby allies.",
+    });
+    const catalog = makeCatalog({ traitById: new Map([[500, trait]]) });
+    const editor = makeEditor({
+      specializations: [{ specializationId: 42, majorChoices: { 1: 500, 2: 0, 3: 0 } }],
+    });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons[0].allyOnly).toBe(true);
+  });
+
   test("marks boon as self when any source lacks ally description", () => {
     const s1 = makeSkill(100, "Self Might", [buffFact("Might", 5)], { description: "Gain might." });
     const s2 = makeSkill(200, "Ally Might", [buffFact("Might", 5)], { description: "Grant allies might." });

--- a/tests/unit/renderer/boon-coverage.test.js
+++ b/tests/unit/renderer/boon-coverage.test.js
@@ -1,0 +1,235 @@
+"use strict";
+
+const { computeBoonCoverage } = require("../../../src/renderer/modules/boon-coverage");
+
+function makeCatalog(overrides = {}) {
+  return {
+    skillById: overrides.skillById || new Map(),
+    traitById: overrides.traitById || new Map(),
+    weaponSkillById: overrides.weaponSkillById || new Map(),
+    professionWeapons: overrides.professionWeapons || {},
+    ...overrides,
+  };
+}
+
+function makeEditor(overrides = {}) {
+  return {
+    skills: { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 },
+    specializations: [],
+    equipment: { weapons: {} },
+    underwaterMode: false,
+    ...overrides,
+  };
+}
+
+function makeSkill(id, name, facts = [], extra = {}) {
+  return { id, name, description: "", facts, type: "Utility", ...extra };
+}
+
+function makeTrait(id, name, facts = [], extra = {}) {
+  return { id, name, description: "", facts, ...extra };
+}
+
+function buffFact(status, duration = 0, applyCount = 0) {
+  return { type: "Buff", status, duration, apply_count: applyCount };
+}
+
+describe("computeBoonCoverage", () => {
+  test("returns empty arrays when no skills or traits have buff facts", () => {
+    const catalog = makeCatalog();
+    const editor = makeEditor();
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toEqual([]);
+    expect(result.conditions).toEqual([]);
+  });
+
+  test("extracts boon from a heal skill", () => {
+    const skill = makeSkill(100, "Healing Breeze", [buffFact("Regeneration", 5)]);
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].name).toBe("Regeneration");
+    expect(result.boons[0].sources).toHaveLength(1);
+    expect(result.boons[0].sources[0]).toMatchObject({ type: "skill", name: "Healing Breeze" });
+  });
+
+  test("extracts condition from a utility skill", () => {
+    const skill = makeSkill(200, "Torch Throw", [buffFact("Burning", 3, 2)]);
+    const catalog = makeCatalog({ skillById: new Map([[200, skill]]) });
+    const editor = makeEditor({ skills: { healId: 0, utilityIds: [200, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.conditions).toHaveLength(1);
+    expect(result.conditions[0].name).toBe("Burning");
+    expect(result.conditions[0].sources[0]).toMatchObject({ stacks: 2, duration: 3 });
+  });
+
+  test("normalizes condition name variants", () => {
+    const skill = makeSkill(300, "Blind Throw", [buffFact("Blind", 4)]);
+    const catalog = makeCatalog({ skillById: new Map([[300, skill]]) });
+    const editor = makeEditor({ skills: { healId: 0, utilityIds: [300, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.conditions).toHaveLength(1);
+    expect(result.conditions[0].name).toBe("Blinded");
+  });
+
+  test("groups multiple sources for the same boon", () => {
+    const s1 = makeSkill(100, "Skill A", [buffFact("Might", 6, 3)]);
+    const s2 = makeSkill(200, "Skill B", [buffFact("Might", 8, 1)]);
+    const catalog = makeCatalog({ skillById: new Map([[100, s1], [200, s2]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [200, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].name).toBe("Might");
+    expect(result.boons[0].sources).toHaveLength(2);
+  });
+
+  test("extracts boons from weapon skills passed as third argument", () => {
+    const ws = makeSkill(400, "Sword Strike", [buffFact("Might", 4, 1)]);
+    const catalog = makeCatalog();
+    const editor = makeEditor();
+    const result = computeBoonCoverage(catalog, editor, [ws, null, null, null, null]);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].name).toBe("Might");
+    expect(result.boons[0].sources[0]).toMatchObject({ type: "skill", name: "Sword Strike" });
+  });
+
+  test("extracts boons from selected traits", () => {
+    const trait = makeTrait(500, "Radiant Power", [buffFact("Fury", 3)]);
+    const catalog = makeCatalog({ traitById: new Map([[500, trait]]) });
+    const editor = makeEditor({
+      specializations: [{ specializationId: 42, majorChoices: { 1: 500, 2: 0, 3: 0 } }],
+    });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].sources[0]).toMatchObject({ type: "trait", name: "Radiant Power" });
+  });
+
+  test("follows flipSkill one level deep", () => {
+    const flip = makeSkill(101, "Flip Skill", [buffFact("Might", 5, 2)]);
+    const base = makeSkill(100, "Base Skill", [], { flipSkill: 101 });
+    const catalog = makeCatalog({ skillById: new Map([[100, base], [101, flip]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].sources[0].name).toBe("Flip Skill");
+  });
+
+  test("does not follow flipSkill beyond one level", () => {
+    const flip2 = makeSkill(102, "Double Flip", [buffFact("Fury", 3)]);
+    const flip1 = makeSkill(101, "Flip Skill", [buffFact("Might", 5)], { flipSkill: 102 });
+    const base = makeSkill(100, "Base Skill", [], { flipSkill: 101 });
+    const catalog = makeCatalog({ skillById: new Map([[100, base], [101, flip1], [102, flip2]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].name).toBe("Might");
+  });
+
+  test("marks ally-only boons when all sources have ally description", () => {
+    const skill = makeSkill(100, "Grant Allies Might", [buffFact("Might", 5, 3)], {
+      description: "Grant nearby allies might.",
+    });
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons[0].allyOnly).toBe(true);
+  });
+
+  test("marks boon as self when any source lacks ally description", () => {
+    const s1 = makeSkill(100, "Self Might", [buffFact("Might", 5)], { description: "Gain might." });
+    const s2 = makeSkill(200, "Ally Might", [buffFact("Might", 5)], { description: "Grant allies might." });
+    const catalog = makeCatalog({ skillById: new Map([[100, s1], [200, s2]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [200, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons[0].allyOnly).toBe(false);
+  });
+
+  test("boons are sorted in GW2 display order", () => {
+    const s1 = makeSkill(100, "S1", [buffFact("Vigor", 3)]);
+    const s2 = makeSkill(200, "S2", [buffFact("Aegis", 3)]);
+    const s3 = makeSkill(300, "S3", [buffFact("Might", 3)]);
+    const catalog = makeCatalog({ skillById: new Map([[100, s1], [200, s2], [300, s3]]) });
+    const editor = makeEditor({ skills: { healId: 0, utilityIds: [100, 200, 300], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons.map((b) => b.name)).toEqual(["Aegis", "Might", "Vigor"]);
+  });
+
+  test("conditions are sorted alphabetically", () => {
+    const s1 = makeSkill(100, "S1", [buffFact("Vulnerability", 3)]);
+    const s2 = makeSkill(200, "S2", [buffFact("Bleeding", 3)]);
+    const catalog = makeCatalog({ skillById: new Map([[100, s1], [200, s2]]) });
+    const editor = makeEditor({ skills: { healId: 0, utilityIds: [100, 200, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.conditions.map((c) => c.name)).toEqual(["Bleeding", "Vulnerability"]);
+  });
+
+  test("includes icon URL from BOON_CONDITION_ICONS", () => {
+    const skill = makeSkill(100, "Might Skill", [buffFact("Might", 5)]);
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons[0].icon).toContain("render.guildwars2.com");
+  });
+
+  test("ignores non-buff fact types", () => {
+    const skill = makeSkill(100, "Damage Skill", [
+      { type: "Damage", value: 500 },
+      { type: "Duration", value: 10 },
+    ]);
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toEqual([]);
+    expect(result.conditions).toEqual([]);
+  });
+
+  test("handles ApplyBuffCondition and PrefixedBuff fact types", () => {
+    const skill = makeSkill(100, "Multi", [
+      { type: "ApplyBuffCondition", status: "Burning", duration: 3, apply_count: 1 },
+      { type: "PrefixedBuff", status: "Might", duration: 5, apply_count: 2 },
+    ]);
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.conditions).toHaveLength(1);
+  });
+
+  test("extracts boons from profession mechanic skills (F1-F5)", () => {
+    const mechSkill = makeSkill(600, "F1 Virtue", [buffFact("Aegis", 3)], {
+      type: "Profession", slot: "Profession_1", specialization: 0,
+    });
+    const catalog = makeCatalog({
+      skillById: new Map([[600, mechSkill]]),
+      skills: [mechSkill],
+    });
+    const editor = makeEditor();
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].name).toBe("Aegis");
+    expect(result.boons[0].sources[0]).toMatchObject({ type: "skill", name: "F1 Virtue" });
+  });
+
+  test("skips profession mechanics requiring unselected elite spec", () => {
+    const mechSkill = makeSkill(700, "Elite F1", [buffFact("Quickness", 5)], {
+      type: "Profession", slot: "Profession_1", specialization: 27,
+    });
+    const catalog = makeCatalog({
+      skillById: new Map([[700, mechSkill]]),
+      skills: [mechSkill],
+    });
+    const editor = makeEditor({ specializations: [] });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toEqual([]);
+  });
+
+  test("handles missing or zero apply_count and duration gracefully", () => {
+    const skill = makeSkill(100, "Passive Skill", [{ type: "Buff", status: "Might" }]);
+    const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
+    const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
+    const result = computeBoonCoverage(catalog, editor);
+    expect(result.boons).toHaveLength(1);
+    expect(result.boons[0].sources[0]).toMatchObject({ stacks: 0, duration: 0 });
+  });
+});

--- a/tests/unit/renderer/boon-coverage.test.js
+++ b/tests/unit/renderer/boon-coverage.test.js
@@ -148,7 +148,7 @@ describe("computeBoonCoverage", () => {
     const catalog = makeCatalog({ skillById: new Map([[100, skill]]) });
     const editor = makeEditor({ skills: { healId: 100, utilityIds: [0, 0, 0], eliteId: 0 } });
     const result = computeBoonCoverage(catalog, editor);
-    expect(result.boons[0].allyOnly).toBe(true);
+    expect(result.boons[0].hasAllySource).toBe(true);
   });
 
   test("marks as ally when description mentions allies but not the specific boon name", () => {
@@ -161,16 +161,16 @@ describe("computeBoonCoverage", () => {
       specializations: [{ specializationId: 42, majorChoices: { 1: 500, 2: 0, 3: 0 } }],
     });
     const result = computeBoonCoverage(catalog, editor);
-    expect(result.boons[0].allyOnly).toBe(true);
+    expect(result.boons[0].hasAllySource).toBe(true);
   });
 
-  test("marks boon as self when any source lacks ally description", () => {
+  test("shows ally badge when any source targets allies, even if others are self", () => {
     const s1 = makeSkill(100, "Self Might", [buffFact("Might", 5)], { description: "Gain might." });
     const s2 = makeSkill(200, "Ally Might", [buffFact("Might", 5)], { description: "Grant allies might." });
     const catalog = makeCatalog({ skillById: new Map([[100, s1], [200, s2]]) });
     const editor = makeEditor({ skills: { healId: 100, utilityIds: [200, 0, 0], eliteId: 0 } });
     const result = computeBoonCoverage(catalog, editor);
-    expect(result.boons[0].allyOnly).toBe(false);
+    expect(result.boons[0].hasAllySource).toBe(true);
   });
 
   test("per-fact ally detection: only marks the specific boon mentioned with allies", () => {
@@ -191,8 +191,8 @@ describe("computeBoonCoverage", () => {
     const stab = result.boons.find((b) => b.name === "Stability");
     expect(might).toBeDefined();
     expect(stab).toBeDefined();
-    expect(might.allyOnly).toBe(true);
-    expect(stab.allyOnly).toBe(false);
+    expect(might.hasAllySource).toBe(true);
+    expect(stab.hasAllySource).toBe(false);
   });
 
   test("boons are sorted in GW2 display order", () => {


### PR DESCRIPTION
## Summary

- Adds boon and condition coverage icons above the heal/utility/elite skill bar, showing what boons/conditions the current build can produce
- Scans all build sources: weapon skills, heal/utility/elite, profession mechanics (F1-F5), flip/chain skills, selected major traits, and minor traits
- Boons sorted in GW2 display order, conditions alphabetical
- Blue badge indicator on boons that can be shared to allies (per-fact detection using description heuristics)
- Hover tooltip showing each source with [Skill]/[Trait] tag, name, and stacks/duration
- Moves Land/Water toggle to top-left of skill bar panel
- Also includes: Dragonhunter F1 fix (closes #11), dual-wield slot restriction fix (closes #10)

## Test plan

- [x] 22 unit tests for `computeBoonCoverage` covering all data sources, normalization, sorting, ally detection, flip skills, edge cases
- [x] Full test suite passes (820 tests)
- [ ] Manual verification: boon/condition icons appear above utility skills
- [ ] Manual verification: hover tooltips show correct source breakdown
- [ ] Manual verification: ally badge appears on boons with ally-targeting sources
- [ ] Manual verification: icons update when changing skills/traits/specializations

🤖 Generated with [Claude Code](https://claude.com/claude-code)