### PR TITLE
fix: include pet skills in petDisplay so SPA shows ranger F2 skills (closes #77)

### DIFF
--- a/src/main/buildPublish.js
+++ b/src/main/buildPublish.js
@@ -518,7 +518,9 @@ function serializeForPublish(build, catalog, upgradeCatalog) {
   const petById = new Map(petsArray.map((p) => [p.id, p]));
   const petDisplay = petIds.map((id) => {
     const pet = petById.get(id);
-    return pet ? { id: pet.id, name: pet.name, icon: pet.icon } : { id, name: "", icon: "" };
+    return pet
+      ? { id: pet.id, name: pet.name, icon: pet.icon, skills: pet.skills || [] }
+      : { id, name: "", icon: "", skills: [] };
   });
 
   // Legend display for Revenant

--- a/src/site/render-build.js
+++ b/src/site/render-build.js
@@ -153,7 +153,7 @@ function populateStateFromBuild(build) {
     legendById:         new Map((build.legendDisplay || []).map(l => [l.id, {
       id: l.id, name: l.name, icon: l.icon, swap: l.swap?.id || null,
     }])),
-    pets:               (build.petDisplay || []).map(p => ({ id: p.id, name: p.name, icon: p.icon })),
+    pets:               (build.petDisplay || []).map(p => ({ id: p.id, name: p.name, icon: p.icon, skills: p.skills || [] })),
     petById:            new Map((build.petDisplay || []).map(p => [p.id, p])),
     professionWeapons:  build.professionWeapons || {},
   };

--- a/tests/unit/buildPublish.test.js
+++ b/tests/unit/buildPublish.test.js
@@ -442,6 +442,31 @@ describe("serializeForPublish", () => {
     expect(result.computedStats).toHaveProperty("ConditionDuration");
   });
 
+  test("petDisplay includes pet skills array for Ranger builds", () => {
+    const build = {
+      ...makeMockBuild(),
+      profession: "Ranger",
+      selectedPets: { terrestrial1: 1, terrestrial2: 5, aquatic1: 0, aquatic2: 0 },
+    };
+    const catalog = {
+      ...makeMockCatalog(),
+      pets: [
+        { id: 1, name: "Juvenile Black Bear", icon: "bear.png", type: "terrestrial",
+          skills: [{ id: 12478, name: "Bite", description: "Bite foe", icon: "bite.png" }] },
+        { id: 5, name: "Juvenile Hyena", icon: "hyena.png", type: "terrestrial",
+          skills: [{ id: 12461, name: "Howl", description: "Howl at foe", icon: "howl.png" }] },
+      ],
+    };
+    const result = serializeForPublish(build, catalog, null);
+    expect(result.petDisplay).toHaveLength(2);
+    // Each pet in petDisplay must include its skills array
+    expect(result.petDisplay[0].skills).toBeDefined();
+    expect(result.petDisplay[0].skills).toHaveLength(1);
+    expect(result.petDisplay[0].skills[0].id).toBe(12478);
+    expect(result.petDisplay[1].skills).toBeDefined();
+    expect(result.petDisplay[1].skills[0].id).toBe(12461);
+  });
+
   test("waterSkills contains aquatic weapon sets and excludes NoUnderwater mechanics", () => {
     const catalog = makeMockCatalog();
     // Add a NoUnderwater mechanic


### PR DESCRIPTION
## Summary

When serializing a build for the SPA, `petDisplay` only included `{ id, name, icon }` — the pet's `skills` array was stripped out. The shared renderer in `skills.js` reads `activePet.skills` to resolve the F2 pet skill, so on the SPA it always resolved to `null`.

This fix includes the pet `skills` array in `petDisplay` (in `buildPublish.js`) and preserves it when populating `activeCatalog.pets` (in `render-build.js`).

Closes #77