### PR TITLE
feat: import builds from GW2Skills editor URLs

### DIFF
--- a/src/main/gw2skillsImport.js
+++ b/src/main/gw2skillsImport.js
@@ -1,0 +1,571 @@
+"use strict";
+
+const https = require("https");
+const vm = require("vm");
+const { decodeChatLinkToBuild } = require("./buildChatLink.js");
+const { getUpgradeCatalog } = require("./gw2Data");
+
+// ── HTTP helper ────────────────────────────────────────────────────────────────
+
+function httpsGet(url, redirectCount = 0) {
+  if (redirectCount > 5) return Promise.reject(new Error("Too many redirects"));
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const req = https.request(
+      {
+        hostname: parsed.hostname,
+        path: parsed.pathname + parsed.search,
+        method: "GET",
+        headers: {
+          "User-Agent": "Mozilla/5.0 (compatible; AxiForge/1.0)",
+          Referer: "https://en.gw2skills.net/",
+          Accept: "text/html,application/json,*/*",
+        },
+        timeout: 15000,
+      },
+      (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          resolve(httpsGet(new URL(res.headers.location, url).href, redirectCount + 1));
+          return;
+        }
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () => resolve(data));
+      }
+    );
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("Request timed out"));
+    });
+    req.end();
+  });
+}
+
+// ── Page parser ────────────────────────────────────────────────────────────────
+
+/**
+ * Parse the BuildEditor preload object from a gw2skills HTML page.
+ * Exported for unit testing.
+ * @param {string} html
+ * @returns {{ preload: object, dbid: string }}
+ */
+function _parsePreloadFromHtml(html) {
+  const dbidMatch = html.match(/dbid\s*:\s*(\d+)/);
+  if (!dbidMatch) throw new Error("Could not find dbid in gw2skills page");
+  const dbid = dbidMatch[1];
+
+  const marker = "new BuildEditor(";
+  const beStart = html.indexOf(marker);
+  if (beStart === -1) throw new Error("Could not find BuildEditor in gw2skills page");
+
+  // Find the balanced braces of the constructor argument
+  let depth = 0;
+  let start = -1;
+  let end = -1;
+  for (let i = beStart + marker.length; i < html.length; i++) {
+    if (html[i] === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (html[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  if (start === -1 || end === -1) throw new Error("Could not extract BuildEditor arguments");
+
+  const objLiteral = html.slice(start, end);
+
+  // Safely evaluate the JS object literal in a sandboxed vm context.
+  // Provide SI=undefined to handle `showinfo: SI || undefined`.
+  const context = vm.createContext({ SI: undefined });
+  let config;
+  try {
+    config = vm.runInContext(`(${objLiteral})`, context, { timeout: 2000 });
+  } catch (err) {
+    throw new Error(`Failed to parse BuildEditor args: ${err.message}`);
+  }
+
+  const preload = config.preload;
+  if (!preload) throw new Error("No preload found in BuildEditor args");
+  if (!preload.chatlink) throw new Error("No chatlink in gw2skills preload");
+
+  return { preload, dbid };
+}
+
+// ── DB fetcher ─────────────────────────────────────────────────────────────────
+
+const _dbCache = new Map();
+
+async function _fetchDb(dbid) {
+  if (_dbCache.has(dbid)) return _dbCache.get(dbid);
+  const json = await httpsGet(`https://en.gw2skills.net/ajax/db/en.${dbid}.json`);
+  const raw = JSON.parse(json);
+  _dbCache.set(dbid, raw);
+  return raw;
+}
+
+// ── Stat name lookup ───────────────────────────────────────────────────────────
+
+/**
+ * Build a Map from profile.id → prfltype name (e.g. "Berserker").
+ * Exported for unit testing.
+ * @param {object} db  raw DB json
+ * @returns {Map<number, string>}
+ */
+function _buildStatLookup(db) {
+  const profileTable = db.profile;
+  const prfltypeTable = db.prfltype;
+  if (!profileTable || !prfltypeTable) return new Map();
+
+  const pDesc = profileTable.desc;
+  const ptDesc = prfltypeTable.desc;
+  const pIdIdx = pDesc.indexOf("id");
+  const pPrflIdx = pDesc.indexOf("profile");
+  const ptIdIdx = ptDesc.indexOf("id");
+  const ptNameIdx = ptDesc.indexOf("name");
+
+  // Build prfltype id → name map first
+  const prfltypeNames = new Map();
+  for (const row of prfltypeTable.rows) {
+    prfltypeNames.set(row[ptIdIdx], row[ptNameIdx]);
+  }
+
+  // Then build profile.id → stat name
+  const lookup = new Map();
+  for (const row of profileTable.rows) {
+    const profileId = row[pIdIdx];
+    const prfltypeId = row[pPrflIdx];
+    const name = prfltypeNames.get(prfltypeId);
+    if (name) lookup.set(profileId, name);
+  }
+  return lookup;
+}
+
+// ── Stat name normalizer ───────────────────────────────────────────────────────
+
+// gw2skills prfltype names → axiforge STAT_COMBOS labels
+const _GW2S_STAT_MAP = {
+  "Berserker":   "Berserker's",
+  "Marauder":    "Marauder's",
+  "Assassin":    "Assassin's",
+  "Valkyrie":    "Valkyrie",
+  "Dragon":      "Dragon's",
+  "Viper":       "Viper's",
+  "Grieving":    "Grieving",
+  "Sinister":    "Sinister",
+  "Dire":        "Dire",
+  "Rabid":       "Rabid",
+  "Carrion":     "Carrion",
+  "Trailblazer": "Trailblazer's",
+  "Knight":      "Knight's",
+  "Soldier":     "Soldier's",
+  "Cleric":      "Cleric's",
+  "Minstrel":    "Minstrel's",
+  "Harrier":     "Harrier's",
+  "Ritualist":   "Ritualist's",
+  "Seraph":      "Seraph",
+  "Zealot":      "Zealot's",
+  "Celestial":   "Celestial",
+};
+
+/**
+ * Normalize a gw2skills stat name to an axiforge STAT_COMBOS label.
+ * Strips WvW/PvP qualifiers, then does a direct lookup.
+ * Exported for unit testing.
+ */
+function _normalizeStatName(name) {
+  if (!name) return "";
+  // Strip WvW/PvP qualifier, e.g. "Berserker (WvW)" → "Berserker"
+  const base = name.replace(/\s*\([^)]*\)\s*$/, "").trim();
+  return _GW2S_STAT_MAP[base] ?? base;
+}
+
+// ── Upgrade / buff lookup helpers ──────────────────────────────────────────────
+
+/**
+ * Look up an upgrade name (sigil, rune, infusion) by id.
+ * Exported for unit testing.
+ * @param {Map<number, Array>} upgradeMap  id → row
+ * @param {number} nameIdx               column index of the name field
+ * @param {number} id
+ * @returns {string}
+ */
+function _lookupUpgradeName(upgradeMap, nameIdx, id) {
+  if (!id) return "";
+  const row = upgradeMap.get(id);
+  return row ? (row[nameIdx] || "") : "";
+}
+
+/**
+ * Look up a buff name (food, utility) by id.
+ * Exported for unit testing.
+ */
+function _lookupBuffName(buffMap, nameIdx, id) {
+  if (!id) return "";
+  const row = buffMap.get(id);
+  return row ? (row[nameIdx] || "") : "";
+}
+
+// ── Slot name maps ─────────────────────────────────────────────────────────────
+
+const _ARMOR_SLOT_MAP = {
+  helm:      "head",
+  shoulders: "shoulders",
+  coat:      "chest",
+  gloves:    "hands",
+  leggings:  "legs",
+  boots:     "feet",
+  breather:  "breather",
+};
+
+const _WEAPON_SLOT_MAP = {
+  w11: "mainhand1",
+  w12: "offhand1",
+  w21: "mainhand2",
+  w22: "offhand2",
+  w31: "aquatic1",
+  w32: "aquatic2",
+};
+
+const _TRINKET_SLOT_MAP = {
+  amulet:   "amulet",
+  ring1:    "ring1",
+  ring2:    "ring2",
+  earring1: "accessory1",
+  earring2: "accessory2",
+  back:     "back",
+};
+
+// How many infusion slots each axiforge slot has (array slots); absent = string (1 slot)
+const _INF_COUNTS = {
+  mainhand1: 2, offhand1: 1, mainhand2: 2, offhand2: 1,
+  aquatic1: 2,  aquatic2: 2,
+  back: 2, ring1: 3, ring2: 3, breather: 1,
+  // head/shoulders/chest/hands/legs/feet/accessory1/accessory2 = string (1)
+};
+
+// ── Equipment mapper ───────────────────────────────────────────────────────────
+
+/**
+ * Map a gw2skills preload.equipment object to axiforge equipment fields.
+ * Exported for unit testing.
+ */
+function _mapEquipment(eq, statLookup, upgradeMap, upgradeNameIdx, buffMap, buffNameIdx) {
+  const slots = {};
+  const runes = {};
+  const sigils = {};
+  const infusions = {};
+
+  function statName(profileId) {
+    return _normalizeStatName(statLookup.get(profileId) || "");
+  }
+  function upgradeName(id) {
+    return _lookupUpgradeName(upgradeMap, upgradeNameIdx, id);
+  }
+  function infName(id) {
+    return id ? upgradeName(id) : "";
+  }
+
+  // ── Armor ────────────────────────────────────────────────────────────────────
+  for (const [gw2Slot, axSlot] of Object.entries(_ARMOR_SLOT_MAP)) {
+    const piece = eq.armor?.[gw2Slot];
+    if (!piece) continue;
+
+    const s = statName(piece.item?.[0]);
+    if (s) slots[axSlot] = s;
+
+    const runeId = piece.up?.[0]?.[0];
+    if (runeId) {
+      const rn = upgradeName(runeId);
+      if (rn) runes[axSlot] = rn;
+    }
+
+    const infId = piece.inf?.[0];
+    infusions[axSlot] = infId ? (infName(infId) || "") : "";
+  }
+
+  // ── Breather: gw2skills rarely exports UW gear; fall back to helmet values ─
+  if (!eq.armor?.breather && eq.armor?.helm) {
+    const helm = eq.armor.helm;
+    const bs = statName(helm.item?.[0]);
+    if (bs) slots.breather = bs;
+    const bRuneId = helm.up?.[0]?.[0];
+    if (bRuneId) { const bn = upgradeName(bRuneId); if (bn) runes.breather = bn; }
+    const bInfId = helm.inf?.[0];
+    infusions.breather = bInfId ? (infName(bInfId) || "") : "";
+  }
+
+  // ── Weapons ──────────────────────────────────────────────────────────────────
+  for (const [gw2Slot, axSlot] of Object.entries(_WEAPON_SLOT_MAP)) {
+    const piece = eq.weapon?.[gw2Slot];
+    if (!piece || piece.item?.[0] == null) continue;
+
+    const s = statName(piece.item[0]);
+    if (s) slots[axSlot] = s;
+
+    // Sigils: offhand slots get 1, all others get 2
+    const isOffhand = axSlot.startsWith("offhand");
+    const sigilCount = isOffhand ? 1 : 2;
+    const sigilArr = [];
+    for (let i = 0; i < sigilCount; i++) {
+      const sigilId = piece.up?.[i]?.[0];
+      sigilArr.push(sigilId ? (upgradeName(sigilId) || "") : "");
+    }
+    sigils[axSlot] = sigilArr;
+
+    // Infusions
+    const infCount = _INF_COUNTS[axSlot] ?? 1;
+    if (infCount === 1) {
+      infusions[axSlot] = [infName(piece.inf?.[0]) || ""];
+    } else {
+      const arr = [];
+      for (let i = 0; i < infCount; i++) arr.push(infName(piece.inf?.[i]) || "");
+      infusions[axSlot] = arr;
+    }
+  }
+
+  // ── Trinkets ─────────────────────────────────────────────────────────────────
+  for (const [gw2Slot, axSlot] of Object.entries(_TRINKET_SLOT_MAP)) {
+    const piece = eq.trinket?.[gw2Slot];
+    if (!piece) continue;
+
+    const s = statName(piece.item?.[0]);
+    if (s) slots[axSlot] = s;
+
+    // Infusions
+    const infCount = _INF_COUNTS[axSlot];
+    if (infCount) {
+      // Array slot
+      const arr = [];
+      for (let i = 0; i < infCount; i++) arr.push(infName(piece.inf?.[i]) || "");
+      infusions[axSlot] = arr;
+    } else if (axSlot !== "amulet") {
+      // Single-string slot (accessory1, accessory2)
+      infusions[axSlot] = infName(piece.inf?.[0]) || "";
+    }
+  }
+
+  // ── Food, utility, relic ──────────────────────────────────────────────────────
+  const food    = _lookupBuffName(buffMap, buffNameIdx, eq.buff?.food)    || "";
+  const utility = _lookupBuffName(buffMap, buffNameIdx, eq.buff?.utility) || "";
+  const relic   = upgradeName(eq.relic) || "";
+
+  // ── Enrichment (amulet upgrade slot) ─────────────────────────────────────────
+  const enrichment = upgradeName(eq.trinket?.amulet?.up?.[0]?.[0]) || "";
+
+  // ── statPackage — set if all non-empty slots share one stat ──────────────────
+  const statValues = Object.values(slots).filter(Boolean);
+  const uniqueStats = [...new Set(statValues)];
+  const statPackage = uniqueStats.length === 1 ? uniqueStats[0] : "";
+
+  return { slots, runes, sigils, infusions, food, utility, relic, enrichment, statPackage };
+}
+
+// ── Profession → primary aquatic weapon ───────────────────────────────────────
+// gw2skills doesn't encode aquatic weapon type in the URL; infer from profession.
+// Professions with multiple options (Ranger, Thief) get the most common choice.
+const _PROFESSION_PRIMARY_AQUATIC = {
+  Guardian:    "trident",
+  Warrior:     "spear",
+  Engineer:    "harpoon",
+  Ranger:      "spear",
+  Thief:       "spear",
+  Elementalist:"trident",
+  Mesmer:      "trident",
+  Necromancer: "trident",
+  Revenant:    "spear",
+};
+
+// ── Weapon key overrides ───────────────────────────────────────────────────────
+// gw2skills weapon table key field → axiforge WEAPON_TYPES id (lowercase)
+// axiforge stores weapons by id (e.g. "dagger", "greatsword"), not label.
+// Only entries where gw2skills key differs from axiforge id.
+const _GW2S_WEAPON_KEY_OVERRIDES = {
+  "landspear":  "spear",   // gw2skills land spear → axiforge "spear"
+  "harpoon_gun": "harpoon", // gw2skills harpoon_gun → axiforge "harpoon"
+};
+
+// ── Main import function ───────────────────────────────────────────────────────
+
+/**
+ * Fetch and decode a gw2skills.net editor URL into an axiforge build object,
+ * then persist it to the build store.
+ *
+ * @param {string}      url       full gw2skills.net editor URL
+ * @param {string}      name      display name for the imported build
+ * @param {string|null} folderId
+ * @param {string}      gameMode  fallback game mode ("pve"/"wvw"/"pvp")
+ * @returns {Promise<object>}     saved axiforge build
+ */
+
+async function importGw2SkillsBuild(url, name, folderId, gameMode) {
+  // Normalize to English site
+  const normalizedUrl = url.replace(/^https?:\/\/(?:www\.)?gw2skills\.net/, "https://en.gw2skills.net");
+
+  const { preload, dbid } = _parsePreloadFromHtml(await httpsGet(normalizedUrl));
+
+  const buildGameMode = preload.mode === "wvw" ? "wvw"
+    : preload.mode === "pvp" ? "pvp"
+    : gameMode || "pve";
+
+  // Decode build template (profession, specs, traits, skills)
+  const chatLink = `[&${preload.chatlink}]`;
+  const [buildTemplate, db, upgradeCatalog] = await Promise.all([
+    decodeChatLinkToBuild(chatLink, name, folderId, buildGameMode),
+    _fetchDb(dbid),
+    getUpgradeCatalog("en"),
+  ]);
+
+  // ── Build gw2skills lookup helpers ──────────────────────────────────────────
+  const statLookup = _buildStatLookup(db);
+
+  const upgradeTable   = db.upgrade;
+  const upgradeDesc    = upgradeTable?.desc ?? [];
+  const upgradeNameIdx = upgradeDesc.indexOf("name");
+  const upgradeTypeIdx = upgradeDesc.indexOf("type");
+
+  const upgradeMap = new Map();
+  for (const row of upgradeTable?.rows ?? []) upgradeMap.set(row[0], row);
+
+  // Expand short names ("Force" → "Superior Sigil of Force", "the Scholar" → "Superior Rune of the Scholar")
+  const expandedUpgradeMap = new Map();
+  for (const [id, row] of upgradeMap) {
+    const expandedRow = [...row];
+    const rawName = expandedRow[upgradeNameIdx] || "";
+    const type    = upgradeTypeIdx >= 0 ? expandedRow[upgradeTypeIdx] : -1;
+    if (rawName) {
+      if (type === 2) expandedRow[upgradeNameIdx] = `Superior Rune of ${rawName}`;
+      else if (type === 1) expandedRow[upgradeNameIdx] = `Superior Sigil of ${rawName}`;
+    }
+    expandedUpgradeMap.set(id, expandedRow);
+  }
+
+  const buffTable   = db.buff;
+  const buffDesc    = buffTable?.desc ?? [];
+  const buffMap     = new Map();
+  const buffNameIdx = buffDesc.indexOf("name");
+  for (const row of buffTable?.rows ?? []) buffMap.set(row[0], row);
+
+  // ── Build weapon type lookup: weapon table id → { name, type } ─────────────
+  // type: 0=offhand, 1=1H mainhand, 2=2H mainhand, 3=underwater
+  const weaponTypeMap = new Map(); // gw2skills weapon id → { axId, type }
+  if (db.weapon) {
+    const wDesc = db.weapon.desc;
+    const wIdIdx   = wDesc.indexOf("id");
+    const wKeyIdx  = wDesc.indexOf("key");
+    const wTypeIdx = wDesc.indexOf("type");
+    for (const row of db.weapon.rows) {
+      const gw2Key = row[wKeyIdx] || "";
+      const axId = _GW2S_WEAPON_KEY_OVERRIDES[gw2Key] || gw2Key;
+      weaponTypeMap.set(row[wIdIdx], { axId, type: row[wTypeIdx] });
+    }
+  }
+
+  const eq = preload.equipment || {};
+
+  // ── Map equipment (returns name strings for upgrades) ──────────────────────
+  const equipment = _mapEquipment(eq, statLookup, expandedUpgradeMap, upgradeNameIdx, buffMap, buffNameIdx);
+
+  // ── Resolve upgrade names → GW2 numeric item IDs ──────────────────────────
+  const runeByName     = new Map(upgradeCatalog.runes.map(r => [r.name, String(r.id)]));
+  const sigilByName    = new Map(upgradeCatalog.sigils.map(s => [s.name, String(s.id)]));
+  const infusionByName = new Map([
+    ...(upgradeCatalog.infusions  || []).map(i => [i.name, String(i.id)]),
+    ...(upgradeCatalog.enrichments || []).map(e => [e.name, String(e.id)]),
+  ]);
+  const foodByName    = new Map((upgradeCatalog.foods     || []).map(f => [f.name, String(f.id)]));
+  const utilityByName = new Map((upgradeCatalog.utilities || []).map(u => [u.name, String(u.id)]));
+
+  const toId = (nameMap, n) => nameMap.get(n) || "";
+
+  const resolvedRunes = {};
+  for (const [slot, n] of Object.entries(equipment.runes || {})) {
+    const id = toId(runeByName, n);
+    if (id) resolvedRunes[slot] = id;
+  }
+
+  const resolvedSigils = {};
+  for (const [slot, arr] of Object.entries(equipment.sigils || {})) {
+    resolvedSigils[slot] = arr.map(n => n ? toId(sigilByName, n) : "");
+  }
+
+  const resolvedInfusions = {};
+  for (const [slot, val] of Object.entries(equipment.infusions || {})) {
+    if (Array.isArray(val)) {
+      resolvedInfusions[slot] = val.map(n => n ? toId(infusionByName, n) : "");
+    } else {
+      resolvedInfusions[slot] = val ? toId(infusionByName, val) : "";
+    }
+  }
+
+  const resolvedFood       = equipment.food       ? toId(foodByName,    equipment.food)       : "";
+  const resolvedUtility    = equipment.utility    ? toId(utilityByName, equipment.utility)    : "";
+  const resolvedEnrichment = equipment.enrichment ? toId(infusionByName, equipment.enrichment) : "";
+
+  // Relic is stored as a label string matching GW2_RELICS (e.g. "Relic of the Scholar").
+  // gw2skills stores short names; prefix "Relic of " if needed.
+  let resolvedRelic = equipment.relic || "";
+  if (resolvedRelic && !resolvedRelic.startsWith("Relic of ")) {
+    resolvedRelic = `Relic of ${resolvedRelic}`;
+  }
+
+  // ── Weapon types from preload.weapon array ────────────────────────────────
+  // preload.weapon = [mainhand1_id, offhand1_id, mainhand2_id, offhand2_id, aquatic1_id?, aquatic2_id?]
+  // weapon table type: 0=offhand-only, 1=one-handed (either), 2=two-handed, 3=underwater
+  const _PRELOAD_WEAPON_SLOTS = ["mainhand1", "offhand1", "mainhand2", "offhand2", "aquatic1", "aquatic2"];
+  const weapons = { ...buildTemplate.equipment?.weapons };
+  (preload.weapon || []).forEach((weaponId, i) => {
+    if (!weaponId) return;
+    const axSlot = _PRELOAD_WEAPON_SLOTS[i];
+    if (!axSlot) return;
+    const wt = weaponTypeMap.get(weaponId);
+    if (!wt?.axId) return;
+    const isOffhand = axSlot.startsWith("offhand");
+    const isAquatic = axSlot.startsWith("aquatic");
+    if (isAquatic  && wt.type !== 3) return;                     // aquatic: underwater only
+    if (!isAquatic && wt.type === 3) return;                     // land: skip underwater
+    if (isOffhand  && wt.type === 2) return;                     // offhand: skip 2H weapons
+    if (!isOffhand && !isAquatic && wt.type === 0) return;       // mainhand: skip offhand-only
+    weapons[axSlot] = wt.axId;
+  });
+
+  // Infer aquatic weapon type from profession when gw2skills doesn't encode it in the URL.
+  if (!weapons.aquatic1 && eq.weapon?.w31?.item?.[0]) {
+    const inferred = _PROFESSION_PRIMARY_AQUATIC[buildTemplate.profession];
+    if (inferred) weapons.aquatic1 = inferred;
+  }
+
+  const finalEquipment = {
+    ...buildTemplate.equipment,
+    ...equipment,
+    runes:      resolvedRunes,
+    sigils:     resolvedSigils,
+    infusions:  resolvedInfusions,
+    enrichment: resolvedEnrichment,
+    food:       resolvedFood,
+    utility:    resolvedUtility,
+    relic:      resolvedRelic,
+    weapons,
+  };
+
+  return {
+    ...buildTemplate,
+    equipment: finalEquipment,
+    gameMode: buildGameMode,
+  };
+}
+
+module.exports = {
+  importGw2SkillsBuild,
+  // Exported for unit tests
+  _parsePreloadFromHtml,
+  _buildStatLookup,
+  _normalizeStatName,
+  _lookupUpgradeName,
+  _lookupBuffName,
+  _mapEquipment,
+};

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -348,6 +348,11 @@ app.whenReady().then(async () => {
     const build = await decodeChatLinkToBuild(link, name, folderId, gameMode);
     return store.upsertBuild(build);
   });
+  ipcMain.handle("builds:import-gw2skills", async (_e, url, name, folderId, gameMode) => {
+    const { importGw2SkillsBuild } = require("./gw2skillsImport.js");
+    const build = await importGw2SkillsBuild(url, name, folderId, gameMode);
+    return store.upsertBuild(build);
+  });
 
   ipcMain.handle("builds:publish-build", async (event, buildId) => {
     const sender = event.sender;

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -44,6 +44,7 @@ contextBridge.exposeInMainWorld("desktopApi", {
   prewarmChatLinks: (builds) => ipcRenderer.invoke("builds:prewarm-chat-links", builds),
   previewChatLink: (link) => ipcRenderer.invoke("builds:preview-chat-link", link),
   importChatLink: (link, name, folderId, gameMode) => ipcRenderer.invoke("builds:import-chat-link", link, name, folderId, gameMode),
+  importGw2Skills: (url, name, folderId, gameMode) => ipcRenderer.invoke("builds:import-gw2skills", url, name, folderId, gameMode),
   listProfessions: () => ipcRenderer.invoke("gw2:list-professions"),
   getProfessionCatalog: (professionId, gameMode) =>
     ipcRenderer.invoke("gw2:get-profession-catalog", professionId, gameMode),

--- a/src/renderer/modules/library/context-menu.js
+++ b/src/renderer/modules/library/context-menu.js
@@ -155,6 +155,7 @@ function showEmptyMenu(x, y) {
     _item(clipboardIcon, "Paste from JSON", "Ctrl+V", () => _callbacks.onPasteJson?.()),
     _submenuItem(arrowDownTrayIcon, "Import", [
       _item(linkIcon, "Build Link", null, () => _callbacks.onImportChatLink?.()),
+      _item(arrowDownTrayIcon, "GW2Skills", null, () => _callbacks.onImportGw2Skills?.()),
     ]),
     _sep(),
     _item(null, "Select All", "Ctrl+A", () => _callbacks.onSelectAll?.()),

--- a/src/renderer/modules/library/library.js
+++ b/src/renderer/modules/library/library.js
@@ -297,9 +297,11 @@ function showToast(message, type = "success") {
   void _toastEl.offsetWidth;
   _toastEl.classList.add("lib-toast--visible");
   clearTimeout(_toastTimer);
-  _toastTimer = setTimeout(() => {
-    _toastEl.classList.remove("lib-toast--visible");
-  }, 2000);
+  if (type !== "loading") {
+    _toastTimer = setTimeout(() => {
+      _toastEl.classList.remove("lib-toast--visible");
+    }, 2000);
+  }
 }
 
 async function handleCopyChatLink(buildId) {
@@ -329,6 +331,24 @@ async function handleImportChatLink() {
   } catch (err) {
     console.error("Import failed:", err);
     showToast("Import failed", "error");
+  }
+}
+
+async function handleImportGw2Skills() {
+  const folderId = state.currentFolder || null;
+  const result = await showGw2SkillsImportModal();
+  if (!result) return;
+  showToast("Importing from GW2Skills\u2026", "loading");
+  try {
+    const gameMode = state.editor?.gameMode || "pve";
+    const saved = await window.desktopApi.importGw2Skills(result.url, result.name, folderId, gameMode);
+    state.builds = await window.desktopApi.listBuilds();
+    renderLibrary();
+    window.desktopApi.prewarmChatLinks?.([saved]);
+    showToast(`"${saved.title}" imported`);
+  } catch (err) {
+    console.error("GW2Skills import failed:", err);
+    showToast("GW2Skills import failed", "error");
   }
 }
 
@@ -555,6 +575,7 @@ function _buildSharedCallbacks() {
     onCopyJson: handleCopyJson,
     onCopyChatLink: handleCopyChatLink,
     onImportChatLink: handleImportChatLink,
+    onImportGw2Skills: handleImportGw2Skills,
     onExportJson: handleCopyJson,
     onPasteJson: handlePasteJson,
     onPublish: handlePublish,
@@ -727,6 +748,97 @@ function showImportModal() {
     importBtn.addEventListener("click", () => {
       dismiss({ link: linkInput.value.trim(), name: nameInput.value.trim() || "Imported Build" });
     });
+  });
+}
+
+function showGw2SkillsImportModal() {
+  return new Promise((resolve) => {
+    const overlay = document.createElement("div");
+    overlay.className = "confirm-modal-overlay";
+    overlay.innerHTML = `
+      <div class="confirm-modal" style="width:460px;max-width:90vw;">
+        <div class="confirm-modal__header">
+          <h3 class="confirm-modal__title">Import from GW2Skills</h3>
+        </div>
+        <div class="confirm-modal__body" style="display:flex;flex-direction:column;gap:10px;">
+          <div>
+            <label style="display:block;font-size:0.8rem;color:#889;margin-bottom:4px;">GW2Skills URL</label>
+            <input
+              type="text"
+              id="gw2s-url-input"
+              placeholder="https://gw2skills.net/editor/?..."
+              style="width:100%;padding:6px 8px;background:#151530;border:1px solid #303060;border-radius:4px;color:#ccd;font-size:0.9rem;outline:none;box-sizing:border-box;"
+            />
+            <div id="gw2s-url-status" style="font-size:0.75rem;min-height:1.2em;margin-top:3px;color:#556;"></div>
+          </div>
+          <div>
+            <label style="display:block;font-size:0.8rem;color:#889;margin-bottom:4px;">Build Name</label>
+            <input
+              type="text"
+              id="gw2s-name-input"
+              placeholder="Build name"
+              style="width:100%;padding:6px 8px;background:#151530;border:1px solid #303060;border-radius:4px;color:#ccd;font-size:0.9rem;outline:none;box-sizing:border-box;"
+            />
+          </div>
+        </div>
+        <div class="confirm-modal__actions">
+          <button class="confirm-modal__btn" data-action="cancel">Cancel</button>
+          <button class="confirm-modal__btn confirm-modal__btn--primary" data-action="import" disabled>Import</button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+
+    const urlInput = overlay.querySelector("#gw2s-url-input");
+    const nameInput = overlay.querySelector("#gw2s-name-input");
+    const statusEl = overlay.querySelector("#gw2s-url-status");
+    const importBtn = overlay.querySelector('[data-action="import"]');
+    let urlValid = false;
+
+    urlInput.focus();
+
+    function setStatus(msg, color) {
+      statusEl.textContent = msg;
+      statusEl.style.color = color;
+    }
+
+    urlInput.addEventListener("input", () => {
+      const val = urlInput.value.trim();
+      importBtn.disabled = true;
+      urlValid = false;
+      if (!val) { setStatus("", "#556"); return; }
+      if (!val.includes("gw2skills.net/editor/?") || val.split("?")[1]?.length < 5) {
+        setStatus("Not a valid GW2Skills URL", "#c55");
+        return;
+      }
+      setStatus("\u2713 Valid GW2Skills URL", "#5a5");
+      urlValid = true;
+      importBtn.disabled = false;
+    });
+
+    nameInput.addEventListener("input", () => {
+      nameInput.dataset.autoFilled = "0";
+    });
+
+    function dismiss(result) {
+      document.removeEventListener("keydown", onKey);
+      overlay.remove();
+      resolve(result);
+    }
+
+    function onKey(e) {
+      if (e.key === "Escape") dismiss(null);
+      if (e.key === "Enter" && urlValid) {
+        dismiss({ url: urlInput.value.trim(), name: nameInput.value.trim() || "Imported Build" });
+      }
+    }
+
+    document.addEventListener("keydown", onKey);
+    overlay.querySelector('[data-action="cancel"]').addEventListener("click", () => dismiss(null));
+    importBtn.addEventListener("click", () => {
+      dismiss({ url: urlInput.value.trim(), name: nameInput.value.trim() || "Imported Build" });
+    });
+    overlay.addEventListener("click", (e) => { if (e.target === overlay) dismiss(null); });
   });
 }
 

--- a/src/renderer/modules/library/toolbar.js
+++ b/src/renderer/modules/library/toolbar.js
@@ -17,6 +17,7 @@ import {
   xMarkIcon,
   checkIcon,
   arrowDownTrayIcon,
+  linkIcon,
 } from "./heroicons.js";
 
 let _callbacks = {};
@@ -67,9 +68,19 @@ export function renderToolbar() {
       <div class="lib-toolbar__view-toggle" role="group" aria-label="View mode">
         ${renderViewToggle(prefs.viewMode)}
       </div>
-      <button type="button" id="lib-import-btn" class="btn lib-toolbar__new-btn">
-        ${arrowDownTrayIcon} Import
-      </button>
+      <div class="lib-import-dropdown" id="lib-import-dropdown">
+        <button type="button" id="lib-import-btn" class="btn lib-toolbar__new-btn lib-import-dropdown__trigger">
+          ${arrowDownTrayIcon} Import
+        </button>
+        <div class="lib-import-dropdown__menu" id="lib-import-menu">
+          <button type="button" class="lib-import-dropdown__item" data-import-type="chatlink">
+            ${linkIcon} Build Link
+          </button>
+          <button type="button" class="lib-import-dropdown__item" data-import-type="gw2skills">
+            ${arrowDownTrayIcon} GW2Skills
+          </button>
+        </div>
+      </div>
       <button type="button" id="lib-new-build-btn" class="btn btn-primary lib-toolbar__new-btn">
         ${plusIcon} New
       </button>
@@ -334,9 +345,28 @@ function bindToolbarEvents(container) {
     });
   });
 
-  // Import button
-  container.querySelector("#lib-import-btn")?.addEventListener("click", () => {
-    _callbacks.onImportChatLink?.();
+  // Import dropdown
+  const importDropdown = container.querySelector("#lib-import-dropdown");
+  const importMenu = container.querySelector("#lib-import-menu");
+  container.querySelector("#lib-import-btn")?.addEventListener("click", (e) => {
+    e.stopPropagation();
+    const isOpen = importDropdown.classList.toggle("lib-import-dropdown--open");
+    if (isOpen) {
+      const closeHandler = (evt) => {
+        if (!importDropdown.contains(evt.target)) {
+          importDropdown.classList.remove("lib-import-dropdown--open");
+          document.removeEventListener("click", closeHandler);
+        }
+      };
+      setTimeout(() => document.addEventListener("click", closeHandler), 0);
+    }
+  });
+  importMenu?.querySelectorAll("[data-import-type]").forEach((item) => {
+    item.addEventListener("click", () => {
+      importDropdown.classList.remove("lib-import-dropdown--open");
+      if (item.dataset.importType === "chatlink") _callbacks.onImportChatLink?.();
+      else if (item.dataset.importType === "gw2skills") _callbacks.onImportGw2Skills?.();
+    });
   });
 
   // New build button

--- a/src/renderer/styles/library.css
+++ b/src/renderer/styles/library.css
@@ -187,6 +187,50 @@
   height: 13px;
 }
 
+/* Import dropdown */
+.lib-import-dropdown {
+  position: relative;
+}
+.lib-import-dropdown__menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 140px;
+  background: #1a1a3a;
+  border: 1px solid #303060;
+  border-radius: 6px;
+  padding: 4px 0;
+  z-index: 200;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+}
+.lib-import-dropdown--open .lib-import-dropdown__menu {
+  display: block;
+}
+.lib-import-dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 14px;
+  background: none;
+  border: none;
+  color: #ccd;
+  font-size: 0.85rem;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.lib-import-dropdown__item:hover {
+  background: rgba(255,255,255,0.06);
+}
+.lib-import-dropdown__item svg {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  color: #889;
+}
+
 /* Breadcrumb */
 .lib-breadcrumb__item {
   background: none;
@@ -1466,3 +1510,22 @@
 }
 .lib-toast--success { border-color: var(--accent); color: var(--accent); }
 .lib-toast--error   { border-color: var(--danger);  color: var(--danger);  }
+.lib-toast--loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted, #889);
+}
+.lib-toast--loading::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: lib-toast-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+@keyframes lib-toast-spin {
+  to { transform: rotate(360deg); }
+}

--- a/tests/unit/gw2skillsImport.test.js
+++ b/tests/unit/gw2skillsImport.test.js
@@ -1,0 +1,324 @@
+"use strict";
+
+const {
+  _parsePreloadFromHtml,
+  _buildStatLookup,
+  _normalizeStatName,
+  _lookupUpgradeName,
+  _lookupBuffName,
+  _mapEquipment,
+} = require("../../src/main/gw2skillsImport");
+
+// ── _parsePreloadFromHtml ─────────────────────────────────────────────────────
+
+describe("_parsePreloadFromHtml", () => {
+  function makeHtml(preloadJs) {
+    return `
+      <script>
+      window.onload = function() {
+        var SI = null;
+        E = new BuildEditor({
+          version: "9.1.2",
+          balance: "2026/02/24 rev. 1",
+          dbid: 1772970067,
+          showinfo: SI || undefined,
+          preload: ${preloadJs}
+        });
+        E.init();
+      };
+      </script>
+    `;
+  }
+
+  it("extracts dbid from HTML", () => {
+    const html = makeHtml(`{ chatlink: "AAAA", mode: "pve", equipment: {} }`);
+    const result = _parsePreloadFromHtml(html);
+    expect(result.dbid).toBe("1772970067");
+  });
+
+  it("extracts chatlink from preload", () => {
+    const html = makeHtml(`{ chatlink: "DQYfHSkb", mode: "pve", equipment: {} }`);
+    const result = _parsePreloadFromHtml(html);
+    expect(result.preload.chatlink).toBe("DQYfHSkb");
+  });
+
+  it("extracts mode from preload", () => {
+    const html = makeHtml(`{ chatlink: "DQYfHSkb", mode: "wvw", equipment: {} }`);
+    const result = _parsePreloadFromHtml(html);
+    expect(result.preload.mode).toBe("wvw");
+  });
+
+  it("extracts equipment.buff.food from preload", () => {
+    const html = makeHtml(`{
+      chatlink: "DQYfHSkb",
+      mode: "pve",
+      equipment: {
+        weapon: {},
+        armor: {},
+        trinket: {},
+        buff: { food: 534, utility: 40 },
+        relic: 267
+      }
+    }`);
+    const result = _parsePreloadFromHtml(html);
+    expect(result.preload.equipment.buff.food).toBe(534);
+    expect(result.preload.equipment.buff.utility).toBe(40);
+  });
+
+  it("throws if BuildEditor is not found", () => {
+    expect(() => _parsePreloadFromHtml("<html>no editor here</html>")).toThrow();
+  });
+
+  it("throws if no preload in BuildEditor", () => {
+    const html = `<script>new BuildEditor({ version: "1", dbid: 123 });</script>`;
+    expect(() => _parsePreloadFromHtml(html)).toThrow();
+  });
+});
+
+// ── _buildStatLookup ──────────────────────────────────────────────────────────
+
+describe("_buildStatLookup", () => {
+  const mockDb = {
+    profile: {
+      desc: ["id", "img", "profile", "name"],
+      rows: [
+        [191, "G/x", 1, "Berserker's Sword"],
+        [273, "G/y", 1, "Berserker's Helm"],
+        [356, "G/z", 36, "Viper's Ring"],
+      ],
+    },
+    prfltype: {
+      desc: ["id", "key", "name"],
+      rows: [
+        [1, "berserker", "Berserker"],
+        [36, "viper", "Viper"],
+      ],
+    },
+  };
+
+  it("maps profile id → prfltype name", () => {
+    const lookup = _buildStatLookup(mockDb);
+    expect(lookup.get(191)).toBe("Berserker");
+    expect(lookup.get(273)).toBe("Berserker");
+    expect(lookup.get(356)).toBe("Viper");
+  });
+
+  it("returns undefined for unknown profile id", () => {
+    const lookup = _buildStatLookup(mockDb);
+    expect(lookup.get(999)).toBeUndefined();
+  });
+});
+
+// ── _normalizeStatName ────────────────────────────────────────────────────────
+
+describe("_normalizeStatName", () => {
+  it("maps Berserker → Berserker's", () => {
+    expect(_normalizeStatName("Berserker")).toBe("Berserker's");
+  });
+  it("maps Viper → Viper's", () => {
+    expect(_normalizeStatName("Viper")).toBe("Viper's");
+  });
+  it("maps Celestial → Celestial (no apostrophe)", () => {
+    expect(_normalizeStatName("Celestial")).toBe("Celestial");
+  });
+  it("maps Grieving → Grieving (no apostrophe)", () => {
+    expect(_normalizeStatName("Grieving")).toBe("Grieving");
+  });
+  it("strips WvW suffix from stat names", () => {
+    expect(_normalizeStatName("Berserker (WvW)")).toBe("Berserker's");
+  });
+  it("returns empty string for empty input", () => {
+    expect(_normalizeStatName("")).toBe("");
+    expect(_normalizeStatName(null)).toBe("");
+    expect(_normalizeStatName(undefined)).toBe("");
+  });
+  it("passes through unknown stat names unchanged", () => {
+    expect(_normalizeStatName("SomeNewStat")).toBe("SomeNewStat");
+  });
+});
+
+// ── _lookupUpgradeName ────────────────────────────────────────────────────────
+
+describe("_lookupUpgradeName", () => {
+  const upgradeMap = new Map([
+    [5,   [5,  "P/x", 5, 2, "Superior Sigil of Force",  "Superior Sigil of Force"]],
+    [134, [134, "P/y", 5, 1, "Superior Rune of the Scholar", "Superior Rune of the Scholar"]],
+    [344, [344, "P/z", 6, 7, "+5 Agony Infusion", "+5 Agony Infusion"]],
+  ]);
+  const nameIdx = 4;
+
+  it("returns the upgrade name by id", () => {
+    expect(_lookupUpgradeName(upgradeMap, nameIdx, 5)).toBe("Superior Sigil of Force");
+    expect(_lookupUpgradeName(upgradeMap, nameIdx, 134)).toBe("Superior Rune of the Scholar");
+    expect(_lookupUpgradeName(upgradeMap, nameIdx, 344)).toBe("+5 Agony Infusion");
+  });
+
+  it("returns empty string for id 0", () => {
+    expect(_lookupUpgradeName(upgradeMap, nameIdx, 0)).toBe("");
+  });
+
+  it("returns empty string for unknown id", () => {
+    expect(_lookupUpgradeName(upgradeMap, nameIdx, 999)).toBe("");
+  });
+});
+
+// ── _lookupBuffName ────────────────────────────────────────────────────────────
+
+describe("_lookupBuffName", () => {
+  const buffMap = new Map([
+    [534, [534, "j/x", 5, 80, 1, "Cilantro Lime Sous-Vide Steak"]],
+    [40,  [40,  "b/x", 5, 80, 2, "Toxic Focusing Crystal"]],
+  ]);
+  const nameIdx = 5;
+
+  it("returns food name", () => {
+    expect(_lookupBuffName(buffMap, nameIdx, 534)).toBe("Cilantro Lime Sous-Vide Steak");
+  });
+
+  it("returns utility name", () => {
+    expect(_lookupBuffName(buffMap, nameIdx, 40)).toBe("Toxic Focusing Crystal");
+  });
+
+  it("returns empty string for id 0", () => {
+    expect(_lookupBuffName(buffMap, nameIdx, 0)).toBe("");
+  });
+});
+
+// ── _mapEquipment ─────────────────────────────────────────────────────────────
+
+describe("_mapEquipment", () => {
+  // Minimal mock tables
+  const statLookup = new Map([
+    [191, "Berserker"],  // weapon
+    [273, "Berserker"],  // armor
+    [356, "Viper"],      // ring
+    [377, "Berserker"],  // amulet
+    [425, "Marauder"],   // back
+  ]);
+  const upgradeMap = new Map([
+    [5,   [5,   "P", 5, 2, "Superior Sigil of Force"]],
+    [29,  [29,  "P", 5, 2, "Superior Sigil of Accuracy"]],
+    [48,  [48,  "P", 5, 2, "Superior Sigil of Air"]],
+    [134, [134, "P", 5, 1, "Superior Rune of the Scholar"]],
+    [344, [344, "P", 6, 7, "+5 Agony Infusion"]],
+    [345, [345, "P", 6, 7, "Mystical +9 Agony Infusion"]],
+  ]);
+  const upgradeNameIdx = 4;
+  const buffMap = new Map([
+    [534, [534, "j", 5, 80, 1, "Cilantro Lime Sous-Vide Steak"]],
+    [40,  [40,  "b", 5, 80, 2, "Toxic Focusing Crystal"]],
+  ]);
+  const buffNameIdx = 5;
+
+  const mockEq = {
+    weapon: {
+      w11: { item: [191, 1], up: [[5, 0], [29, 0]], inf: [344, 344] },
+      w12: { item: [191, 1], up: [[29, 0]],          inf: [344, 0]  },
+    },
+    armor: {
+      helm:      { item: [273, 1], up: [[134, 0]], inf: [344] },
+      shoulders: { item: [273, 1], up: [[134, 0]], inf: [344] },
+      coat:      { item: [273, 1], up: [[134, 0]], inf: [344] },
+      gloves:    { item: [273, 1], up: [[134, 0]], inf: [344] },
+      leggings:  { item: [273, 1], up: [[134, 0]], inf: [344] },
+      boots:     { item: [273, 1], up: [[134, 0]], inf: [344] },
+    },
+    trinket: {
+      amulet:   { item: [377, 1], up: [[0, 0]],  inf: [0]         },
+      ring1:    { item: [356, 1], up: [[0, 0]],  inf: [344, 344, 344] },
+      ring2:    { item: [356, 1], up: [[0, 0]],  inf: [344, 344, 344] },
+      earring1: { item: [356, 1], up: [[0, 0]],  inf: [344, 0, 0] },
+      earring2: { item: [377, 1], up: [[0, 0]],  inf: [344, 0, 0] },
+      back:     { item: [425, 1], up: [[0, 0]],  inf: [344, 345]  },
+    },
+    buff:  { food: 534, utility: 40 },
+    relic: 0,
+  };
+
+  let result;
+  beforeEach(() => {
+    result = _mapEquipment(mockEq, statLookup, upgradeMap, upgradeNameIdx, buffMap, buffNameIdx);
+  });
+
+  it("maps armor stat slots", () => {
+    expect(result.slots.head).toBe("Berserker's");
+    expect(result.slots.shoulders).toBe("Berserker's");
+    expect(result.slots.chest).toBe("Berserker's");
+    expect(result.slots.hands).toBe("Berserker's");
+    expect(result.slots.legs).toBe("Berserker's");
+    expect(result.slots.feet).toBe("Berserker's");
+  });
+
+  it("maps weapon stat slots", () => {
+    expect(result.slots.mainhand1).toBe("Berserker's");
+    expect(result.slots.offhand1).toBe("Berserker's");
+  });
+
+  it("maps trinket stat slots", () => {
+    expect(result.slots.ring1).toBe("Viper's");
+    expect(result.slots.ring2).toBe("Viper's");
+    expect(result.slots.amulet).toBe("Berserker's");
+    expect(result.slots.accessory1).toBe("Viper's");
+    expect(result.slots.accessory2).toBe("Berserker's");
+    expect(result.slots.back).toBe("Marauder's");
+  });
+
+  it("maps armor runes", () => {
+    expect(result.runes.head).toBe("Superior Rune of the Scholar");
+    expect(result.runes.chest).toBe("Superior Rune of the Scholar");
+    expect(result.runes.feet).toBe("Superior Rune of the Scholar");
+  });
+
+  it("maps weapon sigils (mainhand = 2 slots)", () => {
+    expect(result.sigils.mainhand1).toEqual(["Superior Sigil of Force", "Superior Sigil of Accuracy"]);
+  });
+
+  it("maps weapon sigils (offhand = 1 slot)", () => {
+    expect(result.sigils.offhand1).toEqual(["Superior Sigil of Accuracy"]);
+  });
+
+  it("maps food and utility", () => {
+    expect(result.food).toBe("Cilantro Lime Sous-Vide Steak");
+    expect(result.utility).toBe("Toxic Focusing Crystal");
+  });
+
+  it("maps armor infusions (single string)", () => {
+    expect(result.infusions.head).toBe("+5 Agony Infusion");
+    expect(result.infusions.shoulders).toBe("+5 Agony Infusion");
+  });
+
+  it("maps ring infusions (array of 3)", () => {
+    expect(result.infusions.ring1).toEqual(["+5 Agony Infusion", "+5 Agony Infusion", "+5 Agony Infusion"]);
+  });
+
+  it("maps back infusions (array of 2)", () => {
+    expect(result.infusions.back).toEqual(["+5 Agony Infusion", "Mystical +9 Agony Infusion"]);
+  });
+
+  it("maps accessory infusions (single string, uses first slot)", () => {
+    expect(result.infusions.accessory1).toBe("+5 Agony Infusion");
+  });
+
+  it("maps weapon infusions (array)", () => {
+    expect(result.infusions.mainhand1).toEqual(["+5 Agony Infusion", "+5 Agony Infusion"]);
+    expect(result.infusions.offhand1).toEqual(["+5 Agony Infusion"]);
+  });
+
+  it("sets statPackage when all slots agree", () => {
+    // All armor + mainhand slots are Berserker's in this mock except rings/back
+    // So statPackage should be empty (mixed)
+    expect(result.statPackage).toBe("");
+  });
+
+  it("sets statPackage when all slots are the same stat", () => {
+    const allBerserker = {
+      weapon: { w11: { item: [191, 1], up: [[5, 0]], inf: [344, 344] } },
+      armor:  { helm: { item: [273, 1], up: [[134, 0]], inf: [344] } },
+      trinket: { amulet: { item: [377, 1], up: [[0, 0]], inf: [0] } },
+      buff: { food: 0, utility: 0 },
+      relic: 0,
+    };
+    const r = _mapEquipment(allBerserker, statLookup, upgradeMap, upgradeNameIdx, buffMap, buffNameIdx);
+    expect(r.statPackage).toBe("Berserker's");
+  });
+});


### PR DESCRIPTION
Closes #32

## Summary
- Adds **Import > GW2Skills** to the library toolbar dropdown and right-click context menu
- Fetches the GW2Skills page, extracts the embedded chat link, and decodes profession / specs / traits / skills
- Resolves full equipment from the GW2Skills DB: armor stats, weapon types, runes, sigils, infusions, trinkets, food, utility, relic
- Breather falls back to helmet stats/rune/infusion when GW2Skills doesn't export underwater gear
- Aquatic weapon type is inferred from profession when not encoded in the URL
- Shows a persistent loading toast with spinner while the import is in progress; replaces it with success/error on completion

## Test Plan
- [ ] Import a GW2Skills URL and verify profession, specs, traits, and skills load correctly
- [ ] Verify armor stats, runes, and infusions populate
- [ ] Verify weapon types and sigils populate for both weapon sets
- [ ] Verify trinket stats and infusions populate
- [ ] Verify food, utility, and relic populate
- [ ] Verify breather copies helm stats/rune/infusion
- [ ] Verify aquatic weapon type is set based on profession
- [ ] Verify loading toast appears while importing and is replaced by success toast on completion
- [ ] Verify error toast appears on invalid/unreachable URL
- [ ] 35 unit tests pass: `npm test tests/unit/gw2skillsImport.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)