### PR TITLE
fix: Consumables don't update attributes (closes #23)

### DIFF
--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -76,11 +76,16 @@ function computePublishStats(equipment, upgradeCatalog, profession) {
     const foodDef = upgradeCatalog.foodById?.get(Number(equipment.food));
     if (foodDef) {
       const foodStatMap = { "Condition Damage": "ConditionDamage", "Healing Power": "HealingPower", "Healing": "HealingPower" };
-      const re = /\+(\d+)\s+(Condition Damage|Healing Power|Healing|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise)/g;
+      const ALL_STAT_KEYS = ["Power", "Precision", "Toughness", "Vitality", "Ferocity", "ConditionDamage", "HealingPower", "Concentration", "Expertise"];
+      const re = /\+(\d+)\s+(Condition Damage|Healing Power|Healing|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise|to All Attributes)/g;
       let m;
       while ((m = re.exec(foodDef.buff)) !== null) {
-        const key = foodStatMap[m[2]] || m[2];
-        if (totals[key] !== undefined) totals[key] += Number(m[1]);
+        if (m[2] === "to All Attributes") {
+          for (const key of ALL_STAT_KEYS) totals[key] += Number(m[1]);
+        } else {
+          const key = foodStatMap[m[2]] || m[2];
+          if (totals[key] !== undefined) totals[key] += Number(m[1]);
+        }
       }
     }
   }

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -67,11 +67,16 @@ export function computeEquipmentStats() {
         "Vitality": "Vitality", "Ferocity": "Ferocity",
         "Concentration": "Concentration", "Expertise": "Expertise",
       };
-      const re = /\+(\d+)\s+(Condition Damage|Healing Power|Healing|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise)/g;
+      const re = /\+(\d+)\s+(Condition Damage|Healing Power|Healing|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise|to All Attributes)/g;
+      const ALL_STAT_KEYS = ["Power", "Precision", "Toughness", "Vitality", "Ferocity", "ConditionDamage", "HealingPower", "Concentration", "Expertise"];
       let m;
       while ((m = re.exec(foodDef.buff)) !== null) {
-        const key = foodStatMap[m[2]];
-        if (key) totals[key] = (totals[key] || 0) + Number(m[1]);
+        if (m[2] === "to All Attributes") {
+          for (const key of ALL_STAT_KEYS) totals[key] = (totals[key] || 0) + Number(m[1]);
+        } else {
+          const key = foodStatMap[m[2]];
+          if (key) totals[key] = (totals[key] || 0) + Number(m[1]);
+        }
       }
     }
   }
@@ -241,12 +246,16 @@ export function computeStatBreakdown(statKey) {
       const STAT_NAMES = { Power: "Power", Precision: "Precision", Toughness: "Toughness", Vitality: "Vitality",
         Ferocity: "Ferocity", ConditionDamage: "Condition Damage", HealingPower: "Healing Power",
         Concentration: "Concentration", Expertise: "Expertise" };
-      const re = /\+(\d+)\s+(Condition Damage|Healing Power|Healing|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise)/g;
+      const re = /\+(\d+)\s+(Condition Damage|Healing Power|Healing|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise|to All Attributes)/g;
       const MAP = { "Condition Damage": "ConditionDamage", "Healing Power": "HealingPower", "Healing": "HealingPower" };
       let m;
       while ((m = re.exec(foodDef.buff)) !== null) {
-        const key = MAP[m[2]] || m[2];
-        if (key === statKey) entries.push({ source: `Food (${foodDef.name})`, value: Number(m[1]) });
+        if (m[2] === "to All Attributes") {
+          entries.push({ source: `Food (${foodDef.name})`, value: Number(m[1]) });
+        } else {
+          const key = MAP[m[2]] || m[2];
+          if (key === statKey) entries.push({ source: `Food (${foodDef.name})`, value: Number(m[1]) });
+        }
       }
     }
   }
