### PR TITLE
feat: persist publish ticker status per-build and per-comp (closes #79)

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -485,7 +485,7 @@ app.whenReady().then(async () => {
 
   ipcMain.handle("builds:publish-build", async (event, buildId) => {
     const sender = event.sender;
-    const progress = (step) => sender.send("publish-progress", step);
+    const progress = (step) => sender.send("publish-progress", { id: buildId, step });
 
     const session = await getSession();
     if (!session) {
@@ -597,7 +597,7 @@ app.whenReady().then(async () => {
 
   ipcMain.handle("comps:publish-comp", async (event, compId, boonCoverageHtml) => {
     const sender = event.sender;
-    const progress = (step) => sender.send("publish-progress", step);
+    const progress = (step) => sender.send("publish-progress", { id: compId, step });
 
     const session = await getSession();
     if (!session) throw new Error("You must log in with GitHub before publishing.");

--- a/src/renderer/modules/comps/comp-detail.js
+++ b/src/renderer/modules/comps/comp-detail.js
@@ -10,6 +10,7 @@ import {
   showPublishResult,
   completeAllPublishSteps,
   setPublishStatusEl,
+  restorePublishProgress,
 } from "../render-pages.js";
 import { roleBadgeHtml } from "../roleEstimator.js";
 import { axiforgeIcon, checkIcon, chevronDownIcon, arrowUpTrayIcon, clipboardDocumentIcon, globeAltIcon } from "../library/heroicons.js";
@@ -861,7 +862,8 @@ function bindDetailEvents(container, comp) {
     const compEl = container.querySelector("#compPublishStatus");
     if (compEl) setPublishStatusEl(compEl);
     try {
-      showPublishProgress();
+      state.publishProgress[comp.id] = { currentStep: "saving" };
+      showPublishProgress(comp.id);
       // Pre-compute boon coverage HTML to include in the published payload
       let boonCoverageHtml = "";
       try {
@@ -873,18 +875,32 @@ function bindDetailEvents(container, comp) {
       const result = await window.desktopApi.publishComp(comp.id, boonCoverageHtml);
       advancePublishStep("pages");
       if (result?.pagesUrl) {
+        state.publishProgress[comp.id] = { ...state.publishProgress[comp.id], result: result.pagesUrl };
         await window.desktopApi.writeClipboardText(result.pagesUrl);
         showPublishResult(result.pagesUrl);
       } else {
+        state.publishProgress[comp.id] = { ...state.publishProgress[comp.id], result: "complete" };
         completeAllPublishSteps();
       }
       state.comps = await window.desktopApi.listComps();
       const pubLinkEl = container.querySelector("[data-action='copy-published-link']");
       if (pubLinkEl) { pubLinkEl.disabled = false; pubLinkEl.removeAttribute("title"); }
     } catch (err) {
+      if (state.publishProgress[comp.id]) {
+        state.publishProgress[comp.id].error = { step: "loading", message: err.message };
+      }
       failPublishStep("loading", err.message);
     }
   });
+
+  // ── Restore publish status if comp has active publish state ─────────────────
+  if (state.publishProgress[comp.id]) {
+    const compEl = container.querySelector("#compPublishStatus");
+    if (compEl) {
+      setPublishStatusEl(compEl);
+      restorePublishProgress(comp.id);
+    }
+  }
 
   // ── Share dropdown ──────────────────────────────────────────────────────────
   const shareDropdown = container.querySelector(".comp-share-dropdown");

--- a/src/renderer/modules/render-pages.js
+++ b/src/renderer/modules/render-pages.js
@@ -268,7 +268,8 @@ export function renderBuildList() {
       try {
         publishBtn.disabled = true;
         publishBtn.textContent = "Publishing...";
-        showPublishProgress();
+        state.publishProgress[build.id] = { currentStep: "saving" };
+        showPublishProgress(build.id);
         advancePublishStep("saving");
 
         if (build.id === state.editor.id && state.editorDirty) {
@@ -282,9 +283,11 @@ export function renderBuildList() {
         advancePublishStep("pages");
 
         if (result?.pagesUrl) {
+          state.publishProgress[build.id] = { ...state.publishProgress[build.id], result: result.pagesUrl };
           await window.desktopApi.writeClipboardText(result.pagesUrl);
           showPublishResult(result.pagesUrl);
         } else {
+          state.publishProgress[build.id] = { ...state.publishProgress[build.id], result: "complete" };
           completeAllPublishSteps();
         }
 
@@ -292,6 +295,9 @@ export function renderBuildList() {
         renderBuildList();
         renderEditorMeta();
       } catch (err) {
+        if (state.publishProgress[build.id]) {
+          state.publishProgress[build.id].error = { step: "saving", message: err.message };
+        }
         showError(err);
       } finally {
         publishBtn.disabled = false;
@@ -507,7 +513,23 @@ export async function startLoginFlow() {
 export function setPublishStatusEl(el) { _el.publishStatus = el; }
 
 export function setPublishStatus(message) {
+  // Don't overwrite an active publish ticker
+  const pid = _el.publishStatus.dataset.publishId;
+  if (pid && state.publishProgress[pid]) return;
   _el.publishStatus.textContent = message || "";
+}
+
+export function getPublishTargetId() {
+  return _el.publishStatus?.dataset?.publishId || null;
+}
+
+export function syncPublishStatus(id) {
+  if (id && state.publishProgress[id]) {
+    restorePublishProgress(id);
+  } else {
+    _el.publishStatus.innerHTML = "";
+    delete _el.publishStatus.dataset.publishId;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -529,15 +551,21 @@ const PUBLISH_STEPS = [
 // Ticker row height must match CSS --ticker-row-h (20px)
 const TICKER_ROW_H = 20;
 
-export function showPublishProgress() {
+export function showPublishProgress(id) {
   _el.publishStatus.innerHTML = "";
+  if (id) _el.publishStatus.dataset.publishId = id;
 
   // Dismiss button
   const dismiss = document.createElement("button");
   dismiss.className = "publish-status__dismiss";
   dismiss.textContent = "\u00d7";
   dismiss.title = "Dismiss";
-  dismiss.addEventListener("click", () => { _el.publishStatus.innerHTML = ""; });
+  dismiss.addEventListener("click", () => {
+    const pid = _el.publishStatus.dataset.publishId;
+    if (pid) delete state.publishProgress[pid];
+    _el.publishStatus.innerHTML = "";
+    delete _el.publishStatus.dataset.publishId;
+  });
 
   // Ticker window — shows 3 rows: prev (done), current (active), next (pending)
   const ticker = document.createElement("div");
@@ -745,6 +773,31 @@ async function pollPageLive(url, resultSlot) {
   // Timeout — show URL anyway
   completeAllPublishSteps();
   _showUrlResult(url, resultSlot);
+}
+
+// ---------------------------------------------------------------------------
+// restorePublishProgress — rebuild ticker UI from state.publishProgress
+// ---------------------------------------------------------------------------
+export function restorePublishProgress(id) {
+  const entry = state.publishProgress[id];
+  if (!entry) {
+    _el.publishStatus.innerHTML = "";
+    delete _el.publishStatus.dataset.publishId;
+    return;
+  }
+  showPublishProgress(id);
+  if (entry.error) {
+    // Advance to the error step first so prior steps show as done
+    advancePublishStep(entry.error.step);
+    failPublishStep(entry.error.step, entry.error.message);
+  } else if (entry.result) {
+    completeAllPublishSteps();
+    if (entry.result !== "complete") {
+      showPublishResult(entry.result);
+    }
+  } else if (entry.currentStep) {
+    advancePublishStep(entry.currentStep);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -60,6 +60,8 @@ export const state = {
   detail: null,
   wikiCache: new Map(),
   openCustomSelect: null,
+  // Per-build/comp publish progress: { [id]: { currentStep, result, error } }
+  publishProgress: {},
 };
 
 export function createEmptyEditor(profession = "", gameMode = "pve") {

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -38,7 +38,7 @@ import {
   render, renderEditor, renderEditorForm, renderEditorMeta, renderBuildList,
   setPublishStatus, showError, runPagesBuildPoll, getSelectedTarget,
   showPublishProgress, advancePublishStep, completeAllPublishSteps,
-  failPublishStep, showPublishResult,
+  failPublishStep, showPublishResult, getPublishTargetId, syncPublishStatus,
 } from "./modules/render-pages.js";
 import { resolveEntityFacts } from "./modules/detail-panel.js";
 import { initWikiModal, openWikiModal } from "./modules/wiki-modal.js";
@@ -589,6 +589,8 @@ function navigateToPage(page) {
   }
   // Redraw spec connectors when editor page becomes visible (they need layout dimensions)
   if (page === "editor") {
+    // Restore publish ticker for the current editor build (if any active publish)
+    syncPublishStatus(state.editor.id);
     requestAnimationFrame(() => {
       document.querySelectorAll(".spec-card__body").forEach((body) => drawSpecConnector(body));
     });
@@ -679,39 +681,52 @@ function wireEvents() {
   });
 
   // Listen for publish progress events from main process
-  window.desktopApi.onPublishProgress((step) => {
-    advancePublishStep(step);
+  window.desktopApi.onPublishProgress((payload) => {
+    const id = typeof payload === "object" ? payload.id : null;
+    const step = typeof payload === "object" ? payload.step : payload;
+    // Store in per-ID state
+    if (id && state.publishProgress[id]) {
+      state.publishProgress[id].currentStep = step;
+    }
+    // Only advance the visible ticker if it matches the current target
+    if (!id || id === getPublishTargetId()) {
+      advancePublishStep(step);
+    }
   });
 
   el.publishSiteBtn.addEventListener("click", async () => {
-    if (!state.editor.id) {
+    const buildId = state.editor.id;
+    if (!buildId) {
       showError(new Error("Save the build first before publishing."));
       return;
     }
     let lastStep = "saving";
     try {
       el.publishSiteBtn.disabled = true;
-      showPublishProgress();
+      state.publishProgress[buildId] = { currentStep: "saving" };
+      showPublishProgress(buildId);
       advancePublishStep("saving");
 
       if (state.editorDirty) {
         const serialized = serializeEditorToBuild();
-        await window.desktopApi.saveBuild({ ...serialized, id: state.editor.id });
+        await window.desktopApi.saveBuild({ ...serialized, id: buildId });
         state.builds = await window.desktopApi.listBuilds();
         captureEditorBaseline();
       }
 
       // The main process sends progress events for loading, repo, site, encrypt, upload, deploy
-      const result = await window.desktopApi.publishBuild(state.editor.id);
+      const result = await window.desktopApi.publishBuild(buildId);
 
       // Mark all upload steps done, advance to Pages polling
       advancePublishStep("pages");
 
       if (result?.pagesUrl) {
+        state.publishProgress[buildId] = { ...state.publishProgress[buildId], result: result.pagesUrl };
         await window.desktopApi.writeClipboardText(result.pagesUrl);
         // showPublishResult marks "pages" done and polls until live
         showPublishResult(result.pagesUrl);
       } else {
+        state.publishProgress[buildId] = { ...state.publishProgress[buildId], result: "complete" };
         completeAllPublishSteps();
       }
 
@@ -719,6 +734,9 @@ function wireEvents() {
       renderBuildList();
       renderEditorMeta();
     } catch (err) {
+      if (state.publishProgress[buildId]) {
+        state.publishProgress[buildId].error = { step: lastStep, message: err.message };
+      }
       failPublishStep(lastStep, err.message);
       showError(err);
     } finally {

--- a/tests/unit/renderer/publish-progress.test.js
+++ b/tests/unit/renderer/publish-progress.test.js
@@ -1,0 +1,249 @@
+"use strict";
+
+// Tests for per-build/comp publish progress tracking (issue #79).
+// render-pages.js uses ES module imports — transformed by babel-jest.
+
+let renderPages;
+let stateModule;
+
+// Minimal DOM mock for the publish ticker
+function makeStatusEl() {
+  const children = [];
+  return {
+    innerHTML: "",
+    textContent: "",
+    dataset: {},
+    append(...els) { children.push(...els); },
+    querySelector(sel) {
+      // Return a mock strip with rows for advancePublishStep
+      if (sel === ".publish-ticker__strip") {
+        return makeMockStrip();
+      }
+      if (sel === ".publish-result") {
+        return { innerHTML: "", querySelector: () => null, append() {} };
+      }
+      if (sel === ".publish-ticker") {
+        return { style: {} };
+      }
+      return null;
+    },
+    _children: children,
+  };
+}
+
+function makeMockStrip() {
+  const rows = [
+    "saving", "loading", "repo", "site", "builds", "encrypt", "upload", "deploy", "pages",
+  ].map((key) => ({
+    dataset: { publishStep: key },
+    classList: {
+      _classes: new Set(["publish-ticker__row--pending"]),
+      add(c) { this._classes.add(c); },
+      remove(...cs) { cs.forEach((c) => this._classes.delete(c)); },
+      contains(c) { return this._classes.has(c); },
+    },
+    querySelector: () => ({ textContent: "", innerHTML: "" }),
+    innerHTML: "",
+    append() {},
+  }));
+  return {
+    querySelectorAll(sel) {
+      if (sel === "[data-publish-step]") return rows;
+      return [];
+    },
+    querySelector(sel) {
+      const match = sel.match(/\[data-publish-step="(\w+)"\]/);
+      if (match) return rows.find((r) => r.dataset.publishStep === match[1]) || null;
+      return null;
+    },
+    style: {},
+    _rows: rows,
+  };
+}
+
+// Mock document.createElement used by showPublishProgress
+function setupDocumentMock() {
+  global.document = {
+    createElement(tag) {
+      const children = [];
+      return {
+        tagName: tag.toUpperCase(),
+        className: "",
+        textContent: "",
+        innerHTML: "",
+        title: "",
+        value: "",
+        readOnly: false,
+        dataset: {},
+        style: {},
+        classList: {
+          _classes: new Set(),
+          add(c) { this._classes.add(c); },
+          remove(c) { this._classes.delete(c); },
+          toggle(c) { if (this._classes.has(c)) { this._classes.delete(c); return false; } else { this._classes.add(c); return true; } },
+          contains(c) { return this._classes.has(c); },
+        },
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        append(...els) { children.push(...els); },
+        appendChild(el) { children.push(el); return el; },
+        querySelector() { return null; },
+        querySelectorAll() { return []; },
+        select() {},
+        _children: children,
+      };
+    },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+  };
+
+  global.location = { port: "", hostname: "app" };
+}
+
+beforeAll(() => {
+  setupDocumentMock();
+  // window.desktopApi stubs
+  global.window = {
+    desktopApi: {
+      writeClipboardText: jest.fn(),
+      pollPagesStatus: jest.fn().mockResolvedValue({ ready: false }),
+      openPreviewWindow: jest.fn(),
+    },
+  };
+  stateModule = require("../../../src/renderer/modules/state");
+  renderPages = require("../../../src/renderer/modules/render-pages");
+});
+
+beforeEach(() => {
+  // Reset publish progress state
+  const { state } = stateModule;
+  for (const key of Object.keys(state.publishProgress)) {
+    delete state.publishProgress[key];
+  }
+  // Re-inject a fresh status element
+  const el = makeStatusEl();
+  renderPages.initRenderPagesDom({ publishStatus: el });
+});
+
+describe("per-ID publish progress", () => {
+  test("state.publishProgress starts empty", () => {
+    const { state } = stateModule;
+    expect(state.publishProgress).toBeDefined();
+    expect(Object.keys(state.publishProgress)).toHaveLength(0);
+  });
+
+  test("showPublishProgress(id) sets data-publish-id on the element", () => {
+    const statusEl = makeStatusEl();
+    renderPages.initRenderPagesDom({ publishStatus: statusEl });
+    renderPages.showPublishProgress("build-123");
+    expect(statusEl.dataset.publishId).toBe("build-123");
+  });
+
+  test("getPublishTargetId returns the current data-publish-id", () => {
+    const statusEl = makeStatusEl();
+    renderPages.initRenderPagesDom({ publishStatus: statusEl });
+    expect(renderPages.getPublishTargetId()).toBeFalsy();
+    renderPages.showPublishProgress("build-abc");
+    expect(renderPages.getPublishTargetId()).toBe("build-abc");
+  });
+
+  test("setPublishStatus is no-op when active publish exists for current element", () => {
+    const { state } = stateModule;
+    const statusEl = makeStatusEl();
+    renderPages.initRenderPagesDom({ publishStatus: statusEl });
+
+    // Set up active publish
+    state.publishProgress["build-x"] = { currentStep: "loading" };
+    statusEl.dataset.publishId = "build-x";
+
+    renderPages.setPublishStatus("Some message");
+    // textContent should NOT be set since active publish blocks it
+    expect(statusEl.textContent).toBe("");
+  });
+
+  test("setPublishStatus works when no active publish for current element", () => {
+    const statusEl = makeStatusEl();
+    renderPages.initRenderPagesDom({ publishStatus: statusEl });
+
+    renderPages.setPublishStatus("Build duplicated.");
+    expect(statusEl.textContent).toBe("Build duplicated.");
+  });
+
+  test("syncPublishStatus restores active publish or clears", () => {
+    const { state } = stateModule;
+    const statusEl = makeStatusEl();
+    renderPages.initRenderPagesDom({ publishStatus: statusEl });
+
+    // No active publish — should clear
+    renderPages.syncPublishStatus("build-999");
+    expect(statusEl.innerHTML).toBe("");
+    expect(statusEl.dataset.publishId).toBeUndefined();
+
+    // With active publish — should populate (showPublishProgress + advancePublishStep)
+    state.publishProgress["build-999"] = { currentStep: "repo" };
+    renderPages.syncPublishStatus("build-999");
+    expect(statusEl.dataset.publishId).toBe("build-999");
+  });
+
+  test("restorePublishProgress with error state", () => {
+    const { state } = stateModule;
+    const statusEl = makeStatusEl();
+    renderPages.initRenderPagesDom({ publishStatus: statusEl });
+
+    state.publishProgress["build-err"] = {
+      currentStep: "loading",
+      error: { step: "loading", message: "Network error" },
+    };
+    renderPages.restorePublishProgress("build-err");
+    expect(statusEl.dataset.publishId).toBe("build-err");
+  });
+
+  test("restorePublishProgress with completed result clears to done state", () => {
+    const { state } = stateModule;
+    const statusEl = makeStatusEl();
+    renderPages.initRenderPagesDom({ publishStatus: statusEl });
+
+    state.publishProgress["build-done"] = {
+      currentStep: "pages",
+      result: "complete",
+    };
+    renderPages.restorePublishProgress("build-done");
+    expect(statusEl.dataset.publishId).toBe("build-done");
+  });
+
+  test("restorePublishProgress with no entry clears the element", () => {
+    const statusEl = makeStatusEl();
+    statusEl.innerHTML = "<div>old content</div>";
+    statusEl.dataset.publishId = "old-id";
+    renderPages.initRenderPagesDom({ publishStatus: statusEl });
+
+    renderPages.restorePublishProgress("nonexistent-id");
+    expect(statusEl.innerHTML).toBe("");
+    expect(statusEl.dataset.publishId).toBeUndefined();
+  });
+
+  test("independent builds have separate publish progress entries", () => {
+    const { state } = stateModule;
+
+    state.publishProgress["build-a"] = { currentStep: "encrypt" };
+    state.publishProgress["build-b"] = { currentStep: "saving" };
+
+    expect(state.publishProgress["build-a"].currentStep).toBe("encrypt");
+    expect(state.publishProgress["build-b"].currentStep).toBe("saving");
+
+    // Updating one doesn't affect the other
+    state.publishProgress["build-a"].currentStep = "upload";
+    expect(state.publishProgress["build-a"].currentStep).toBe("upload");
+    expect(state.publishProgress["build-b"].currentStep).toBe("saving");
+  });
+
+  test("independent comps have separate publish progress entries", () => {
+    const { state } = stateModule;
+
+    state.publishProgress["comp-1"] = { currentStep: "builds" };
+    state.publishProgress["comp-2"] = { currentStep: "repo" };
+
+    expect(state.publishProgress["comp-1"].currentStep).toBe("builds");
+    expect(state.publishProgress["comp-2"].currentStep).toBe("repo");
+  });
+});


### PR DESCRIPTION
## Summary

- Publish progress state is now stored per-build/comp ID in `state.publishProgress`, so each object tracks its own publish ticker independently
- Main process progress events include the build/comp ID, allowing the renderer to route updates to the correct target
- Navigating between builds in the editor or between comps restores the correct publish ticker from state
- The dismiss button clears state for that specific build/comp; text status messages don't overwrite an active publish ticker

Closes #79

## Test plan
- [ ] Publish a build from the editor, navigate to library and back — ticker should persist
- [ ] Publish build A, switch to build B — B should not show A's ticker; switch back to A — A's ticker restores
- [ ] Publish a comp, navigate away from comp detail and back — comp ticker should restore
- [ ] Dismiss a publish ticker — it should not reappear on navigation
- [ ] Verify existing publish flow still works end-to-end (build + comp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)