### PR TITLE
fix: Attributes count all weapon sets instead of only the active one (closes #64)

### DIFF
--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -261,6 +261,21 @@ export function resolveEntityFacts(entity) {
   });
 }
 
+function _renderStatBreakdown(entries, total, statName) {
+  const lines = entries.map((e) => {
+    let iconHtml = "";
+    if (e.svgIcon) {
+      iconHtml = `<span class="breakdown-svg-icon">${e.svgIcon}</span>`;
+    } else if (e.icon) {
+      iconHtml = `<img class="fact-status-icon" src="${escapeHtml(e.icon)}" alt="" aria-hidden="true">`;
+    }
+    const countSuffix = e.count > 1 ? ` <span class="breakdown-count">\u00d7${e.count}</span>` : "";
+    return `<li>${iconHtml}<span class="breakdown-value">+${e.value}</span> ${escapeHtml(e.source)}${countSuffix}</li>`;
+  });
+  lines.push(`<li class="breakdown-total"><span class="breakdown-value">${total}</span> Total ${escapeHtml(statName)}</li>`);
+  return `<ul class="hover-preview__breakdown">${lines.join("")}</ul>`;
+}
+
 export function buildSkillCard(skill, kind, isChained = false, dmgStats = null) {
   const icon = String(skill.icon || skill.iconFallback || "");
   const description = normalizeText(skill.description || "");
@@ -284,8 +299,9 @@ export function buildSkillCard(skill, kind, isChained = false, dmgStats = null) 
         <p class="hover-preview__meta">${escapeHtml(meta)}${skill.hasSplit ? ' <span class="split-badge">WvW split</span>' : ''}${_isAquaticOnlySkill(kind, skill) ? ' <span class="split-badge aquatic-badge">Aquatic</span>' : ''}</p>
       </div>
     </div>
-    ${description ? `<p class="hover-preview__desc">${escapeHtml(description).replace(/\n/g, "<br>")}</p>` : (!factsItems.length && !skill.bonuses?.length && !kind.startsWith("equip-") ? `<p class="hover-preview__desc">No description available.</p>` : "")}
+    ${description ? `<p class="hover-preview__desc">${escapeHtml(description).replace(/\n/g, "<br>")}</p>` : (!factsItems.length && !skill.bonuses?.length && !skill.breakdown?.length && !kind.startsWith("equip-") ? `<p class="hover-preview__desc">No description available.</p>` : "")}
     ${skill.bonuses?.length ? `<ul class="hover-preview__bonuses">${skill.bonuses.map((b, i) => `<li class="${i < (skill.activeBonusCount || 0) ? "hover-preview__bonus--active" : "hover-preview__bonus--inactive"}">(${i + 1}): ${escapeHtml(b)}</li>`).join("")}</ul>` : ""}
+    ${skill.breakdown?.length ? _renderStatBreakdown(skill.breakdown, skill.breakdownTotal, skill.name) : ""}
     ${factsItems.length ? `<ul class="hover-preview__facts">${factsItems.join("")}</ul>` : ""}
   `;
 }

--- a/src/renderer/modules/equipment.js
+++ b/src/renderer/modules/equipment.js
@@ -12,6 +12,8 @@ import { escapeHtml } from "./utils.js";
 import { computeSlotStats, computeEquipmentStats, computeUpgradeModifiers, computeStatBreakdown } from "./stats.js";
 import { bindHoverPreview, selectDetail } from "./detail-panel.js";
 import { getProfessionSvg } from "./profession-icons.js";
+import { getSlotSvg } from "./slot-icons.js";
+import { getWeaponSvg } from "./weapon-icons.js";
 import { resolveEquippedWeaponSkills, getAvailableAttunements, resolveWarriorBurst } from "./equipment-weapon-skills.js";
 import { getSkillOptionsByType } from "./skills.js";
 import { computeBoonCoverage } from "./boon-coverage.js";
@@ -1292,14 +1294,30 @@ export function renderEquipmentPanel() {
       for (const e of breakdown) {
         const existing = grouped.get(e.source);
         if (existing) { existing.value += e.value; existing.count++; }
-        else grouped.set(e.source, { source: e.source, value: e.value, count: 1 });
+        else grouped.set(e.source, { ...e, count: 1 });
       }
-      const lines = [...grouped.values()].map((e) =>
-        e.count > 1 ? `+${e.value}  ${e.source} \u00d7${e.count}` : `+${e.value}  ${e.source}`
-      );
+      // Attach SVG icons for equipment slot entries
+      const weight = PROFESSION_WEIGHT[state.editor.profession] || "heavy";
+      const weapons = state.editor.equipment?.weapons || {};
+      for (const entry of grouped.values()) {
+        if (entry.slotKey && !entry.svgIcon) {
+          // Weapon slots: use the weapon type SVG
+          const weaponId = weapons[entry.slotKey];
+          if (weaponId) {
+            entry.svgIcon = getWeaponSvg(weaponId);
+          }
+          // Armor/trinket slots: use the slot SVG
+          if (!entry.svgIcon) {
+            entry.svgIcon = getSlotSvg(entry.slotKey, weight);
+          }
+        }
+      }
       const total = breakdown.reduce((s, e) => s + e.value, 0);
-      lines.push(`——\n${total}  Total ${row.stat}`);
-      return { name: row.stat, description: lines.join("\n") };
+      return {
+        name: row.stat,
+        breakdown: [...grouped.values()],
+        breakdownTotal: total,
+      };
     });
 
     rowEl.append(leftEl);

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -33,11 +33,13 @@ let _renderEditor = () => {};
 let _markEditorChanged = () => {};
 let _enforceEditorConsistency = () => {};
 let _openSlotPicker = () => {};
-export function initSkillsCallbacks({ renderEditor, markEditorChanged, enforceEditorConsistency, openSlotPicker }) {
+let _renderEquipmentPanel = () => {};
+export function initSkillsCallbacks({ renderEditor, markEditorChanged, enforceEditorConsistency, openSlotPicker, renderEquipmentPanel }) {
   _renderEditor = renderEditor;
   _markEditorChanged = markEditorChanged;
   _enforceEditorConsistency = enforceEditorConsistency;
   _openSlotPicker = openSlotPicker;
+  if (renderEquipmentPanel) _renderEquipmentPanel = renderEquipmentPanel;
 }
 
 // Tracks which utility slot (0–2) is currently being dragged; -1 means none.
@@ -1646,6 +1648,7 @@ export function renderSkills() {
   swapBtn.addEventListener("click", () => {
     state.editor.activeWeaponSet = activeWeaponSet === 1 ? 2 : 1;
     renderSkills();
+    _renderEquipmentPanel(); // active weapon set affects attribute totals
     if (!_readOnly && _markEditorChanged) _markEditorChanged();
   });
 

--- a/src/renderer/modules/slot-icons.js
+++ b/src/renderer/modules/slot-icons.js
@@ -1,0 +1,62 @@
+// Equipment slot SVG icons from gw2-class-icons package.
+// Provides inline SVG strings for armor, weapon, and trinket slots.
+
+// ─── Armor SVGs (by weight class) ────────────────────────────────────────────
+import LightHelm      from "gw2-class-icons/armor/svg/light-helm.svg?raw";
+import LightPauldrons from "gw2-class-icons/armor/svg/light-pauldrons.svg?raw";
+import LightChest     from "gw2-class-icons/armor/svg/light-chest.svg?raw";
+import LightGloves    from "gw2-class-icons/armor/svg/light-gloves.svg?raw";
+import LightLeggings  from "gw2-class-icons/armor/svg/light-leggings.svg?raw";
+import LightBoots     from "gw2-class-icons/armor/svg/light-boots.svg?raw";
+
+import MediumHead     from "gw2-class-icons/armor/svg/medium-headgear.svg?raw";
+import MediumShoulders from "gw2-class-icons/armor/svg/medium-shoulders.svg?raw";
+import MediumChest    from "gw2-class-icons/armor/svg/medium-chest.svg?raw";
+import MediumGloves   from "gw2-class-icons/armor/svg/medium-gloves.svg?raw";
+import MediumLeggings from "gw2-class-icons/armor/svg/medium-leggings.svg?raw";
+import MediumBoots    from "gw2-class-icons/armor/svg/medium-boots.svg?raw";
+
+import HeavyHead      from "gw2-class-icons/armor/svg/heavy-headgear.svg?raw";
+import HeavyShoulders from "gw2-class-icons/armor/svg/heavy-shoulders.svg?raw";
+import HeavyChest     from "gw2-class-icons/armor/svg/heavy-chest.svg?raw";
+import HeavyGloves    from "gw2-class-icons/armor/svg/heavy-gloves.svg?raw";
+import HeavyLeggings  from "gw2-class-icons/armor/svg/heavy-leggings.svg?raw";
+import HeavyBoots     from "gw2-class-icons/armor/svg/heavy-boots.svg?raw";
+
+// ─── Trinket SVGs ────────────────────────────────────────────────────────────
+import Backpack from "gw2-class-icons/trinkets/svg/backpack.svg?raw";
+import Amulet   from "gw2-class-icons/trinkets/svg/amulet.svg?raw";
+import Ring     from "gw2-class-icons/trinkets/svg/ring.svg?raw";
+import Earring  from "gw2-class-icons/trinkets/svg/earring.svg?raw";
+
+const ARMOR_SVGS = {
+  light:  { head: LightHelm, shoulders: LightPauldrons, chest: LightChest, hands: LightGloves, legs: LightLeggings, feet: LightBoots, breather: LightHelm },
+  medium: { head: MediumHead, shoulders: MediumShoulders, chest: MediumChest, hands: MediumGloves, legs: MediumLeggings, feet: MediumBoots, breather: MediumHead },
+  heavy:  { head: HeavyHead, shoulders: HeavyShoulders, chest: HeavyChest, hands: HeavyGloves, legs: HeavyLeggings, feet: HeavyBoots, breather: HeavyHead },
+};
+
+const TRINKET_SVGS = {
+  back: Backpack,
+  amulet: Amulet,
+  ring1: Ring,
+  ring2: Ring,
+  accessory1: Earring,
+  accessory2: Earring,
+};
+
+/**
+ * Returns the raw SVG string for an equipment slot, or null if unknown.
+ * @param {string} slotKey — e.g. "head", "mainhand1", "ring1"
+ * @param {string} armorWeight — "light", "medium", or "heavy"
+ */
+export function getSlotSvg(slotKey, armorWeight) {
+  // Armor slots
+  const armorSvg = ARMOR_SVGS[armorWeight]?.[slotKey];
+  if (armorSvg) return armorSvg;
+
+  // Trinket slots
+  const trinketSvg = TRINKET_SVGS[slotKey];
+  if (trinketSvg) return trinketSvg;
+
+  return null;
+}

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -5,6 +5,28 @@ import {
   MIGHT_POWER_PER_STACK, MIGHT_CONDI_PER_STACK,
 } from "./constants.js";
 
+/**
+ * Build the set of equipment slot keys to exclude from stat calculations.
+ * Excludes the opposite environment's slots AND the inactive weapon set.
+ */
+function getExcludedSlots() {
+  const isUnderwater = Boolean(state.editor.underwaterMode);
+  const activeSet = Number(state.editor.activeWeaponSet) || 1;
+  const excluded = new Set(isUnderwater ? LAND_ONLY_SLOTS : AQUATIC_SLOTS);
+  if (isUnderwater) {
+    excluded.add(activeSet === 2 ? "aquatic1" : "aquatic2");
+  } else {
+    if (activeSet === 2) {
+      excluded.add("mainhand1");
+      excluded.add("offhand1");
+    } else {
+      excluded.add("mainhand2");
+      excluded.add("offhand2");
+    }
+  }
+  return excluded;
+}
+
 export function computeSlotStats(comboLabel, slotKey) {
   const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
   const w = SLOT_WEIGHTS[slotKey];
@@ -33,7 +55,7 @@ export function computeEquipmentStats(assumedBoons = null) {
     Ferocity: 0, ConditionDamage: 0, Expertise: 0, Concentration: 0, HealingPower: 0,
   };
   const isUnderwater = Boolean(state.editor.underwaterMode);
-  const EXCLUDED_SLOTS = isUnderwater ? LAND_ONLY_SLOTS : AQUATIC_SLOTS;
+  const EXCLUDED_SLOTS = getExcludedSlots();
   for (const [slotKey, comboLabel] of Object.entries(slots)) {
     if (!comboLabel || EXCLUDED_SLOTS.has(slotKey)) continue;
     const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
@@ -336,7 +358,7 @@ export function computeStatBreakdown(statKey, assumedBoons = null) {
 
   const slots = state.editor.equipment?.slots || {};
   const isUnderwater = Boolean(state.editor.underwaterMode);
-  const EXCLUDED_SLOTS = isUnderwater ? LAND_ONLY_SLOTS : AQUATIC_SLOTS;
+  const EXCLUDED_SLOTS = getExcludedSlots();
   const SLOT_LABELS = {
     head: "Head", shoulders: "Shoulders", chest: "Chest", hands: "Hands", legs: "Legs", feet: "Feet",
     mainhand1: "Mainhand 1", offhand1: "Offhand 1", mainhand2: "Mainhand 2", offhand2: "Offhand 2",
@@ -362,7 +384,14 @@ export function computeStatBreakdown(statKey, assumedBoons = null) {
     } else {
       if (combo.stats.includes(statKey)) val = w.c;
     }
-    if (val) entries.push({ source: `${SLOT_LABELS[slotKey] || slotKey} (${comboLabel})`, value: val });
+    if (val) {
+      const weapons = state.editor.equipment?.weapons || {};
+      const weaponName = weapons[slotKey] || "";
+      const label = weaponName
+        ? `${SLOT_LABELS[slotKey] || slotKey} — ${weaponName} (${comboLabel})`
+        : `${SLOT_LABELS[slotKey] || slotKey} (${comboLabel})`;
+      entries.push({ source: label, value: val, slotKey });
+    }
   }
 
   const upgradeCatalog = state.upgradeCatalog;
@@ -380,10 +409,10 @@ export function computeStatBreakdown(statKey, assumedBoons = null) {
       let m;
       while ((m = re.exec(foodDef.buff)) !== null) {
         if (m[2] === "to All Attributes") {
-          entries.push({ source: `Food (${foodDef.name})`, value: Number(m[1]) });
+          entries.push({ source: `Food (${foodDef.name})`, value: Number(m[1]), icon: foodDef.icon });
         } else {
           const key = MAP[m[2]] || m[2];
-          if (key === statKey) entries.push({ source: `Food (${foodDef.name})`, value: Number(m[1]) });
+          if (key === statKey) entries.push({ source: `Food (${foodDef.name})`, value: Number(m[1]), icon: foodDef.icon });
         }
       }
     }
@@ -402,7 +431,7 @@ export function computeStatBreakdown(statKey, assumedBoons = null) {
       if (!def?.infixUpgrade?.attributes) continue;
       for (const attr of def.infixUpgrade.attributes) {
         if (toStatKey(attr.attribute) === statKey && attr.modifier) {
-          entries.push({ source: `Infusion (${def.name})`, value: attr.modifier });
+          entries.push({ source: `Infusion (${def.name})`, value: attr.modifier, icon: def.icon });
         }
       }
     }
@@ -414,7 +443,7 @@ export function computeStatBreakdown(statKey, assumedBoons = null) {
       if (def?.infixUpgrade?.attributes) {
         for (const attr of def.infixUpgrade.attributes) {
           if (toStatKey(attr.attribute) === statKey && attr.modifier) {
-            entries.push({ source: `Enrichment (${def.name})`, value: attr.modifier });
+            entries.push({ source: `Enrichment (${def.name})`, value: attr.modifier, icon: def.icon });
           }
         }
       }
@@ -441,7 +470,7 @@ export function computeStatBreakdown(statKey, assumedBoons = null) {
         if (m[2] === "to All Stats") runeTotal += val;
         else { const key = MAP[m[2]] || m[2]; if (key === statKey) runeTotal += val; }
       }
-      if (runeTotal) entries.push({ source: `Rune (${runeDef.name})`, value: runeTotal });
+      if (runeTotal) entries.push({ source: `Rune (${runeDef.name})`, value: runeTotal, icon: runeDef.icon });
     }
   }
 
@@ -514,7 +543,7 @@ export function computeUpgradeModifiers() {
   const FLAT_STAT_RE = /\+\d+\s+(Condition Damage|Healing Power|Healing|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise|to All Stats|to All Attributes)/;
 
   const isUnderwater = Boolean(state.editor.underwaterMode);
-  const EXCLUDED_SLOTS = isUnderwater ? LAND_ONLY_SLOTS : AQUATIC_SLOTS;
+  const EXCLUDED_SLOTS = getExcludedSlots();
 
   // Rune percentage modifiers (cumulative per piece, exclude breather)
   const runes = state.editor.equipment?.runes || {};

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -129,6 +129,7 @@ initSkillsCallbacks({
   markEditorChanged,
   enforceEditorConsistency,
   openSlotPicker,
+  renderEquipmentPanel,
 });
 
 initEquipment({ equipmentPanel: el.equipmentPanel });

--- a/src/renderer/styles/detail-panel.css
+++ b/src/renderer/styles/detail-panel.css
@@ -161,6 +161,60 @@
   color: #7a8a9e;
 }
 
+/* Stat breakdown list (attribute hover) */
+.hover-preview__breakdown {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+  color: #cadfff;
+  display: grid;
+  gap: 2px;
+}
+
+.hover-preview__breakdown li {
+  font-size: 0.74rem;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.breakdown-value {
+  color: #6fdc6f;
+  font-weight: 600;
+  min-width: 36px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.breakdown-svg-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #cadfff;
+  opacity: 0.85;
+}
+
+.breakdown-svg-icon svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+
+.breakdown-count {
+  color: #7a8a9e;
+}
+
+.breakdown-total {
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid rgba(202, 223, 255, 0.15);
+  font-weight: 600;
+  color: #e4efff;
+}
+
 .hover-preview__facts {
   margin: 8px 0 0;
   padding-left: 16px;

--- a/tests/e2e/specs/weapon-set-stats.spec.js
+++ b/tests/e2e/specs/weapon-set-stats.spec.js
@@ -1,0 +1,207 @@
+const { test, expect } = require("playwright/test");
+const { launchApp, closeApp } = require("../helpers/app");
+const { goToEditor, switchTab } = require("../helpers/nav");
+const { selectProfession } = require("../helpers/editor");
+
+// Helper: read a stat value from the Attributes section
+async function getStatValue(window, statLabel) {
+  const panel = window.locator("#equipmentPanel");
+  const statsSection = panel.locator(".equip-section").filter({ hasText: "Attributes" }).first();
+  const rows = statsSection.locator(".equip-stat-row");
+  const count = await rows.count();
+  for (let i = 0; i < count; i++) {
+    const label = await rows.nth(i).locator(".equip-stat-label").first().textContent();
+    if (label.trim() === statLabel) {
+      const value = await rows.nth(i).locator(".equip-stat-value").first().textContent();
+      return parseInt(value.replace(/,/g, ""));
+    }
+  }
+  return null;
+}
+
+// Helper: select a weapon type in a weapon slot, then set its stat combo
+async function equipWeapon(window, weaponName, statCombo) {
+  const panel = window.locator("#equipmentPanel");
+  const weaponSection = panel.locator(".equip-section").filter({ hasText: "Weapons" }).first();
+
+  // Find the first weapon type button and click to open picker
+  const weaponSlots = weaponSection.locator(".equip-slot--weapon");
+  const slot = weaponSlots.first();
+  const weaponBtn = slot.locator(".equip-weapon-type-btn");
+  await weaponBtn.click();
+  await window.waitForSelector(".slot-picker", { timeout: 3000 });
+  await window.click(`.slot-picker__option:has-text("${weaponName}")`);
+  await window.waitForTimeout(300);
+
+  // Now click the stat picker button
+  const statBtn = slot.locator(".equip-stat-pick-btn");
+  await statBtn.click();
+  await window.waitForSelector(".slot-picker", { timeout: 3000 });
+  const search = window.locator(".slot-picker__search");
+  if (await search.isVisible()) {
+    await search.fill(statCombo);
+    await window.waitForTimeout(200);
+  }
+  await window.click(`.slot-picker__option:has-text("${statCombo}")`);
+  await window.waitForTimeout(300);
+}
+
+// ─── Active weapon set filtering (issue #64) ────────────────────────────────
+
+test.describe("Weapon set stats — swapping sets updates attributes", () => {
+  let app, window;
+
+  test.beforeAll(async () => {
+    ({ app, window } = await launchApp());
+    await goToEditor(window);
+    await selectProfession(window, "Necromancer");
+    await switchTab(window, "equipment");
+    await window.waitForFunction(
+      () => document.querySelector("#equipmentPanel .equip-section") !== null,
+      null,
+      { timeout: 10_000 }
+    );
+  });
+
+  test.afterAll(async () => {
+    await closeApp(app);
+  });
+
+  test("only active weapon set contributes to stats, swapping updates attributes", async () => {
+    // Seed state: Berserker's on mainhand1 (set 1), Celestial on mainhand2 (set 2)
+    // This bypasses the complex weapon picker UI.
+    await window.evaluate(() => {
+      const el = document.querySelector("#equipmentPanel");
+      // Access state through the module system is not possible from evaluate,
+      // so we trigger the stat change via the equipment panel's own mechanisms.
+    });
+
+    // Equip Axe + Berserker's on mainhand1 (set 1)
+    await equipWeapon(window, "Axe", "Berserker");
+
+    // Power and Ferocity should increase
+    const ferocitySet1 = await getStatValue(window, "Ferocity");
+    expect(ferocitySet1).toBeGreaterThan(0);
+    const powerSet1 = await getStatValue(window, "Power");
+    expect(powerSet1).toBeGreaterThan(1000);
+
+    // Also equip a weapon on set 2 so the swap button is enabled.
+    // Set 2 weapon slots are the 3rd and 4th .equip-slot--weapon elements.
+    const panel = window.locator("#equipmentPanel");
+    const weaponSection = panel.locator(".equip-section").filter({ hasText: "Weapons" }).first();
+    const weaponSlots = weaponSection.locator(".equip-slot--weapon");
+    const mh2Slot = weaponSlots.nth(2); // mainhand2
+    const mh2WeaponBtn = mh2Slot.locator(".equip-weapon-type-btn");
+    await mh2WeaponBtn.click();
+    await window.waitForSelector(".slot-picker", { timeout: 3000 });
+    await window.click('.slot-picker__option:has-text("Dagger")');
+    await window.waitForTimeout(300);
+
+    // Set Celestial stats on mainhand2
+    const mh2StatBtn = mh2Slot.locator(".equip-stat-pick-btn");
+    await mh2StatBtn.click();
+    await window.waitForSelector(".slot-picker", { timeout: 3000 });
+    const search = window.locator(".slot-picker__search");
+    if (await search.isVisible()) {
+      await search.fill("Celestial");
+      await window.waitForTimeout(200);
+    }
+    await window.click('.slot-picker__option:has-text("Celestial")');
+    await window.waitForTimeout(300);
+
+    // Set 1 is still active — Ferocity should reflect Berserker's only (not Celestial)
+    const ferocityStillSet1 = await getStatValue(window, "Ferocity");
+    expect(ferocityStillSet1).toBe(ferocitySet1); // unchanged
+
+    // Force a full re-render so the skill bar picks up the set 2 weapon
+    // (toggling underwater mode triggers renderEditor which re-renders skills + equipment)
+    await switchTab(window, "build");
+    await window.waitForTimeout(300);
+    const waterBtn = window.locator('.underwater-toggle__btn[data-mode="water"]');
+    await waterBtn.click();
+    await window.waitForTimeout(300);
+    const landBtn = window.locator('.underwater-toggle__btn[data-mode="land"]');
+    await landBtn.click();
+    await window.waitForTimeout(500);
+
+    // Now swap to set 2
+    const swapBtn = window.locator(".skills-bar .weapon-swap-btn");
+    await expect(swapBtn).toBeVisible({ timeout: 3000 });
+    await swapBtn.click();
+    await window.waitForTimeout(500);
+
+    // Check equipment tab — set 2 (Celestial) should be active
+    await switchTab(window, "equipment");
+    await window.waitForTimeout(500);
+
+    // Celestial has equal stats across all 9 attributes (59 per stat for 1H weapon)
+    const ferocitySet2 = await getStatValue(window, "Ferocity");
+    const expertiseSet2 = await getStatValue(window, "Expertise");
+    // Celestial gives the same value to all stats
+    expect(ferocitySet2).toBeGreaterThan(0);
+    expect(expertiseSet2).toBeGreaterThan(0);
+    // Berserker's set 1 should NOT be contributing (it has 0 Expertise)
+    expect(ferocitySet2).toBe(expertiseSet2);
+
+    // Swap back to set 1
+    await switchTab(window, "build");
+    await window.waitForTimeout(300);
+    await swapBtn.click();
+    await window.waitForTimeout(500);
+    await switchTab(window, "equipment");
+    await window.waitForTimeout(500);
+
+    // Ferocity should be Berserker's value again, Expertise should be 0
+    expect(await getStatValue(window, "Ferocity")).toBe(ferocitySet1);
+    expect(await getStatValue(window, "Expertise")).toBe(0);
+  });
+});
+
+test.describe("Weapon set stats — land/water toggle", () => {
+  let app, window;
+
+  test.beforeAll(async () => {
+    ({ app, window } = await launchApp());
+    await goToEditor(window);
+    await selectProfession(window, "Necromancer");
+    await switchTab(window, "equipment");
+    await window.waitForFunction(
+      () => document.querySelector("#equipmentPanel .equip-section") !== null,
+      null,
+      { timeout: 10_000 }
+    );
+  });
+
+  test.afterAll(async () => {
+    await closeApp(app);
+  });
+
+  test("switching to underwater excludes land weapon stats", async () => {
+    // Equip Axe + Berserker's on mainhand1
+    await equipWeapon(window, "Axe", "Berserker");
+    const ferocityLand = await getStatValue(window, "Ferocity");
+    expect(ferocityLand).toBeGreaterThan(0);
+
+    // Switch to underwater via the toggle
+    await switchTab(window, "build");
+    await window.waitForTimeout(300);
+    const waterBtn = window.locator('.underwater-toggle__btn[data-mode="water"]');
+    await waterBtn.click();
+    await window.waitForTimeout(500);
+
+    // Equipment tab should show 0 Ferocity (land weapon excluded)
+    await switchTab(window, "equipment");
+    await window.waitForTimeout(500);
+    expect(await getStatValue(window, "Ferocity")).toBe(0);
+
+    // Switch back to land — Ferocity should restore
+    await switchTab(window, "build");
+    await window.waitForTimeout(300);
+    const landBtn = window.locator('.underwater-toggle__btn[data-mode="land"]');
+    await landBtn.click();
+    await window.waitForTimeout(500);
+    await switchTab(window, "equipment");
+    await window.waitForTimeout(500);
+    expect(await getStatValue(window, "Ferocity")).toBe(ferocityLand);
+  });
+});

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -200,13 +200,14 @@ describe("computeEquipmentStats — multiple slot accumulation", () => {
     expect(result.Ferocity).toBe(totalSecondary);
   });
 
-  test("dual weapon set adds mainhand1 + mainhand2", () => {
+  test("only active weapon set contributes (default = set 1)", () => {
     // mainhand1 and mainhand2 each: p=125, s=90 (ascended)
+    // Only the active set (default = 1) should count
     state.editor = makeEditor({ mainhand1: "Berserker's", mainhand2: "Berserker's" });
     const result = computeEquipmentStats();
-    expect(result.Power).toBe(1000 + 125 + 125);
-    expect(result.Precision).toBe(1000 + 90 + 90);
-    expect(result.Ferocity).toBe(90 + 90);
+    expect(result.Power).toBe(1000 + 125);
+    expect(result.Precision).toBe(1000 + 90);
+    expect(result.Ferocity).toBe(90);
   });
 });
 
@@ -402,6 +403,102 @@ describe("computeEquipmentStats — underwater mode", () => {
     };
     const result = computeEquipmentStats();
     expect(result.Power).toBe(1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeEquipmentStats — active weapon set filtering (issue #64)
+// ---------------------------------------------------------------------------
+
+describe("computeEquipmentStats — active weapon set filtering", () => {
+  test("only active weapon set 1 contributes to stats on land", () => {
+    // Set 1 = Berserker's, Set 2 = Celestial. With set 1 active, only set 1 should count.
+    state.editor = {
+      ...makeEditor({
+        mainhand1: "Berserker's", offhand1: "Berserker's",
+        mainhand2: "Celestial",   offhand2: "Celestial",
+      }),
+      activeWeaponSet: 1,
+    };
+    const result = computeEquipmentStats();
+    // mainhand1 + offhand1 Berserker's: Power = 2×125 = 250, Precision = 2×90 = 180
+    expect(result.Power).toBe(1000 + 250);
+    expect(result.Precision).toBe(1000 + 180);
+    // Celestial stats from set 2 should NOT be included
+    expect(result.Expertise).toBe(0);
+    expect(result.Concentration).toBe(0);
+    expect(result.HealingPower).toBe(0);
+  });
+
+  test("only active weapon set 2 contributes to stats on land", () => {
+    state.editor = {
+      ...makeEditor({
+        mainhand1: "Berserker's", offhand1: "Berserker's",
+        mainhand2: "Celestial",   offhand2: "Celestial",
+      }),
+      activeWeaponSet: 2,
+    };
+    const result = computeEquipmentStats();
+    // Only Celestial set 2 should count: 2 weapons × 59 per stat = 118
+    expect(result.Expertise).toBe(118);
+    expect(result.Concentration).toBe(118);
+    // Berserker's set 1 should NOT be included — base Power = 1000 + Celestial 118
+    expect(result.Power).toBe(1000 + 118);
+  });
+
+  test("switching active set changes which weapon stats are included", () => {
+    state.editor = {
+      ...makeEditor({
+        mainhand1: "Berserker's",
+        mainhand2: "Cleric's",
+      }),
+      activeWeaponSet: 1,
+    };
+    const r1 = computeEquipmentStats();
+    expect(r1.HealingPower).toBe(0); // Berserker's has no HealingPower
+
+    state.editor.activeWeaponSet = 2;
+    const r2 = computeEquipmentStats();
+    expect(r2.HealingPower).toBe(125); // Cleric's mainhand2 primary = HealingPower
+  });
+
+  test("underwater mode only includes active aquatic weapon", () => {
+    // Aquatic weapons are 2H — weights: p=251, s=179, c=118
+    state.editor = {
+      ...makeEditor({
+        aquatic1: "Berserker's",
+        aquatic2: "Celestial",
+      }),
+      underwaterMode: true,
+      activeWeaponSet: 1,
+      underwaterSkills: { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 },
+    };
+    const r1 = computeEquipmentStats();
+    // Only aquatic1 (Berserker's) should count: Power primary = 251
+    expect(r1.Power).toBe(1000 + 251);
+    expect(r1.Expertise).toBe(0); // Celestial not included
+
+    state.editor.activeWeaponSet = 2;
+    const r2 = computeEquipmentStats();
+    // Only aquatic2 (Celestial) should count: per-stat = 118
+    expect(r2.Expertise).toBe(118);
+    expect(r2.Power).toBe(1000 + 118); // Celestial Power, not Berserker's
+  });
+
+  test("armor slots are unaffected by weapon set selection", () => {
+    state.editor = {
+      ...makeEditor({
+        head: "Berserker's",
+        chest: "Berserker's",
+        mainhand1: "Celestial",
+      }),
+      activeWeaponSet: 2, // set 2 is active, but set 2 has no weapons
+    };
+    const result = computeEquipmentStats();
+    // Armor should still count even though active set is 2
+    expect(result.Power).toBe(1000 + 63 + 141); // head(63) + chest(141)
+    // mainhand1 is set 1 — should be excluded since set 2 is active
+    expect(result.Ferocity).toBe(45 + 101); // head(45) + chest(101), no weapon contribution
   });
 });
 


### PR DESCRIPTION
## Summary

`computeEquipmentStats()` included stats from all weapon slots (mainhand1, offhand1, mainhand2, offhand2) simultaneously instead of filtering to the active weapon set. Added a `getExcludedSlots()` helper that builds the exclusion set based on both environment mode (land/underwater) and the active weapon set. Also wired `renderEquipmentPanel()` to the weapon swap button so attribute numbers update immediately on swap.

Additionally enhanced the stat breakdown hover tooltip with:
- Green `+value` text for each source
- Inline SVG icons for armor (weight-class-specific), weapons, and trinkets from `gw2-class-icons`
- PNG item icons for food, runes, and infusions from the GW2 API
- Clean separator line for the total

Closes #64