### PR TITLE
fix: Infusion of weapons (closes #13)

### DIFF
--- a/src/renderer/modules/editor.js
+++ b/src/renderer/modules/editor.js
@@ -16,7 +16,11 @@ export function normalizeSigilArray(value, slotKey) {
 }
 
 // Normalize infusion value — arrays for multi-slot items (back, rings), strings otherwise.
-export const INFUSION_ARRAY_SLOTS = { back: 2, ring1: 3, ring2: 3 };
+export const INFUSION_ARRAY_SLOTS = {
+  back: 2, ring1: 3, ring2: 3,
+  mainhand1: 2, offhand1: 1, mainhand2: 2, offhand2: 1,
+  aquatic1: 2, aquatic2: 2, breather: 1,
+};
 
 export function normalizeInfusionValue(value, slotKey) {
   const expectedLen = INFUSION_ARRAY_SLOTS[slotKey];

--- a/src/renderer/modules/equipment.js
+++ b/src/renderer/modules/equipment.js
@@ -576,6 +576,9 @@ export function renderEquipmentPanel() {
       const sigilCount = slotDef.key.startsWith("offhand") ? 1 : (isAquaticSlot || isTwoHanded ? 2 : 1);
       const sigilArr = equip.sigils?.[slotDef.key] || [];
 
+      // Two-handed: stack SS / II in a 2×2 grid
+      if (isTwoHanded) upgradeContainer.classList.add("equip-upgrade-slots--stacked");
+
       for (let i = 0; i < sigilCount; i++) {
         const sigilVal = String(sigilArr[i] || "");
         const sigilBtn = makeUpgradeBtn("sigils", slotDef.key, sigilVal, (newVal) => {
@@ -590,15 +593,24 @@ export function renderEquipmentPanel() {
         if (sigilBtn) upgradeContainer.append(sigilBtn);
       }
 
-      // Infusion
-      const infVal = equip.infusions?.[slotDef.key] || "";
-      const weapInfBtn = makeUpgradeBtn("infusions", slotDef.key, infVal, (newVal) => {
-        if (!equip.infusions) equip.infusions = {};
-        equip.infusions[slotDef.key] = newVal || "";
-        _markEditorChanged();
-        renderEquipmentPanel();
-      });
-      if (weapInfBtn) upgradeContainer.append(weapInfBtn);
+      // Infusion — two-handed / aquatic = 2 slots; offhand = 1
+      const infusionCount = slotDef.key.startsWith("offhand") ? 1 : (isAquaticSlot || isTwoHanded ? 2 : 1);
+      const infArr = equip.infusions?.[slotDef.key] || [];
+      const infArrNorm = Array.isArray(infArr) ? infArr : [infArr];
+
+      for (let i = 0; i < infusionCount; i++) {
+        const infVal = String(infArrNorm[i] || "");
+        const weapInfBtn = makeUpgradeBtn("infusions", slotDef.key, infVal, (newVal) => {
+          if (!equip.infusions) equip.infusions = {};
+          if (!Array.isArray(equip.infusions[slotDef.key])) {
+            equip.infusions[slotDef.key] = slotDef.key.startsWith("offhand") ? [""] : ["", ""];
+          }
+          equip.infusions[slotDef.key][i] = newVal || "";
+          _markEditorChanged();
+          renderEquipmentPanel();
+        });
+        if (weapInfBtn) upgradeContainer.append(weapInfBtn);
+      }
 
       if (upgradeContainer.children.length > 0) {
         wrapper.append(upgradeContainer);

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -65,11 +65,11 @@ export function createEmptyEditor(profession = "", gameMode = "pve") {
       },
       infusions: {
         head: "", shoulders: "", chest: "", hands: "", legs: "", feet: "",
-        mainhand1: "", offhand1: "", mainhand2: "", offhand2: "",
+        mainhand1: ["", ""], offhand1: [""], mainhand2: ["", ""], offhand2: [""],
         back: ["", ""],
         ring1: ["", "", ""], ring2: ["", "", ""],
         accessory1: "", accessory2: "",
-        breather: "", aquatic1: "", aquatic2: "",
+        breather: [""], aquatic1: ["", ""], aquatic2: ["", ""],
       },
       enrichment: "",
     },

--- a/src/renderer/styles/equipment.css
+++ b/src/renderer/styles/equipment.css
@@ -707,6 +707,13 @@
   flex-shrink: 0;
 }
 
+/* Two-handed weapons: stack SS on top, II on bottom */
+.equip-upgrade-slots--stacked {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3px;
+}
+
 .equip-upgrade-btn {
   width: 24px;
   height: 24px;

--- a/tests/unit/renderer/infusions.test.js
+++ b/tests/unit/renderer/infusions.test.js
@@ -1,0 +1,92 @@
+"use strict";
+
+// Tests for two-handed weapon infusion slots (issue #13).
+// Two-handed weapons should have 2 infusion slots, matching sigil behaviour.
+
+const { normalizeInfusionValue, INFUSION_ARRAY_SLOTS } = require("../../../src/renderer/modules/editor");
+const { createEmptyEditor } = require("../../../src/renderer/modules/state");
+
+describe("INFUSION_ARRAY_SLOTS includes weapon slots", () => {
+  test("mainhand1 allows 2 infusion slots", () => {
+    expect(INFUSION_ARRAY_SLOTS.mainhand1).toBe(2);
+  });
+
+  test("mainhand2 allows 2 infusion slots", () => {
+    expect(INFUSION_ARRAY_SLOTS.mainhand2).toBe(2);
+  });
+
+  test("offhand1 allows 1 infusion slot", () => {
+    expect(INFUSION_ARRAY_SLOTS.offhand1).toBe(1);
+  });
+
+  test("offhand2 allows 1 infusion slot", () => {
+    expect(INFUSION_ARRAY_SLOTS.offhand2).toBe(1);
+  });
+
+  test("aquatic1 allows 2 infusion slots", () => {
+    expect(INFUSION_ARRAY_SLOTS.aquatic1).toBe(2);
+  });
+
+  test("aquatic2 allows 2 infusion slots", () => {
+    expect(INFUSION_ARRAY_SLOTS.aquatic2).toBe(2);
+  });
+
+  test("breather allows 1 infusion slot", () => {
+    expect(INFUSION_ARRAY_SLOTS.breather).toBe(1);
+  });
+});
+
+describe("normalizeInfusionValue for weapon slots", () => {
+  test("normalizes mainhand1 string to empty array of 2 (migration)", () => {
+    expect(normalizeInfusionValue("123", "mainhand1")).toEqual(["", ""]);
+  });
+
+  test("normalizes mainhand1 array to correct length", () => {
+    expect(normalizeInfusionValue(["123", "456"], "mainhand1")).toEqual(["123", "456"]);
+  });
+
+  test("normalizes empty mainhand1 to array of 2 empty strings", () => {
+    expect(normalizeInfusionValue("", "mainhand1")).toEqual(["", ""]);
+  });
+
+  test("normalizes offhand1 string to empty array of 1 (migration)", () => {
+    expect(normalizeInfusionValue("456", "offhand1")).toEqual([""]);
+  });
+
+  test("normalizes offhand1 array to correct length", () => {
+    expect(normalizeInfusionValue(["456"], "offhand1")).toEqual(["456"]);
+  });
+
+  test("normalizes aquatic1 to array of 2", () => {
+    expect(normalizeInfusionValue("", "aquatic1")).toEqual(["", ""]);
+  });
+
+  test("normalizes breather to array of 1", () => {
+    expect(normalizeInfusionValue("", "breather")).toEqual([""]);
+  });
+});
+
+describe("createEmptyEditor weapon infusions are arrays", () => {
+  const editor = createEmptyEditor();
+  const inf = editor.equipment.infusions;
+
+  test("mainhand1 infusion is array of length 2", () => {
+    expect(Array.isArray(inf.mainhand1)).toBe(true);
+    expect(inf.mainhand1).toHaveLength(2);
+  });
+
+  test("offhand1 infusion is array of length 1", () => {
+    expect(Array.isArray(inf.offhand1)).toBe(true);
+    expect(inf.offhand1).toHaveLength(1);
+  });
+
+  test("aquatic1 infusion is array of length 2", () => {
+    expect(Array.isArray(inf.aquatic1)).toBe(true);
+    expect(inf.aquatic1).toHaveLength(2);
+  });
+
+  test("breather infusion is array of length 1", () => {
+    expect(Array.isArray(inf.breather)).toBe(true);
+    expect(inf.breather).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Two-handed weapons only showed 1 infusion slot instead of 2. Weapon infusion slots are now stored as arrays (matching sigils), and two-handed weapons render upgrades in a stacked 2×2 grid (SS / II) to avoid a scrunched layout.

- Added weapon slots to `INFUSION_ARRAY_SLOTS` in `editor.js`
- Changed weapon infusion defaults from strings to arrays in `state.js`
- Updated weapon upgrade rendering in `equipment.js` to loop infusions like sigils, with a `--stacked` grid for two-handed weapons
- Added `equip-upgrade-slots--stacked` CSS for the 2×2 layout
- Added 18 unit tests covering normalization and state initialization

Closes #13