@@ -360,7 +369,7 @@ export function computeUpgradeModifiers() {
   // Regex for percentage bonuses in rune bonus text: "+N% Something"
   const PCT_RE = /\+(\d+)%\s+(.+)/;
   // Regex for flat bonuses we already handle as stats — skip these
-  const FLAT_STAT_RE = /\+\d+\s+(Condition Damage|Healing Power|Healing|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise|to All Stats)/;
+  const FLAT_STAT_RE = /\+\d+\s+(Condition Damage|Healing Power|Healing|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise|to All Stats|to All Attributes)/;
 
   const isUnderwater = Boolean(state.editor.underwaterMode);
   const EXCLUDED_SLOTS = isUnderwater ? LAND_ONLY_SLOTS : AQUATIC_SLOTS;

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -224,6 +224,25 @@ describe("computeEquipmentStats — food contributions", () => {
     expect(result.Power).toBe(1000 + 134 + 100);
     expect(result.Ferocity).toBe(96 + 70);
   });
+
+  test("food with 'to All Attributes' adds to every stat", () => {
+    state.upgradeCatalog = {
+      foodById: new Map([
+        [91713, { id: 91713, name: "Feast of All-Stat Food", buff: "-10% Incoming Damage | +45 to All Attributes | +10% Karma" }],
+      ]),
+    };
+    state.editor = makeEditor({}, "91713");
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000 + 45);
+    expect(result.Precision).toBe(1000 + 45);
+    expect(result.Toughness).toBe(1000 + 45);
+    expect(result.Vitality).toBe(1000 + 45);
+    expect(result.Ferocity).toBe(45);
+    expect(result.ConditionDamage).toBe(45);
+    expect(result.HealingPower).toBe(45);
+    expect(result.Expertise).toBe(45);
+    expect(result.Concentration).toBe(45);
+  });
 });
 
 describe("computeEquipmentStats — 4-stat combo accumulation", () => {

--- a/tests/unit/statsCompute.test.js
+++ b/tests/unit/statsCompute.test.js
@@ -131,4 +131,27 @@ describe("computePublishStats", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Warrior");
     expect(Array.isArray(result.modifiers)).toBe(true);
   });
+
+  test("food with 'to All Attributes' adds to every stat", () => {
+    const equipment = { slots: {}, runes: {}, infusions: {}, food: "91713", utility: "" };
+    const upgradeCatalog = {
+      runeById: new Map(),
+      infusionById: new Map(),
+      enrichmentById: new Map(),
+      foodById: new Map([
+        [91713, { id: 91713, name: "Feast of All-Stat Food", buff: "-10% Incoming Damage | +45 to All Attributes | +10% Karma" }],
+      ]),
+      utilityById: new Map(),
+    };
+    const result = computePublishStats(equipment, upgradeCatalog, "Warrior");
+    expect(result.stats.Power).toBe(1000 + 45);
+    expect(result.stats.Precision).toBe(1000 + 45);
+    expect(result.stats.Toughness).toBe(1000 + 45);
+    expect(result.stats.Vitality).toBe(1000 + 45);
+    expect(result.stats.Ferocity).toBe(45);
+    expect(result.stats.ConditionDamage).toBe(45);
+    expect(result.stats.HealingPower).toBe(45);
+    expect(result.stats.Expertise).toBe(45);
+    expect(result.stats.Concentration).toBe(45);
+  });
 });


### PR DESCRIPTION
## Summary

Foods with `+N to All Attributes` buff text (feast-type foods) were silently ignored by the stat computation regex, which only matched individual stat names like `+100 Power`. This meant selecting these foods showed them in the UI but contributed zero stats to the Attributes panel — Crit Chance, Health, and all other derived values remained unchanged.

Added `to All Attributes` to the food regex in all four stat computation paths:
- `computeEquipmentStats()` — renderer attribute totals
- `computeStatBreakdown()` — hover breakdown tooltip
- `computeUpgradeModifiers()` — flat-stat exclusion filter
- `computePublishStats()` — published/web build stats

Closes #23