### PR TITLE
fix: site bundle missing from packaged app (closes #72)

### DIFF
--- a/.claude/agent-memory/build-and-notify/project_build_config.md
+++ b/.claude/agent-memory/build-and-notify/project_build_config.md
@@ -7,7 +7,7 @@ type: project
 Build system is electron-builder (v26) with Vite as the renderer bundler.
 
 **Build commands (per build-local.md):**
-- Both platforms in one pass: `npm run build:renderer && npx electron-builder --linux --win --publish never`
+- Both platforms in one pass: `npm run build:site && npm run build:renderer && npx electron-builder --linux --win --publish never`
 - Linux only: `npm run build:app:linux`
 - Windows only: `npm run build:app:win`
 

--- a/.claude/commands/build-local.md
+++ b/.claude/commands/build-local.md
@@ -41,10 +41,10 @@ rm -rf dist/ dist_out/
 ### Step 4 — Build
 
 ```bash
-npm run build:renderer && npx electron-builder --linux --win --publish never
+npm run build:site && npm run build:renderer && npx electron-builder --linux --win --publish never
 ```
 
-Note: Building Windows from Linux requires Wine. If `--win` fails due to Wine, retry with `--linux` only and note this in the output.
+Note: `build:site` must run before electron-builder so the site bundle is included as an extra resource in the packaged app. Building Windows from Linux requires Wine. If `--win` fails due to Wine, retry with `--linux` only and note this in the output.
 
 ### Step 5 — Restore version
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -51,8 +51,10 @@ rm -rf dist/ dist_out/
 ### Step 5 — Build
 
 ```bash
-npm run build:renderer && npx electron-builder --linux --win --publish never
+npm run build:site && npm run build:renderer && npx electron-builder --linux --win --publish never
 ```
+
+Note: `build:site` must run before electron-builder so the site bundle is included as an extra resource in the packaged app.
 
 If the build fails, abort: "Build failed — see output above."
 

--- a/src/main/siteBundle.js
+++ b/src/main/siteBundle.js
@@ -71,4 +71,4 @@ function buildRedirectFile(fileId, encKey, type) {
   };
 }
 
-module.exports = { buildSpaBundle, buildEncryptedBuildFile, buildEncryptedCompFile, buildRedirectFile };
+module.exports = { getSiteDistDir, buildSpaBundle, buildEncryptedBuildFile, buildEncryptedCompFile, buildRedirectFile };

--- a/tests/unit/siteBundle.test.js
+++ b/tests/unit/siteBundle.test.js
@@ -73,6 +73,25 @@ describe("buildSpaBundle", () => {
   });
 });
 
+describe("getSiteDistDir — packaged path", () => {
+  test("uses process.resourcesPath/site when app.isPackaged is true", () => {
+    jest.resetModules();
+    jest.mock("electron", () => ({ app: { isPackaged: true } }), { virtual: true });
+    const origResources = process.resourcesPath;
+    process.resourcesPath = "/mock/resources";
+    try {
+      const { getSiteDistDir } = require("../../src/main/siteBundle");
+      expect(getSiteDistDir()).toBe(path.join("/mock/resources", "site"));
+    } finally {
+      if (origResources === undefined) delete process.resourcesPath;
+      else process.resourcesPath = origResources;
+      // Restore original mock for remaining tests
+      jest.resetModules();
+      jest.mock("electron", () => ({ app: { isPackaged: false } }), { virtual: true });
+    }
+  });
+});
+
 describe("buildEncryptedBuildFile", () => {
   test("returns filePath and content", () => {
     const result = buildEncryptedBuildFile({ title: "Test" }, "abc12345", "someBase64urlKey_that_is_43_chars_longAAAAA");


### PR DESCRIPTION
## Summary
The `build-local.md` and `release.md` build scripts both run `rm -rf dist/` (deleting `dist/site`) but then skip `npm run build:site` before running `electron-builder`. This means the `extraResources` config that copies `dist/site` → `resources/site/` has nothing to copy, so the packaged app has no site bundle. When `setupRepoPages` calls `buildSpaBundle()`, it throws "Site not built" because `resources/site/` doesn't exist.

**Fix:** Added `npm run build:site` to the build step in both `build-local.md` and `release.md`, matching the pattern already used by `build:app` / `build:app:linux` / `build:app:win` in package.json. Also updated the `build-and-notify` agent memory to reflect the correct command, and exported `getSiteDistDir` for test coverage of the packaged path resolution.

Closes #72