### PR TITLE
fix: skills with crit chance modifiers not affecting attributes (closes #61)

### DIFF
--- a/src/renderer/modules/constants.js
+++ b/src/renderer/modules/constants.js
@@ -503,6 +503,31 @@ export const MIGHT_CONDI_PER_STACK = 30;
 export const MIGHT_MAX_STACKS = 25;
 export const FURY_CRIT_CHANCE = 25; // percentage points
 
+// Signet passive flat attribute bonuses (GW2 API doesn't expose these numerically).
+// Values sourced from GW2 wiki; keyed by skill ID → { attribute, pve, wvw }.
+// Only signets that grant flat attribute increases are included (not %, speed, regen, etc.).
+export const SKILL_PASSIVE_BONUSES = new Map([
+  // Elementalist
+  [5542, { attribute: "Precision", pve: 180, wvw: 180 }],         // Signet of Fire
+  // Guardian
+  [9093, { attribute: "Power", pve: 180, wvw: 180 }],             // Bane Signet
+  [9151, { attribute: "ConditionDamage", pve: 180, wvw: 180 }],   // Signet of Wrath
+  [9163, { attribute: "Concentration", pve: 180, wvw: 120 }],     // Signet of Mercy
+  // Warrior
+  [14404, { attribute: "Power", pve: 180, wvw: 180 }],            // Signet of Might
+  [14410, { attribute: "Precision", pve: 180, wvw: 180 }],        // Signet of Fury
+  // Thief
+  [13046, { attribute: "Power", pve: 200, wvw: 180 }],            // Assassin's Signet
+  [13062, { attribute: "Precision", pve: 180, wvw: 180 }],        // Signet of Agility
+  // Necromancer
+  [10622, { attribute: "Power", pve: 180, wvw: 180 }],            // Signet of Spite
+  // Mesmer
+  [10232, { attribute: "ConditionDamage", pve: 180, wvw: 180 }],  // Signet of Domination
+  // Ranger
+  [12500, { attribute: "Toughness", pve: 180, wvw: 180 }],        // Signet of Stone
+  [12491, { attribute: "Ferocity", pve: 180, wvw: 180 }],         // Signet of the Wild
+]);
+
 export const BOON_NAMES = new Set([
   "Aegis", "Alacrity", "Fury", "Might", "Protection", "Quickness",
   "Regeneration", "Resistance", "Resolution", "Stability", "Swiftness", "Vigor",

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -33,11 +33,13 @@ let _renderEditor = () => {};
 let _markEditorChanged = () => {};
 let _enforceEditorConsistency = () => {};
 let _openSlotPicker = () => {};
-export function initSkillsCallbacks({ renderEditor, markEditorChanged, enforceEditorConsistency, openSlotPicker }) {
+let _renderEquipmentPanel = () => {};
+export function initSkillsCallbacks({ renderEditor, markEditorChanged, enforceEditorConsistency, openSlotPicker, renderEquipmentPanel }) {
   _renderEditor = renderEditor;
   _markEditorChanged = markEditorChanged;
   _enforceEditorConsistency = enforceEditorConsistency;
   _openSlotPicker = openSlotPicker;
+  if (renderEquipmentPanel) _renderEquipmentPanel = renderEquipmentPanel;
 }
 
 // Tracks which utility slot (0–2) is currently being dragged; -1 means none.
@@ -945,6 +947,7 @@ export function makeSkillSlot(slot, catalog, options, utilitySelection, markSkil
         state.editor.activeKit = 0; // clear kit view when utility selection changes
         _markEditorChanged({ updateBuildList: true });
         renderSkills();
+        _renderEquipmentPanel(); // skill passives (e.g. signets) affect attributes
 
         // FLIP animation: after re-render, briefly offset the new icons to their OLD positions
         // then transition them to their natural (0,0) resting place with a springy easing.
@@ -1726,6 +1729,7 @@ export function openLegendPicker(anchorEl, slotIdx, catalog) {
       syncRevenantSkillsFromLegend(catalog);
       _markEditorChanged();
       renderSkills();
+      _renderEquipmentPanel(); // legend skills may have passive attribute bonuses
     }, { items, searchPlaceholder: "Search legends…" });
   }
 }

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -2,7 +2,7 @@
 import { state } from "./state.js";
 import {
   STAT_COMBOS_BY_LABEL, SLOT_WEIGHTS, LAND_ONLY_SLOTS, AQUATIC_SLOTS,
-  MIGHT_POWER_PER_STACK, MIGHT_CONDI_PER_STACK,
+  MIGHT_POWER_PER_STACK, MIGHT_CONDI_PER_STACK, SKILL_PASSIVE_BONUSES,
 } from "./constants.js";
 
 export function computeSlotStats(comboLabel, slotKey) {
@@ -191,6 +191,27 @@ export function computeEquipmentStats(assumedBoons = null) {
       while ((m = flatRe.exec(utilDef.buff)) !== null) {
         const key = UTIL_STAT_MAP[m[2]];
         if (key) totals[key] = (totals[key] || 0) + Number(m[1]);
+      }
+    }
+  }
+
+  // Skill passive attribute bonuses (e.g. signets)
+  const skillSource = isUnderwater ? state.editor.underwaterSkills : state.editor.skills;
+  if (skillSource) {
+    const gameMode = state.editor.gameMode || "pve";
+    const modeKey = gameMode === "wvw" ? "wvw" : "pve";
+    const skillIds = [
+      skillSource.healId,
+      ...(skillSource.utilityIds || []),
+      skillSource.eliteId,
+    ];
+    for (const id of skillIds) {
+      if (!id) continue;
+      const bonus = SKILL_PASSIVE_BONUSES.get(Number(id));
+      if (!bonus) continue;
+      const value = bonus[modeKey] ?? bonus.pve;
+      if (value && totals[bonus.attribute] !== undefined) {
+        totals[bonus.attribute] += value;
       }
     }
   }
@@ -476,6 +497,31 @@ export function computeStatBreakdown(statKey, assumedBoons = null) {
       while ((m = flatRe.exec(utilDef.buff)) !== null) {
         const key = MAP[m[2]] || m[2];
         if (key === statKey) entries.push({ source: `${utilDef.name}`, value: Number(m[1]) });
+      }
+    }
+  }
+
+  // Skill passive attribute bonuses (e.g. signets)
+  {
+    const skillSource = isUnderwater ? state.editor.underwaterSkills : state.editor.skills;
+    if (skillSource) {
+      const gameMode = state.editor.gameMode || "pve";
+      const modeKey = gameMode === "wvw" ? "wvw" : "pve";
+      const catalog = state.activeCatalog;
+      const skillIds = [
+        skillSource.healId,
+        ...(skillSource.utilityIds || []),
+        skillSource.eliteId,
+      ];
+      for (const id of skillIds) {
+        if (!id) continue;
+        const bonus = SKILL_PASSIVE_BONUSES.get(Number(id));
+        if (!bonus || bonus.attribute !== statKey) continue;
+        const value = bonus[modeKey] ?? bonus.pve;
+        if (value) {
+          const skillName = catalog?.skillById?.get(Number(id))?.name || "Signet";
+          entries.push({ source: `Skill (${skillName})`, value });
+        }
       }
     }
   }

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -129,6 +129,7 @@ initSkillsCallbacks({
   markEditorChanged,
   enforceEditorConsistency,
   openSlotPicker,
+  renderEquipmentPanel,
 });
 
 initEquipment({ equipmentPanel: el.equipmentPanel });

--- a/tests/e2e/specs/skill-passives.spec.js
+++ b/tests/e2e/specs/skill-passives.spec.js
@@ -1,0 +1,148 @@
+const { test, expect } = require("playwright/test");
+const { launchApp, closeApp } = require("../helpers/app");
+const { goToEditor, switchTab } = require("../helpers/nav");
+const { selectProfession, setGameMode } = require("../helpers/editor");
+
+// Helper: select a utility skill by clicking the nth slot (0-based) and picking by name
+async function selectUtilitySkill(window, utilIndex, skillName) {
+  const utilGroup = window.locator(".skill-group--utilities");
+  // Utility slots are at indices 1, 2, 3 (heal=0, elite=4)
+  const slot = utilGroup.locator(".skill-slot").nth(utilIndex + 1);
+  const iconBtn = slot.locator(".skill-icon-large");
+  await iconBtn.click();
+
+  const cselectOpen = window.locator(".cselect--skill-slot.cselect--open");
+  await expect(cselectOpen).toBeVisible({ timeout: 3000 });
+
+  // Click the option matching the skill name (scroll into view handled by Playwright)
+  const option = cselectOpen.locator(`.cselect__option:has-text("${skillName}")`).first();
+  await option.scrollIntoViewIfNeeded();
+  await option.click();
+  await window.waitForTimeout(500);
+}
+
+// Helper: read a stat value from the Attributes section
+async function getStatValue(window, statLabel) {
+  const panel = window.locator("#equipmentPanel");
+  const statsSection = panel.locator(".equip-section").filter({ hasText: "Attributes" }).first();
+  const rows = statsSection.locator(".equip-stat-row");
+  const count = await rows.count();
+  for (let i = 0; i < count; i++) {
+    const label = await rows.nth(i).locator(".equip-stat-label").first().textContent();
+    if (label.trim() === statLabel) {
+      const value = await rows.nth(i).locator(".equip-stat-value").first().textContent();
+      return parseInt(value.replace(/,/g, ""));
+    }
+  }
+  return null;
+}
+
+// Helper: read the Crit Chance derived stat value
+async function getCritChance(window) {
+  const panel = window.locator("#equipmentPanel");
+  const statsSection = panel.locator(".equip-section").filter({ hasText: "Attributes" }).first();
+  const precisionRow = statsSection.locator(".equip-stat-row").nth(1); // Precision is second row
+  const derivedCell = precisionRow.locator(".equip-stat-cell--derived");
+  const critValue = await derivedCell.locator(".equip-stat-value").textContent();
+  return critValue.trim();
+}
+
+// ─── Skill passive attribute bonuses (issue #61) ────────────────────────────
+
+test.describe("Skill passive attribute bonuses", () => {
+  let app, window;
+
+  test.beforeAll(async () => {
+    ({ app, window } = await launchApp());
+    await goToEditor(window);
+    await selectProfession(window, "Elementalist");
+  });
+
+  test.afterAll(async () => {
+    await closeApp(app);
+  });
+
+  test("Signet of Fire increases Precision and Crit Chance", async () => {
+    // 1. Check base attributes on the equipment tab
+    await switchTab(window, "equipment");
+    await window.waitForFunction(
+      () => document.querySelector("#equipmentPanel .equip-section") !== null,
+      null,
+      { timeout: 10_000 }
+    );
+
+    const basePrecision = await getStatValue(window, "Precision");
+    expect(basePrecision).toBe(1000);
+
+    const baseCrit = await getCritChance(window);
+    expect(baseCrit).toBe("10.0%");
+
+    // 2. Switch to build tab and equip Signet of Fire
+    await switchTab(window, "build");
+    await window.waitForTimeout(300);
+    await selectUtilitySkill(window, 0, "Signet of Fire");
+
+    // Verify the skill icon title updated to confirm selection
+    const utilGroup = window.locator(".skill-group--utilities");
+    const utilSlot = utilGroup.locator(".skill-slot").nth(1); // first utility slot
+    const iconTitle = await utilSlot.locator(".skill-icon-large").getAttribute("title");
+    expect(iconTitle).toContain("Signet of Fire");
+
+    // 3. Switch back to equipment tab and verify Precision increased by 180
+    await switchTab(window, "equipment");
+    await window.waitForTimeout(500);
+
+    const newPrecision = await getStatValue(window, "Precision");
+    expect(newPrecision).toBe(1000 + 180);
+
+    // 4. Verify Crit Chance updated: 5 + (1180 - 895) / 21.0 = 18.6%
+    const newCrit = await getCritChance(window);
+    expect(newCrit).toBe("18.6%");
+  });
+
+  test("removing signet reverts Precision and Crit Chance to base", async () => {
+    // Signet of Fire is equipped from previous test. Replace it with a non-signet skill.
+    await switchTab(window, "build");
+    await window.waitForTimeout(300);
+    // Select a different utility that does NOT grant a passive attribute bonus
+    await selectUtilitySkill(window, 0, "Glyph of Storms");
+
+    await switchTab(window, "equipment");
+    await window.waitForTimeout(500);
+
+    const precision = await getStatValue(window, "Precision");
+    expect(precision).toBe(1000);
+
+    const crit = await getCritChance(window);
+    expect(crit).toBe("10.0%");
+  });
+});
+
+test.describe("Skill passive bonuses — WvW mode", () => {
+  let app, window;
+
+  test.beforeAll(async () => {
+    ({ app, window } = await launchApp());
+    await goToEditor(window);
+    await selectProfession(window, "Guardian");
+  });
+
+  test.afterAll(async () => {
+    await closeApp(app);
+  });
+
+  test("Bane Signet adds +180 Power in PvE", async () => {
+    // Equip Bane Signet
+    await selectUtilitySkill(window, 0, "Bane Signet");
+
+    await switchTab(window, "equipment");
+    await window.waitForFunction(
+      () => document.querySelector("#equipmentPanel .equip-section") !== null,
+      null,
+      { timeout: 10_000 }
+    );
+
+    const power = await getStatValue(window, "Power");
+    expect(power).toBe(1000 + 180);
+  });
+});

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -406,6 +406,128 @@ describe("computeEquipmentStats — underwater mode", () => {
 });
 
 // ---------------------------------------------------------------------------
+// computeEquipmentStats — skill passive bonuses (issue #61)
+// ---------------------------------------------------------------------------
+
+describe("computeEquipmentStats — skill passive bonuses", () => {
+  test("Signet of Fire adds +180 Precision in PvE", () => {
+    state.editor = {
+      ...makeEditor(),
+      skills: { healId: 0, utilityIds: [5542, 0, 0], eliteId: 0 },
+      gameMode: "pve",
+    };
+    const result = computeEquipmentStats();
+    expect(result.Precision).toBe(1000 + 180);
+  });
+
+  test("Signet of Fire adds +180 Precision in WvW", () => {
+    state.editor = {
+      ...makeEditor(),
+      skills: { healId: 0, utilityIds: [5542, 0, 0], eliteId: 0 },
+      gameMode: "wvw",
+    };
+    const result = computeEquipmentStats();
+    expect(result.Precision).toBe(1000 + 180);
+  });
+
+  test("Bane Signet adds +180 Power", () => {
+    state.editor = {
+      ...makeEditor(),
+      skills: { healId: 0, utilityIds: [9093, 0, 0], eliteId: 0 },
+      gameMode: "pve",
+    };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000 + 180);
+  });
+
+  test("Assassin's Signet adds +200 Power in PvE but +180 in WvW", () => {
+    state.editor = {
+      ...makeEditor(),
+      skills: { healId: 0, utilityIds: [13046, 0, 0], eliteId: 0 },
+      gameMode: "pve",
+    };
+    expect(computeEquipmentStats().Power).toBe(1000 + 200);
+
+    state.editor.gameMode = "wvw";
+    expect(computeEquipmentStats().Power).toBe(1000 + 180);
+  });
+
+  test("multiple signets stack on top of each other", () => {
+    // Bane Signet (+180 Power) + Signet of Wrath (+180 ConditionDamage)
+    state.editor = {
+      ...makeEditor(),
+      skills: { healId: 0, utilityIds: [9093, 9151, 0], eliteId: 0 },
+      gameMode: "pve",
+    };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000 + 180);
+    expect(result.ConditionDamage).toBe(180);
+  });
+
+  test("signet passives stack on top of equipment stats", () => {
+    // Berserker's chest (Power +141, Precision +101) + Signet of Fire (Precision +180)
+    state.editor = {
+      ...makeEditor({ chest: "Berserker's" }),
+      skills: { healId: 0, utilityIds: [5542, 0, 0], eliteId: 0 },
+      gameMode: "pve",
+    };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000 + 141);
+    expect(result.Precision).toBe(1000 + 101 + 180);
+  });
+
+  test("heal and elite slot passives also contribute", () => {
+    // Healing signet as heal, signet passive in elite (Signet of Rage has no attribute bonus)
+    // Using Bane Signet as heal (unusual but tests the slot) and Signet of Wrath as elite
+    state.editor = {
+      ...makeEditor(),
+      skills: { healId: 9093, utilityIds: [0, 0, 0], eliteId: 9151 },
+      gameMode: "pve",
+    };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000 + 180);
+    expect(result.ConditionDamage).toBe(180);
+  });
+
+  test("unknown skill IDs add nothing", () => {
+    state.editor = {
+      ...makeEditor(),
+      skills: { healId: 99999, utilityIds: [88888, 0, 0], eliteId: 77777 },
+      gameMode: "pve",
+    };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000);
+    expect(result.Precision).toBe(1000);
+  });
+
+  test("underwater mode uses underwaterSkills", () => {
+    state.editor = {
+      ...makeEditor(),
+      skills: { healId: 0, utilityIds: [5542, 0, 0], eliteId: 0 },
+      underwaterSkills: { healId: 0, utilityIds: [9093, 0, 0], eliteId: 0 },
+      underwaterMode: true,
+      gameMode: "pve",
+    };
+    const result = computeEquipmentStats();
+    // Should use underwaterSkills (Bane Signet +180 Power), not land skills (Signet of Fire)
+    expect(result.Power).toBe(1000 + 180);
+    expect(result.Precision).toBe(1000); // Signet of Fire is NOT applied (land only)
+  });
+
+  test("Signet of Mercy adds +180 Concentration in PvE but +120 in WvW", () => {
+    state.editor = {
+      ...makeEditor(),
+      skills: { healId: 0, utilityIds: [9163, 0, 0], eliteId: 0 },
+      gameMode: "pve",
+    };
+    expect(computeEquipmentStats().Concentration).toBe(180);
+
+    state.editor.gameMode = "wvw";
+    expect(computeEquipmentStats().Concentration).toBe(120);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // computeBuildConcentration
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Signet passive attribute bonuses (e.g. Signet of Fire's +180 Precision) were never included in the attribute calculation. The GW2 API doesn't expose these values numerically in skill facts, so a hardcoded `SKILL_PASSIVE_BONUSES` map covers all 12 signets across professions with PvE/WvW-specific values.

**Root cause:** `computeEquipmentStats()` computed attributes from equipment, food, upgrades, and boons but completely ignored skill passive effects. Additionally, `renderEquipmentPanel()` was never called when skills changed, so even after adding the stat logic the displayed numbers stayed stale.

**Changes:**
- `constants.js` — Added `SKILL_PASSIVE_BONUSES` map (12 signets, PvE + WvW values)
- `stats.js` — Integrated skill passives into `computeEquipmentStats()` and `computeStatBreakdown()` (hover tooltip)
- `skills.js` / `renderer.js` — Call `renderEquipmentPanel()` after skill selection and Revenant legend changes
- 9 unit tests covering PvE/WvW values, stacking, underwater mode, and edge cases
- 3 Playwright e2e tests verifying Precision/Crit Chance update live when equipping/removing signets

Closes #61