### PR TITLE
fix: unselected traits are not greyed out (closes #55)

### DIFF
--- a/src/renderer/styles/specializations.css
+++ b/src/renderer/styles/specializations.css
@@ -258,6 +258,14 @@
   opacity: 1;
 }
 
+.trait-column--major .trait-btn:not(.trait-btn--active):not(.trait-btn--always) img {
+  filter: grayscale(60%) brightness(0.7);
+}
+
+.trait-column--major .trait-btn:not(.trait-btn--active):not(.trait-btn--always):hover img {
+  filter: grayscale(20%) brightness(0.9);
+}
+
 .trait-column--major .trait-btn:hover {
   border-color: transparent;
   background: transparent;

--- a/tests/unit/renderer/specializations.test.js
+++ b/tests/unit/renderer/specializations.test.js
@@ -1,0 +1,76 @@
+"use strict";
+
+// makeTraitButton uses document.createElement — mock the DOM.
+const _listeners = [];
+function makeElement(tag) {
+  const el = {
+    tagName: tag.toUpperCase(),
+    type: "",
+    className: "",
+    title: "",
+    textContent: "",
+    disabled: false,
+    src: "",
+    alt: "",
+    dataset: {},
+    classList: {
+      _set: new Set(),
+      add(c) { this._set.add(c); },
+      remove(c) { this._set.delete(c); },
+      contains(c) { return this._set.has(c); },
+    },
+    addEventListener(evt, fn) { _listeners.push({ evt, fn }); },
+    append(...children) {},
+  };
+  return el;
+}
+
+global.document = { createElement: (tag) => makeElement(tag) };
+
+const { makeTraitButton } = require("../../../src/renderer/modules/specializations");
+
+const fakeTrait = (id, name = "Test Trait") => ({
+  id,
+  name,
+  icon: `https://example.com/trait-${id}.png`,
+});
+
+describe("makeTraitButton", () => {
+  test("inactive major trait button does NOT have trait-btn--active class", () => {
+    const trait = fakeTrait(100, "Signet Mastery");
+    const btn = makeTraitButton(trait, false, () => {});
+    expect(btn.className).not.toContain("trait-btn--active");
+    expect(btn.className).toContain("trait-btn");
+  });
+
+  test("active major trait button has trait-btn--active class", () => {
+    const trait = fakeTrait(101, "Radiant Fire");
+    const btn = makeTraitButton(trait, true, () => {});
+    expect(btn.className).toContain("trait-btn--active");
+  });
+
+  test("CSS contains rule to visually dim inactive major trait buttons", () => {
+    const fs = require("fs");
+    const path = require("path");
+    const css = fs.readFileSync(
+      path.join(__dirname, "../../../src/renderer/styles/specializations.css"),
+      "utf8"
+    );
+    const hasInactiveRule =
+      css.includes("trait-btn:not(.trait-btn--active)") ||
+      css.includes("trait-btn:not(.trait-btn--active):not(.trait-btn--always)");
+    expect(hasInactiveRule).toBe(true);
+  });
+
+  test("inactive trait CSS rule applies opacity or grayscale to dim the icon", () => {
+    const fs = require("fs");
+    const path = require("path");
+    const css = fs.readFileSync(
+      path.join(__dirname, "../../../src/renderer/styles/specializations.css"),
+      "utf8"
+    );
+    const hasOpacityOrGrayscale =
+      /trait-btn:not\(\.trait-btn--active\)[^{]*\{[^}]*(opacity\s*:|grayscale)/s.test(css);
+    expect(hasOpacityOrGrayscale).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Unselected major traits had no visual distinction from the selected trait in each specialization tier. Added CSS rules to apply `grayscale(60%) brightness(0.7)` to inactive major trait icons, with a lighter `grayscale(20%) brightness(0.9)` on hover. Active traits retain their full-color glow. Opacity stays at 100% throughout.

Closes #55