### PR TITLE
fix: Stats (closes #50)

### DIFF
--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -1,6 +1,7 @@
 "use strict";
 
 // Embed static constants
+// For 4-stat combos: first 2 stats are major (0.3 multiplier), last 2 are minor (0.165 multiplier)
 const STAT_COMBOS_BY_LABEL = new Map([
   ["Berserker's", { stats: ["Power", "Precision", "Ferocity"] }],
   ["Marauder's", { stats: ["Power", "Precision", "Vitality", "Ferocity"] }],
@@ -16,6 +17,9 @@ const STAT_COMBOS_BY_LABEL = new Map([
   ["Trailblazer's", { stats: ["Toughness", "ConditionDamage", "Vitality", "Expertise"] }],
   ["Knight's", { stats: ["Toughness", "Power", "Precision"] }],
   ["Soldier's", { stats: ["Power", "Toughness", "Vitality"] }],
+  ["Sentinel's", { stats: ["Vitality", "Power", "Toughness"] }],
+  ["Wanderer's", { stats: ["Power", "Vitality", "Toughness", "Concentration"] }],
+  ["Diviner's", { stats: ["Power", "Concentration", "Ferocity", "Precision"] }],
   ["Cleric's", { stats: ["HealingPower", "Toughness", "Power"] }],
   ["Minstrel's", { stats: ["Toughness", "HealingPower", "Vitality", "Concentration"] }],
   ["Harrier's", { stats: ["Power", "HealingPower", "Concentration"] }],
@@ -25,14 +29,26 @@ const STAT_COMBOS_BY_LABEL = new Map([
   ["Celestial", { stats: ["Power", "Precision", "Toughness", "Vitality", "ConditionDamage", "Ferocity", "HealingPower", "Expertise", "Concentration"] }],
 ]);
 
+// Ascended/Legendary stat weights per slot.
+// p/s = 3-stat major/minor; p4/s4 = 4-stat major/minor; c = Celestial per-stat.
+// Derived from GW2 API attribute_adjustment × stat multipliers (0.35/0.25/0.3/0.165).
 const SLOT_WEIGHTS = {
-  head: { p: 60, s: 43 }, shoulders: { p: 45, s: 32 }, chest: { p: 134, s: 96 },
-  hands: { p: 45, s: 32 }, legs: { p: 90, s: 64 }, feet: { p: 45, s: 32 },
-  mainhand1: { p: 120, s: 85 }, offhand1: { p: 90, s: 64 },
-  mainhand2: { p: 120, s: 85 }, offhand2: { p: 90, s: 64 },
-  back: { p: 63, s: 40 }, amulet: { p: 157, s: 108 },
-  ring1: { p: 126, s: 85 }, ring2: { p: 126, s: 85 },
-  accessory1: { p: 110, s: 74 }, accessory2: { p: 110, s: 74 },
+  head:       { p: 63,  s: 45,  p4: 54,  s4: 30, c: 30 },
+  shoulders:  { p: 47,  s: 34,  p4: 40,  s4: 22, c: 22 },
+  chest:      { p: 141, s: 101, p4: 121, s4: 66, c: 66 },
+  hands:      { p: 47,  s: 34,  p4: 40,  s4: 22, c: 22 },
+  legs:       { p: 94,  s: 67,  p4: 81,  s4: 44, c: 44 },
+  feet:       { p: 47,  s: 34,  p4: 40,  s4: 22, c: 22 },
+  mainhand1:  { p: 125, s: 90,  p4: 107, s4: 59, c: 59 },
+  offhand1:   { p: 125, s: 90,  p4: 107, s4: 59, c: 59 },
+  mainhand2:  { p: 125, s: 90,  p4: 107, s4: 59, c: 59 },
+  offhand2:   { p: 125, s: 90,  p4: 107, s4: 59, c: 59 },
+  back:       { p: 63,  s: 40,  p4: 51,  s4: 27, c: 28 },
+  amulet:     { p: 157, s: 108, p4: 132, s4: 71, c: 72 },
+  ring1:      { p: 126, s: 85,  p4: 105, s4: 56, c: 57 },
+  ring2:      { p: 126, s: 85,  p4: 105, s4: 56, c: 57 },
+  accessory1: { p: 110, s: 74,  p4: 92,  s4: 49, c: 50 },
+  accessory2: { p: 110, s: 74,  p4: 92,  s4: 49, c: 50 },
 };
 
 const PROFESSION_BASE_HP = {
@@ -61,13 +77,13 @@ function computePublishStats(equipment, upgradeCatalog, profession) {
       totals[combo.stats[0]] = (totals[combo.stats[0]] || 0) + w.p;
       for (let i = 1; i < n; i++) totals[combo.stats[i]] = (totals[combo.stats[i]] || 0) + w.s;
     } else if (n === 4) {
-      totals[combo.stats[0]] = (totals[combo.stats[0]] || 0) + Math.round(w.p * 0.895);
-      totals[combo.stats[1]] = (totals[combo.stats[1]] || 0) + Math.round(w.s * 0.889);
-      totals[combo.stats[2]] = (totals[combo.stats[2]] || 0) + Math.round(w.s * 0.889);
-      totals[combo.stats[3]] = (totals[combo.stats[3]] || 0) + Math.round(w.p * 0.452);
+      // 2-2 pattern: first 2 stats are major, last 2 are minor
+      totals[combo.stats[0]] = (totals[combo.stats[0]] || 0) + w.p4;
+      totals[combo.stats[1]] = (totals[combo.stats[1]] || 0) + w.p4;
+      totals[combo.stats[2]] = (totals[combo.stats[2]] || 0) + w.s4;
+      totals[combo.stats[3]] = (totals[combo.stats[3]] || 0) + w.s4;
     } else {
-      const each = Math.round((w.p + 2 * w.s) / n);
-      for (const stat of combo.stats) totals[stat] = (totals[stat] || 0) + each;
+      for (const stat of combo.stats) totals[stat] = (totals[stat] || 0) + w.c;
     }
   }
 

--- a/src/renderer/modules/constants.js
+++ b/src/renderer/modules/constants.js
@@ -12,6 +12,7 @@ export const CONDUIT_F2_BY_SWAP = new Map([
   [76610, 78661],                 // Legendary Entity Stance   → Release Potential: Dervish
 ]);
 
+// For 4-stat combos: first 2 stats are major (0.3 multiplier), last 2 are minor (0.165 multiplier)
 export const STAT_COMBOS = [
   { label: "Berserker's",   stats: ["Power", "Precision", "Ferocity"] },
   { label: "Marauder's",    stats: ["Power", "Precision", "Vitality", "Ferocity"] },
@@ -28,8 +29,8 @@ export const STAT_COMBOS = [
   { label: "Knight's",      stats: ["Toughness", "Power", "Precision"] },
   { label: "Soldier's",     stats: ["Power", "Toughness", "Vitality"] },
   { label: "Sentinel's",    stats: ["Vitality", "Power", "Toughness"] },
-  { label: "Wanderer's",    stats: ["Toughness", "Power", "Vitality", "Concentration"] },
-  { label: "Diviner's",     stats: ["Power", "Ferocity", "Concentration", "Precision"] },
+  { label: "Wanderer's",    stats: ["Power", "Vitality", "Toughness", "Concentration"] },
+  { label: "Diviner's",     stats: ["Power", "Concentration", "Ferocity", "Precision"] },
   { label: "Cleric's",      stats: ["HealingPower", "Toughness", "Power"] },
   { label: "Minstrel's",    stats: ["Toughness", "HealingPower", "Vitality", "Concentration"] },
   { label: "Harrier's",     stats: ["Power", "HealingPower", "Concentration"] },
@@ -41,26 +42,29 @@ export const STAT_COMBOS = [
 
 export const STAT_COMBOS_BY_LABEL = new Map(STAT_COMBOS.map((c) => [c.label, c]));
 
+// Ascended/Legendary stat weights per slot.
+// p/s = 3-stat major/minor; p4/s4 = 4-stat major/minor; c = Celestial per-stat.
+// Derived from GW2 API attribute_adjustment × stat multipliers (0.35/0.25/0.3/0.165).
 export const SLOT_WEIGHTS = {
-  head:       { p: 60,  s: 43 },
-  shoulders:  { p: 45,  s: 32 },
-  chest:      { p: 134, s: 96 },
-  hands:      { p: 45,  s: 32 },
-  legs:       { p: 90,  s: 64 },
-  feet:       { p: 45,  s: 32 },
-  mainhand1:  { p: 120, s: 85 },
-  offhand1:   { p: 90,  s: 64 },
-  mainhand2:  { p: 120, s: 85 },
-  offhand2:   { p: 90,  s: 64 },
-  back:       { p: 63,  s: 40 },
-  amulet:     { p: 157, s: 108 },
-  ring1:      { p: 126, s: 85 },
-  ring2:      { p: 126, s: 85 },
-  accessory1: { p: 110, s: 74 },
-  accessory2: { p: 110, s: 74 },
-  breather:   { p: 60,  s: 43  },
-  aquatic1:   { p: 215, s: 154 },
-  aquatic2:   { p: 215, s: 154 },
+  head:       { p: 63,  s: 45,  p4: 54,  s4: 30, c: 30 },
+  shoulders:  { p: 47,  s: 34,  p4: 40,  s4: 22, c: 22 },
+  chest:      { p: 141, s: 101, p4: 121, s4: 66, c: 66 },
+  hands:      { p: 47,  s: 34,  p4: 40,  s4: 22, c: 22 },
+  legs:       { p: 94,  s: 67,  p4: 81,  s4: 44, c: 44 },
+  feet:       { p: 47,  s: 34,  p4: 40,  s4: 22, c: 22 },
+  mainhand1:  { p: 125, s: 90,  p4: 107, s4: 59, c: 59 },
+  offhand1:   { p: 125, s: 90,  p4: 107, s4: 59, c: 59 },
+  mainhand2:  { p: 125, s: 90,  p4: 107, s4: 59, c: 59 },
+  offhand2:   { p: 125, s: 90,  p4: 107, s4: 59, c: 59 },
+  back:       { p: 63,  s: 40,  p4: 51,  s4: 27, c: 28 },
+  amulet:     { p: 157, s: 108, p4: 132, s4: 71, c: 72 },
+  ring1:      { p: 126, s: 85,  p4: 105, s4: 56, c: 57 },
+  ring2:      { p: 126, s: 85,  p4: 105, s4: 56, c: 57 },
+  accessory1: { p: 110, s: 74,  p4: 92,  s4: 49, c: 50 },
+  accessory2: { p: 110, s: 74,  p4: 92,  s4: 49, c: 50 },
+  breather:   { p: 63,  s: 45,  p4: 54,  s4: 30, c: 30 },
+  aquatic1:   { p: 251, s: 179, p4: 215, s4: 118, c: 118 },
+  aquatic2:   { p: 251, s: 179, p4: 215, s4: 118, c: 118 },
 };
 
 export const EQUIP_ARMOR_SLOTS = [

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -15,13 +15,13 @@ export function computeSlotStats(comboLabel, slotKey) {
     result.push({ stat: combo.stats[0], value: w.p });
     for (let i = 1; i < n; i++) result.push({ stat: combo.stats[i], value: w.s });
   } else if (n === 4) {
-    result.push({ stat: combo.stats[0], value: Math.round(w.p * 0.895) });
-    result.push({ stat: combo.stats[1], value: Math.round(w.s * 0.889) });
-    result.push({ stat: combo.stats[2], value: Math.round(w.s * 0.889) });
-    result.push({ stat: combo.stats[3], value: Math.round(w.p * 0.452) });
+    // 2-2 pattern: first 2 stats are major, last 2 are minor
+    result.push({ stat: combo.stats[0], value: w.p4 });
+    result.push({ stat: combo.stats[1], value: w.p4 });
+    result.push({ stat: combo.stats[2], value: w.s4 });
+    result.push({ stat: combo.stats[3], value: w.s4 });
   } else {
-    const each = Math.round((w.p + 2 * w.s) / n);
-    for (const stat of combo.stats) result.push({ stat, value: each });
+    for (const stat of combo.stats) result.push({ stat, value: w.c });
   }
   return result;
 }
@@ -46,14 +46,14 @@ export function computeEquipmentStats(assumedBoons = null) {
         totals[combo.stats[i]] = (totals[combo.stats[i]] || 0) + w.s;
       }
     } else if (n === 4) {
-      totals[combo.stats[0]] = (totals[combo.stats[0]] || 0) + Math.round(w.p * 0.895);
-      totals[combo.stats[1]] = (totals[combo.stats[1]] || 0) + Math.round(w.s * 0.889);
-      totals[combo.stats[2]] = (totals[combo.stats[2]] || 0) + Math.round(w.s * 0.889);
-      totals[combo.stats[3]] = (totals[combo.stats[3]] || 0) + Math.round(w.p * 0.452);
+      // 2-2 pattern: first 2 stats are major, last 2 are minor
+      totals[combo.stats[0]] = (totals[combo.stats[0]] || 0) + w.p4;
+      totals[combo.stats[1]] = (totals[combo.stats[1]] || 0) + w.p4;
+      totals[combo.stats[2]] = (totals[combo.stats[2]] || 0) + w.s4;
+      totals[combo.stats[3]] = (totals[combo.stats[3]] || 0) + w.s4;
     } else {
-      const each = Math.round((w.p + 2 * w.s) / n);
       for (const stat of combo.stats) {
-        totals[stat] = (totals[stat] || 0) + each;
+        totals[stat] = (totals[stat] || 0) + w.c;
       }
     }
   }
@@ -233,11 +233,10 @@ export function computeBuildConcentration(build, upgradeCatalog) {
       }
     } else if (n === 4) {
       const idx = combo.stats.indexOf("Concentration");
-      if (idx === 0) concentration += Math.round(w.p * 0.895);
-      else if (idx === 1 || idx === 2) concentration += Math.round(w.s * 0.889);
-      else if (idx === 3) concentration += Math.round(w.p * 0.452);
+      if (idx === 0 || idx === 1) concentration += w.p4;
+      else if (idx === 2 || idx === 3) concentration += w.s4;
     } else {
-      if (combo.stats.includes("Concentration")) concentration += Math.round((w.p + 2 * w.s) / n);
+      if (combo.stats.includes("Concentration")) concentration += w.c;
     }
   }
 
@@ -358,11 +357,10 @@ export function computeStatBreakdown(statKey, assumedBoons = null) {
       else if (combo.stats.includes(statKey)) val = w.s;
     } else if (n === 4) {
       const idx = combo.stats.indexOf(statKey);
-      if (idx === 0) val = Math.round(w.p * 0.895);
-      else if (idx === 1 || idx === 2) val = Math.round(w.s * 0.889);
-      else if (idx === 3) val = Math.round(w.p * 0.452);
+      if (idx === 0 || idx === 1) val = w.p4;
+      else if (idx === 2 || idx === 3) val = w.s4;
     } else {
-      if (combo.stats.includes(statKey)) val = Math.round((w.p + 2 * w.s) / n);
+      if (combo.stats.includes(statKey)) val = w.c;
     }
     if (val) entries.push({ source: `${SLOT_LABELS[slotKey] || slotKey} (${comboLabel})`, value: val });
   }

--- a/tests/unit/renderer/comp-boon-coverage.test.js
+++ b/tests/unit/renderer/comp-boon-coverage.test.js
@@ -291,7 +291,7 @@ describe("computeCompBoonCoverage — sources and effectiveDuration on line prov
   test("effectiveDuration is multiplied by concentrationBonus from gear", async () => {
     const build = makeBuild("b1", "Guardian");
     build.skills.healId = 100;
-    // Give build Harrier's chest — gives 96 Concentration
+    // Give build Harrier's chest — gives 101 Concentration (ascended)
     build.equipment.slots = { chest: "Harrier's" };
 
     const catalog = makeCatalog(new Map([[100, makeMightSkill()]]));
@@ -304,8 +304,8 @@ describe("computeCompBoonCoverage — sources and effectiveDuration on line prov
     const { lines } = await computeCompBoonCoverage(comp, [build], catalogCache, getCatalog, upgradeCatalog);
 
     const provider = lines[0].boons.get("Might").providers[0];
-    // 96 Concentration → 96/1500 = 0.064 → 10 * 1.064 = 10.6
-    expect(provider.sources[0].effectiveDuration).toBeCloseTo(10.6, 1);
+    // 101 Concentration → 101/1500 = 0.0673 → 10 * 1.0673 = 10.7
+    expect(provider.sources[0].effectiveDuration).toBeCloseTo(10.7, 1);
   });
 
   test("sources with duration 0 are filtered out", async () => {

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -35,16 +35,16 @@ describe("computeSlotStats — 3-stat combos", () => {
   test("Berserker's chest returns Power primary, Precision+Ferocity secondary", () => {
     const result = computeSlotStats("Berserker's", "chest");
     expect(result).toHaveLength(3);
-    expect(result[0]).toEqual({ stat: "Power",     value: 134 });
-    expect(result[1]).toEqual({ stat: "Precision",  value: 96  });
-    expect(result[2]).toEqual({ stat: "Ferocity",   value: 96  });
+    expect(result[0]).toEqual({ stat: "Power",     value: 141 });
+    expect(result[1]).toEqual({ stat: "Precision",  value: 101 });
+    expect(result[2]).toEqual({ stat: "Ferocity",   value: 101 });
   });
 
   test("Berserker's head returns correct head weights", () => {
     const result = computeSlotStats("Berserker's", "head");
-    expect(result[0]).toEqual({ stat: "Power",    value: 60 });
-    expect(result[1]).toEqual({ stat: "Precision", value: 43 });
-    expect(result[2]).toEqual({ stat: "Ferocity",  value: 43 });
+    expect(result[0]).toEqual({ stat: "Power",    value: 63 });
+    expect(result[1]).toEqual({ stat: "Precision", value: 45 });
+    expect(result[2]).toEqual({ stat: "Ferocity",  value: 45 });
   });
 
   test("returns empty for unknown combo", () => {
@@ -59,22 +59,22 @@ describe("computeSlotStats — 3-stat combos", () => {
     const result = computeSlotStats("Sinister", "mainhand1");
     expect(result).toHaveLength(3);
     expect(result[0].stat).toBe("ConditionDamage");
-    expect(result[0].value).toBe(120); // p weight for mainhand1
+    expect(result[0].value).toBe(125); // p weight for mainhand1 (ascended)
     expect(result[1].stat).toBe("Power");
-    expect(result[1].value).toBe(85);  // s weight for mainhand1
+    expect(result[1].value).toBe(90);  // s weight for mainhand1 (ascended)
   });
 });
 
 describe("computeSlotStats — 4-stat combos", () => {
-  test("Viper's chest applies 4-stat scaling formula", () => {
-    // Viper's: Power, ConditionDamage, Precision, Expertise
-    // chest weights: p=134, s=96
+  test("Viper's chest applies 4-stat 2-2 pattern", () => {
+    // Viper's: Power, ConditionDamage (major), Precision, Expertise (minor)
+    // chest weights: p4=121, s4=66
     const result = computeSlotStats("Viper's", "chest");
     expect(result).toHaveLength(4);
-    expect(result[0]).toEqual({ stat: "Power",          value: Math.round(134 * 0.895) });
-    expect(result[1]).toEqual({ stat: "ConditionDamage", value: Math.round(96  * 0.889) });
-    expect(result[2]).toEqual({ stat: "Precision",       value: Math.round(96  * 0.889) });
-    expect(result[3]).toEqual({ stat: "Expertise",       value: Math.round(134 * 0.452) });
+    expect(result[0]).toEqual({ stat: "Power",          value: 121 });
+    expect(result[1]).toEqual({ stat: "ConditionDamage", value: 121 });
+    expect(result[2]).toEqual({ stat: "Precision",       value: 66 });
+    expect(result[3]).toEqual({ stat: "Expertise",       value: 66 });
   });
 
   test("Marauder's ring1 applies 4-stat formula", () => {
@@ -92,39 +92,41 @@ describe("computeSlotStats — missing stat combos (issue #29)", () => {
   test("Sentinel's is defined and uses Vitality as primary 3-stat", () => {
     const result = computeSlotStats("Sentinel's", "chest");
     expect(result).toHaveLength(3);
-    expect(result[0]).toEqual({ stat: "Vitality", value: 134 });
-    expect(result[1]).toEqual({ stat: "Power",    value: 96  });
-    expect(result[2]).toEqual({ stat: "Toughness", value: 96 });
+    expect(result[0]).toEqual({ stat: "Vitality", value: 141 });
+    expect(result[1]).toEqual({ stat: "Power",    value: 101 });
+    expect(result[2]).toEqual({ stat: "Toughness", value: 101 });
   });
 
-  test("Wanderer's is defined and uses Toughness primary 4-stat", () => {
+  test("Wanderer's is defined with Power+Vitality major, Toughness+Concentration minor", () => {
     const result = computeSlotStats("Wanderer's", "chest");
     expect(result).toHaveLength(4);
-    expect(result[0].stat).toBe("Toughness");
-    expect(result[1].stat).toBe("Power");
-    expect(result[2].stat).toBe("Vitality");
+    expect(result[0].stat).toBe("Power");
+    expect(result[1].stat).toBe("Vitality");
+    expect(result[2].stat).toBe("Toughness");
     expect(result[3].stat).toBe("Concentration");
-    for (const r of result) expect(r.value).toBeGreaterThan(0);
+    // Major stats get p4, minor stats get s4
+    expect(result[0].value).toBe(121); // p4 for chest
+    expect(result[2].value).toBe(66);  // s4 for chest
   });
 
-  test("Diviner's is defined and uses Power primary 4-stat", () => {
+  test("Diviner's is defined with Power+Concentration major, Ferocity+Precision minor", () => {
     const result = computeSlotStats("Diviner's", "chest");
     expect(result).toHaveLength(4);
     expect(result[0].stat).toBe("Power");
-    expect(result[1].stat).toBe("Ferocity");
-    expect(result[2].stat).toBe("Concentration");
+    expect(result[1].stat).toBe("Concentration");
+    expect(result[2].stat).toBe("Ferocity");
     expect(result[3].stat).toBe("Precision");
-    for (const r of result) expect(r.value).toBeGreaterThan(0);
+    expect(result[0].value).toBe(121); // p4 for chest
+    expect(result[2].value).toBe(66);  // s4 for chest
   });
 });
 
 describe("computeSlotStats — 9-stat combo (Celestial)", () => {
-  test("Celestial chest distributes evenly across 9 stats", () => {
-    // chest: p=134, s=96; each = Math.round((134 + 2*96) / 9)
-    const each = Math.round((134 + 2 * 96) / 9);
+  test("Celestial chest uses per-stat Celestial weight", () => {
+    // chest: c=66 (Celestial per-stat weight)
     const result = computeSlotStats("Celestial", "chest");
     expect(result).toHaveLength(9);
-    for (const r of result) expect(r.value).toBe(each);
+    for (const r of result) expect(r.value).toBe(66);
     const stats = result.map((r) => r.stat);
     expect(stats).toContain("Power");
     expect(stats).toContain("HealingPower");
@@ -156,9 +158,9 @@ describe("computeEquipmentStats — single slot contributions", () => {
   test("Berserker's chest adds Power/Precision/Ferocity correctly", () => {
     state.editor = makeEditor({ chest: "Berserker's" });
     const result = computeEquipmentStats();
-    expect(result.Power).toBe(1000 + 134);
-    expect(result.Precision).toBe(1000 + 96);
-    expect(result.Ferocity).toBe(96);
+    expect(result.Power).toBe(1000 + 141);
+    expect(result.Precision).toBe(1000 + 101);
+    expect(result.Ferocity).toBe(101);
   });
 
   test("Cleric's amulet adds HealingPower primary, Toughness+Power secondary", () => {
@@ -186,25 +188,25 @@ describe("computeEquipmentStats — single slot contributions", () => {
 
 describe("computeEquipmentStats — multiple slot accumulation", () => {
   test("full Berserker's armor set accumulates all 6 armor slots", () => {
-    // armor: head(p60,s43), shoulders(p45,s32), chest(p134,s96), hands(p45,s32), legs(p90,s64), feet(p45,s32)
+    // armor (ascended): head(p63,s45), shoulders(p47,s34), chest(p141,s101), hands(p47,s34), legs(p94,s67), feet(p47,s34)
     const armorSlots = { head: "Berserker's", shoulders: "Berserker's", chest: "Berserker's",
                          hands: "Berserker's", legs: "Berserker's",  feet: "Berserker's" };
     state.editor = makeEditor(armorSlots);
     const result = computeEquipmentStats();
-    const totalPrimary   = 60 + 45 + 134 + 45 + 90 + 45;  // = 419
-    const totalSecondary = 43 + 32 +  96 + 32 + 64 + 32;  // = 299
+    const totalPrimary   = 63 + 47 + 141 + 47 + 94 + 47;  // = 439
+    const totalSecondary = 45 + 34 + 101 + 34 + 67 + 34;   // = 315
     expect(result.Power).toBe(1000 + totalPrimary);
     expect(result.Precision).toBe(1000 + totalSecondary);
     expect(result.Ferocity).toBe(totalSecondary);
   });
 
   test("dual weapon set adds mainhand1 + mainhand2", () => {
-    // mainhand1 and mainhand2 each: p=120, s=85
+    // mainhand1 and mainhand2 each: p=125, s=90 (ascended)
     state.editor = makeEditor({ mainhand1: "Berserker's", mainhand2: "Berserker's" });
     const result = computeEquipmentStats();
-    expect(result.Power).toBe(1000 + 120 + 120);
-    expect(result.Precision).toBe(1000 + 85 + 85);
-    expect(result.Ferocity).toBe(85 + 85);
+    expect(result.Power).toBe(1000 + 125 + 125);
+    expect(result.Precision).toBe(1000 + 90 + 90);
+    expect(result.Ferocity).toBe(90 + 90);
   });
 });
 
@@ -248,11 +250,11 @@ describe("computeEquipmentStats — food contributions", () => {
   });
 
   test("food stacks on top of equipment stats", () => {
-    // Berserker's chest + food with +100 Power
+    // Berserker's chest (ascended) + food with +100 Power
     state.editor = makeEditor({ chest: "Berserker's" }, "91734");
     const result = computeEquipmentStats();
-    expect(result.Power).toBe(1000 + 134 + 100);
-    expect(result.Ferocity).toBe(96 + 70);
+    expect(result.Power).toBe(1000 + 141 + 100);
+    expect(result.Ferocity).toBe(101 + 70);
   });
 
   test("food with 'to All Attributes' adds to every stat", () => {
@@ -276,15 +278,14 @@ describe("computeEquipmentStats — food contributions", () => {
 });
 
 describe("computeEquipmentStats — 4-stat combo accumulation", () => {
-  test("Viper's chest applies 4-stat scaling and accumulates correctly", () => {
+  test("Viper's chest applies 4-stat 2-2 pattern and accumulates correctly", () => {
     state.editor = makeEditor({ chest: "Viper's" });
     const result = computeEquipmentStats();
-    // Viper's: Power(0), ConditionDamage(1), Precision(2), Expertise(3)
-    // chest: p=134, s=96
-    expect(result.Power).toBe(1000 + Math.round(134 * 0.895));
-    expect(result.ConditionDamage).toBe(Math.round(96 * 0.889));
-    expect(result.Precision).toBe(1000 + Math.round(96 * 0.889));
-    expect(result.Expertise).toBe(Math.round(134 * 0.452));
+    // Viper's: Power+CondDmg (major p4=121), Precision+Expertise (minor s4=66)
+    expect(result.Power).toBe(1000 + 121);
+    expect(result.ConditionDamage).toBe(121);
+    expect(result.Precision).toBe(1000 + 66);
+    expect(result.Expertise).toBe(66);
   });
 });
 
@@ -327,11 +328,11 @@ describe("computeEquipmentStats — utility contributions", () => {
   });
 
   test("utility stacks on top of equipment stats", () => {
-    // Berserker's chest (Power 134, Precision 96, Ferocity 96) + Superior Sharpening Stone
+    // Berserker's chest ascended (Power 141, Precision 101, Ferocity 101) + Superior Sharpening Stone
     state.editor = makeEditor({ chest: "Berserker's" }, "", "9443");
     const result = computeEquipmentStats();
-    // Power += round((1000+96) * 0.03) + round(96 * 0.06) = 33 + 6 = 39
-    expect(result.Power).toBe(1000 + 134 + 33 + 6);
+    // Power += round((1000+101) * 0.03) + round(101 * 0.06) = 33 + 6 = 39
+    expect(result.Power).toBe(1000 + 141 + 33 + 6);
   });
 
   test("unknown utility ID adds nothing", () => {
@@ -438,10 +439,10 @@ describe("computeBuildConcentration", () => {
 
   test("Harrier's chest adds Concentration from slot stats", () => {
     // Harrier's: Power (primary), Healing Power, Concentration (secondary)
-    // chest secondary weight = 96
+    // chest secondary weight = 101 (ascended)
     const build = { equipment: { slots: { chest: "Harrier's" } } };
     const result = computeBuildConcentration(build, makeUpgradeCatalog());
-    expect(result).toBe(96); // chest secondary weight
+    expect(result).toBe(101); // chest secondary weight (ascended)
   });
 
   test("adds flat Concentration from food buff string", () => {
@@ -456,15 +457,15 @@ describe("computeBuildConcentration", () => {
   test("returns slot Concentration only when upgradeCatalog is null (rune/food/util skipped)", () => {
     const build = { equipment: { slots: { chest: "Harrier's" }, food: "1001" } };
     // Without catalog, food lookup is skipped
-    expect(computeBuildConcentration(build, null)).toBe(96);
+    expect(computeBuildConcentration(build, null)).toBe(101);
   });
 
   test("accumulates Concentration from multiple sources", () => {
     const foodDef = { buff: "+40 Concentration" };
     const catalog = makeUpgradeCatalog({ foodById: new Map([[1001, foodDef]]) });
     const build = { equipment: { slots: { chest: "Harrier's" }, food: "1001" } };
-    // 96 from slot + 40 from food = 136
-    expect(computeBuildConcentration(build, catalog)).toBe(136);
+    // 101 from slot + 40 from food = 141
+    expect(computeBuildConcentration(build, catalog)).toBe(141);
   });
 
   test("excludes aquatic slots (always land mode)", () => {

--- a/tests/unit/statsCompute.test.js
+++ b/tests/unit/statsCompute.test.js
@@ -26,20 +26,20 @@ describe("computePublishStats", () => {
 
   test("full Berserker's gear: Power total", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Necromancer");
-    // Base 1000 + all slot primary contributions
-    expect(result.stats.Power).toBe(2531);
+    // Base 1000 + all slot primary contributions (ascended weights)
+    expect(result.stats.Power).toBe(2631);
   });
 
   test("full Berserker's gear: Precision total", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Necromancer");
-    // Base 1000 + all slot secondary contributions
-    expect(result.stats.Precision).toBe(2063);
+    // Base 1000 + all slot secondary contributions (ascended weights)
+    expect(result.stats.Precision).toBe(2141);
   });
 
   test("full Berserker's gear: Ferocity total", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Necromancer");
-    // Base 0 + all slot secondary contributions (same as Precision secondary)
-    expect(result.stats.Ferocity).toBe(1063);
+    // Base 0 + all slot secondary contributions (ascended weights)
+    expect(result.stats.Ferocity).toBe(1141);
   });
 
   test("full Berserker's gear: Vitality stays at base (no Vitality in Berserker's)", () => {
@@ -67,14 +67,14 @@ describe("computePublishStats", () => {
 
   test("derived stat: CritChance computed from Precision", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Necromancer");
-    // Precision = 2063 => (2063 - 1000) / 21 + 5 = 50.619... + 5 = 55.6%
-    expect(result.stats.CritChance).toBe("55.6%");
+    // Precision = 2141 => (2141 - 1000) / 21 + 5 = 54.333... + 5 = 59.3%
+    expect(result.stats.CritChance).toBe("59.3%");
   });
 
   test("derived stat: CritDamage computed from Ferocity", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Necromancer");
-    // Ferocity = 1063 => 150 + 1063/15 = 150 + 70.866... = 220.9%
-    expect(result.stats.CritDamage).toBe("220.9%");
+    // Ferocity = 1141 => 150 + 1141/15 = 150 + 76.066... = 226.1%
+    expect(result.stats.CritDamage).toBe("226.1%");
   });
 
   test("derived stat: BoonDuration is 0.0% for Berserker's (no Concentration)", () => {
@@ -120,16 +120,55 @@ describe("computePublishStats", () => {
       utilityById: new Map(),
     };
     const result = computePublishStats(equipment, upgradeCatalog, "Necromancer");
-    // Head slot Berserker's: Power +60, Precision +43, Ferocity +43 (secondary)
+    // Head slot Berserker's (ascended): Power +63, Precision +45, Ferocity +45
     // 6 runes: bonuses[0]=+25P, bonuses[1]=+35F, bonuses[2]=+50P, bonuses[3]=+65F, bonuses[4]=+100P, bonuses[5]=no stat match
-    expect(result.stats.Power).toBe(1000 + 60 + 25 + 50 + 100);
-    // Ferocity: 43 from head Berserker's secondary + 35 + 65 from rune bonuses
-    expect(result.stats.Ferocity).toBe(43 + 35 + 65);
+    expect(result.stats.Power).toBe(1000 + 63 + 25 + 50 + 100);
+    // Ferocity: 45 from head Berserker's secondary + 35 + 65 from rune bonuses
+    expect(result.stats.Ferocity).toBe(45 + 35 + 65);
   });
 
   test("modifiers array is returned (may be empty)", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Warrior");
     expect(Array.isArray(result.modifiers)).toBe(true);
+  });
+
+  test("single head slot Viper's: 4-stat uses 2-2 pattern (two major, two minor)", () => {
+    const equipment = { slots: { head: "Viper's" }, runes: {}, infusions: {} };
+    const result = computePublishStats(equipment, null, "Necromancer");
+    // Viper's: Power + CondDmg are both major (p4=54), Precision + Expertise are both minor (s4=30)
+    expect(result.stats.Power).toBe(1000 + 54);
+    expect(result.stats.ConditionDamage).toBe(54);  // major stat, NOT minor
+    expect(result.stats.Precision).toBe(1000 + 30);
+    expect(result.stats.Expertise).toBe(30);         // minor stat
+  });
+
+  test("full Viper's gear: 4-stat totals", () => {
+    const slots = {};
+    for (const slot of ALL_STAT_SLOTS) slots[slot] = "Viper's";
+    const equipment = { slots, runes: {}, infusions: {} };
+    const result = computePublishStats(equipment, null, "Necromancer");
+    // Major stats (Power, CondDmg) sum of p4 across all 16 slots = 1381
+    expect(result.stats.Power).toBe(1000 + 1381);
+    expect(result.stats.ConditionDamage).toBe(1381);
+    // Minor stats (Precision, Expertise) sum of s4 across all 16 slots = 750
+    expect(result.stats.Precision).toBe(1000 + 750);
+    expect(result.stats.Expertise).toBe(750);
+  });
+
+  test("full Celestial gear: all 9 stats equal", () => {
+    const slots = {};
+    for (const slot of ALL_STAT_SLOTS) slots[slot] = "Celestial";
+    const equipment = { slots, runes: {}, infusions: {} };
+    const result = computePublishStats(equipment, null, "Necromancer");
+    // Celestial: all stats get c weight, sum across 16 slots = 756
+    expect(result.stats.Ferocity).toBe(756);
+    expect(result.stats.ConditionDamage).toBe(756);
+    expect(result.stats.HealingPower).toBe(756);
+    expect(result.stats.Expertise).toBe(756);
+    expect(result.stats.Concentration).toBe(756);
+    // Base stats get +1000
+    expect(result.stats.Power).toBe(1000 + 756);
+    expect(result.stats.Precision).toBe(1000 + 756);
   });
 
   test("food with 'to All Attributes' adds to every stat", () => {


### PR DESCRIPTION
## Summary

Equipment stats showed incorrect values for all stat combos except Berserker's. Root cause was threefold:

1. **Wrong 4-stat formula**: Code used a 1-2-1 distribution (1 major + 2 middle + 1 minor) with incorrect scaling factors (0.895/0.889/0.452). All GW2 4-stat combos actually use a **2-2 pattern** — two major stats at 0.3 multiplier and two minor stats at 0.165 multiplier. This caused massive stat miscalculations (e.g., Viper's ConditionDamage was ~200 points too low).

2. **Wrong Celestial formula**: Used `(p + 2s) / 9` which severely undervalued all Celestial stats (~405 total vs correct ~756).

3. **Exotic weights instead of ascended**: All slot weights were for exotic-tier equipment. Updated to ascended/legendary tier values derived from GW2 API `attribute_adjustment` data.

Also adds missing stat combos (Sentinel's, Wanderer's, Diviner's) and fixes Wanderer's/Diviner's stat array ordering so major stats come first in the 2-2 pattern.

Closes #50