### PR TITLE
fix: HTML exposed in in-game description of traits (closes #54)

### DIFF
--- a/src/renderer/modules/detail-modal.js
+++ b/src/renderer/modules/detail-modal.js
@@ -1,6 +1,6 @@
 import { formatFactHtml, resolveEntityFacts } from "./detail-panel.js";
 import { getProfessionSvg } from "./profession-icons.js";
-import { escapeHtml } from "./utils.js";
+import { escapeHtml, stripGw2Markup } from "./utils.js";
 
 // Module-level singleton — one modal for the app lifetime
 let _overlay = null;
@@ -220,7 +220,7 @@ function _buildModalDetail(kind, entity) {
     title: entity.name || "Unknown",
     icon: entity.icon || "",
     iconFallback: entity.iconFallback || "",
-    description: entity.description || "",
+    description: stripGw2Markup(entity.description),
     facts: resolveEntityFacts(entity),
     wiki: { loading: false, summary: "", url: "" },
     hasSplit: Boolean(entity.hasSplit),

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -1,6 +1,6 @@
 import { state } from "./state.js";
 import { WEAPON_STRENGTH_MIDPOINT, BOON_CONDITION_ICONS, BUFF_FACT_TYPES, FACT_TYPE_ICONS } from "./constants.js";
-import { escapeHtml, tierLabel, normalizeText } from "./utils.js";
+import { escapeHtml, tierLabel, normalizeText, stripGw2Markup } from "./utils.js";
 import { computeEquipmentStats } from "./stats.js";
 import { getAssumedBoons } from "./equipment.js";
 
@@ -460,7 +460,7 @@ export async function selectDetail(kind, entity) {
     title: entity.name || "Unknown",
     icon: entity.icon || "",
     iconFallback: entity.iconFallback || "",
-    description: entity.description || "",
+    description: stripGw2Markup(entity.description),
     facts: resolveEntityFacts(entity),
     wiki: { loading: true, summary: "", url: "" },
     hasSplit: Boolean(entity.hasSplit),
@@ -506,11 +506,6 @@ function formatBuffConditionText(fact) {
       ? `: ${fact.text}`
       : "";
   return `${name}${stackPart}${duration}${extra}`;
-}
-
-/** Strip GW2 in-game markup like <c=@abilitytype>text</c> from API strings. */
-function stripGw2Markup(s) {
-  return String(s || "").replace(/<c=[^>]*>(.*?)<\/c>/gi, "$1").trim();
 }
 
 export function formatFactHtml(fact, dmgStats = null, { alacrity = false } = {}) {

--- a/src/renderer/modules/utils.js
+++ b/src/renderer/modules/utils.js
@@ -1,5 +1,14 @@
 // Pure utility functions with no DOM dependencies or global state.
 
+/** Strip GW2 in-game markup (e.g. <c=@abilitytype>text</c>, <br>) from API strings. */
+export function stripGw2Markup(s) {
+  return String(s || "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<c=[^>]*>(.*?)<\/c>/gi, "$1")
+    .replace(/<[^>]*>/g, "")
+    .trim();
+}
+
 export function escapeHtml(value) {
   return String(value)
     .replaceAll("&", "&amp;")
@@ -201,7 +210,7 @@ export function simplifyTrait(trait) {
     id: Number(trait.id) || 0,
     name: String(trait.name || ""),
     icon: String(trait.icon || ""),
-    description: String(trait.description || ""),
+    description: stripGw2Markup(trait.description),
     tier: Number(trait.tier) || 0,
   };
 }
@@ -212,7 +221,7 @@ export function simplifySkill(skill) {
     id: Number(skill.id) || 0,
     name: String(skill.name || ""),
     icon: String(skill.icon || ""),
-    description: String(skill.description || ""),
+    description: stripGw2Markup(skill.description),
     slot: String(skill.slot || ""),
     type: String(skill.type || ""),
     specialization: Number(skill.specialization) || 0,

--- a/tests/unit/renderer/stripGw2Markup.test.js
+++ b/tests/unit/renderer/stripGw2Markup.test.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const { stripGw2Markup, simplifyTrait, simplifySkill } = require("../../../src/renderer/modules/utils");
+
+describe("stripGw2Markup", () => {
+  test("strips <c=@...>text</c> tags, keeping inner text", () => {
+    expect(stripGw2Markup("Gain <c=@reminder>5</c> stacks of <c=@abilitytype>Might</c>."))
+      .toBe("Gain 5 stacks of Might.");
+  });
+
+  test("converts <br> to newline", () => {
+    expect(stripGw2Markup("Line one.<br>Line two."))
+      .toBe("Line one.\nLine two.");
+  });
+
+  test("handles self-closing <br />", () => {
+    expect(stripGw2Markup("Line one.<br />Line two."))
+      .toBe("Line one.\nLine two.");
+  });
+
+  test("strips unknown HTML-like tags", () => {
+    expect(stripGw2Markup("Apply <b>Burning</b> for 3s."))
+      .toBe("Apply Burning for 3s.");
+  });
+
+  test("returns empty string for null/undefined", () => {
+    expect(stripGw2Markup(null)).toBe("");
+    expect(stripGw2Markup(undefined)).toBe("");
+    expect(stripGw2Markup("")).toBe("");
+  });
+
+  test("returns plain text unchanged", () => {
+    expect(stripGw2Markup("No markup here.")).toBe("No markup here.");
+  });
+
+  test("handles nested or multiple markup tags", () => {
+    expect(stripGw2Markup("<c=@reminder>10</c>% chance to gain <c=@abilitytype>Fury</c>"))
+      .toBe("10% chance to gain Fury");
+  });
+});
+
+describe("simplifyTrait strips GW2 markup from description", () => {
+  test("strips <c=@...> markup from trait description", () => {
+    const trait = {
+      id: 123,
+      name: "Battle Presence",
+      icon: "http://example.com/icon.png",
+      description: "Grant nearby allies <c=@abilitytype>Retaliation</c>. <c=@reminder>Duration: 5s</c>",
+      tier: 2,
+    };
+    const result = simplifyTrait(trait);
+    expect(result.description).toBe("Grant nearby allies Retaliation. Duration: 5s");
+    expect(result.description).not.toMatch(/<c=/);
+  });
+});
+
+describe("simplifySkill strips GW2 markup from description", () => {
+  test("strips <c=@...> markup from skill description", () => {
+    const skill = {
+      id: 456,
+      name: "Fireball",
+      icon: "http://example.com/icon.png",
+      description: "Hurl a fireball that <c=@abilitytype>burns</c> foes.",
+      slot: "Weapon_1",
+      type: "Weapon",
+      specialization: 0,
+    };
+    const result = simplifySkill(skill);
+    expect(result.description).toBe("Hurl a fireball that burns foes.");
+    expect(result.description).not.toMatch(/<c=/);
+  });
+});


### PR DESCRIPTION
## Summary

GW2 API trait/skill descriptions contain custom in-game markup tags (e.g. `<c=@reminder>5</c>`, `<c=@abilitytype>Might</c>`). These were being passed through `escapeHtml()` which converted the angle brackets to visible text like `<c=@reminder>`. The fix adds a shared `stripGw2Markup()` utility that strips these tags (keeping inner text) and converts `<br>` to newlines. Applied at the data source (`simplifyTrait`/`simplifySkill`) and at display entry points (`selectDetail`, `_buildDetail`) to ensure all views render clean descriptions.

Closes #54