### PR TITLE
fix: Hammer Ranger (closes #51)

### DIFF
--- a/src/main/gw2Data/catalog.js
+++ b/src/main/gw2Data/catalog.js
@@ -34,6 +34,7 @@ const {
   LEGEND_FLIP_OVERRIDES,
   KNOWN_SKILL_ATTUNEMENT_OVERRIDES,
   EVOKER_F5_EXTRA_VARIANTS,
+  UNTAMED_UNLEASHED_AMBUSH,
 } = require("./overrides");
 
 const { getSkillSplit, getTraitSplit, getSkillPveFacts, getTraitPveFacts } = require("../../../lib/gw2-balance-splits");
@@ -358,6 +359,8 @@ async function getProfessionCatalog(professionId, lang = "en", gameMode = "pve")
     // - Specter Siphon (63067, spec=71) — not in Thief profession endpoint
     // - Shadow Shroud Enter/Exit (63155/63251) + weapon skills (for bundle display)
     ...(professionId === "Thief" ? [63067, 63155, 63251, ...SHADOW_SHROUD_BUNDLE] : []),
+    // Untamed Unleashed Ambush skills — trait-granted (Unleashed Power), not in profession endpoint.
+    ...(professionId === "Ranger" ? UNTAMED_UNLEASHED_AMBUSH : []),
     // Weapon auto-attack chain continuations (depth 1): merged here to avoid an extra round-trip.
     ...weaponChainDepth1Ids,
   ]);

--- a/src/main/gw2Data/overrides.js
+++ b/src/main/gw2Data/overrides.js
@@ -381,6 +381,24 @@ const KNOWN_SKILL_ATTUNEMENT_OVERRIDES = new Map([
 // mechanics so the F5 slot switches correctly when attunement changes.
 const EVOKER_F5_EXTRA_VARIANTS = [77225, 77370, 77226]; // Splash (Water), Zap (Air), Calcify (Earth)
 
+// Untamed (spec 72) Unleashed Ambush skills — trait-granted by Unleashed Power (trait 2268).
+// NOT listed in the Ranger profession endpoint; must be explicitly fetched so they appear
+// in the Weapon_1 slot when Unleash Ranger is active.
+const UNTAMED_UNLEASHED_AMBUSH = [
+  63129,  // Sundering Volley (Axe)
+  69223,  // Neurotoxin Burst (Dagger)
+  63350,  // Savage Slash (Greatsword)
+  63438,  // Relentless Whirl (Hammer)
+  63301,  // Jagged Fan (Harpoon gun / Speargun)
+  72079,  // Rampant Growth (Mace)
+  63225,  // Multishot (Longbow)
+  63326,  // Toxic Shot (Short bow)
+  72932,  // Ravager's Abandon (Spear, land)
+  63065,  // Vicious Pike (Spear, aquatic)
+  69175,  // Solar Brilliance (Staff)
+  63336,  // Deft Strike (Sword)
+];
+
 module.exports = {
   KNOWN_SKILL_DESCRIPTION_OVERRIDES,
   _IC,
@@ -413,4 +431,5 @@ module.exports = {
   LEGEND_FLIP_OVERRIDES,
   KNOWN_SKILL_ATTUNEMENT_OVERRIDES,
   EVOKER_F5_EXTRA_VARIANTS,
+  UNTAMED_UNLEASHED_AMBUSH,
 };

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -1518,8 +1518,8 @@ export function renderSkills() {
             } else if (isDragonTriggerToggle) {
               state.editor.activeKit = resolvedKit === 62803 ? 0 : 62803;
             } else if (isUnleashToggle) {
-              // Toggle between Unleash Ranger active (63147) and inactive (0)
-              state.editor.activeKit = activeKit === 63147 ? 0 : 63147;
+              // Three-state Unleash cycle: 0 → 63344 (Unleash Pet) → 63147 (Unleash Ranger) → 0
+              state.editor.activeKit = activeKit === 0 ? 63344 : activeKit === 63344 ? 63147 : 0;
             } else {
               state.editor.activeKit = resolvedKit === skill.id ? 0 : skill.id;
             }

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -579,20 +579,13 @@ export function buildMechanicSlotsForRender({
         });
       }
     } else if (eliteSpecId === 72) {
-      // Untamed: default state is Unleash Pet (normal pet bar: attack / pet F2 / return).
-      // Toggling F5 activates Unleash Ranger (activeKit=63147), which gives the pet empowered
-      // commands at F1-F3 (Venomous Outburst, Rending Vines, Enveloping Haze).
+      // Untamed: default state is Unleash Pet — pet is unleashed and gets empowered commands
+      // at F1-F3 (Venomous Outburst, Rending Vines, Enveloping Haze).
+      // Toggling F5 activates Unleash Ranger (activeKit=63147) — ranger gets unleashed weapon
+      // skills, pet reverts to normal controls (attack / pet F2 / return).
       const unleashRangerActive = activeKit === 63147;
       if (unleashRangerActive) {
-        // Unleash Ranger active: pet gets empowered commands
-        const venomousOutburst = catalog.skillById.get(63209) || null;
-        const rendingVines = catalog.skillById.get(63258) || null;
-        const envHaze = catalog.skillById.get(63094) || null;
-        mechSlots.push({ skill: venomousOutburst, sourceId: venomousOutburst?.id || 0, isStatic: true, isSelectable: false });
-        mechSlots.push({ skill: rendingVines, sourceId: rendingVines?.id || 0, isStatic: true, isSelectable: false });
-        mechSlots.push({ skill: envHaze, sourceId: envHaze?.id || 0, isStatic: true, isSelectable: false });
-      } else {
-        // Unleash Pet active (default): normal pet controls (attack / pet F2 / return)
+        // Unleash Ranger active: pet reverts to normal controls
         mechSlots.push({ skill: null, sourceId: 0, isStatic: true, isSelectable: false, fakeCommand: "attack" });
         const petSkills = activePet?.skills || [];
         const isAquaticSlot = activePetSlotKey === "aquatic1" || activePetSlotKey === "aquatic2";
@@ -600,6 +593,14 @@ export function buildMechanicSlotsForRender({
         const f2Skill = petSkills[f2SkillIdx] || null;
         mechSlots.push({ skill: f2Skill, sourceId: f2Skill?.id || 0, isStatic: true, isSelectable: false });
         mechSlots.push({ skill: null, sourceId: 0, isStatic: true, isSelectable: false, fakeCommand: "return" });
+      } else {
+        // Unleash Pet active (default): pet gets empowered commands
+        const venomousOutburst = catalog.skillById.get(63209) || null;
+        const rendingVines = catalog.skillById.get(63258) || null;
+        const envHaze = catalog.skillById.get(63094) || null;
+        mechSlots.push({ skill: venomousOutburst, sourceId: venomousOutburst?.id || 0, isStatic: true, isSelectable: false });
+        mechSlots.push({ skill: rendingVines, sourceId: rendingVines?.id || 0, isStatic: true, isSelectable: false });
+        mechSlots.push({ skill: envHaze, sourceId: envHaze?.id || 0, isStatic: true, isSelectable: false });
       }
     } else {
       mechSlots.push({ skill: null, sourceId: 0, isStatic: true, isSelectable: false, fakeCommand: "attack" });

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -292,6 +292,15 @@ export function getEquippedWeaponSkills(catalog, weapons, activeAttunement = "",
   return slots;
 }
 
+// Untamed: when Unleash Ranger is active, swap each weapon skill to its unleashed flip variant.
+export function applyUnleashWeaponFlip(catalog, weaponSkills) {
+  const wById = catalog?.weaponSkillById || new Map();
+  return weaponSkills.map((skill) => {
+    if (!skill?.flipSkill) return skill;
+    return wById.get(skill.flipSkill) || skill;
+  });
+}
+
 // Returns the offensive and defensive artifact pools for Antiquary's Skritt Swipe.
 // Currently the pools are fixed; hook is here for future trait-based modifications.
 export function getAntiquaryArtifactPools(_catalog, _editor) {
@@ -1235,6 +1244,11 @@ export function renderSkills() {
       mainhand: equippedWeapons[mhKey] || "",
       offhand: equippedWeapons[ohKey] || "",
     }, activeAttunement, activeAttunement2, isWeaver, false);
+  }
+
+  // Untamed: when Unleash Ranger is active, swap weapon skills to unleashed flip variants.
+  if (resolvedKit === 63147) {
+    weaponSkills = applyUnleashWeaponFlip(catalog, weaponSkills);
   }
 
   const weaponGroup = document.createElement("div");

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -292,29 +292,11 @@ export function getEquippedWeaponSkills(catalog, weapons, activeAttunement = "",
   return slots;
 }
 
-// Untamed: when Unleash Ranger is active, swap weapon skills to unleashed variants.
-// Weapon_1 (index 0) is replaced by the Unleashed Ambush skill for the current weapon type
-// (trait-granted from Unleashed Power, specialization=72, in skillById).
-// Weapons 2-5 are swapped to their unleashed flip variants via flipSkill in weaponSkillById.
+// Untamed: when Unleash Ranger is active, swap each weapon skill to its unleashed flip variant.
 export function applyUnleashWeaponFlip(catalog, weaponSkills) {
   const wById = catalog?.weaponSkillById || new Map();
-  return weaponSkills.map((skill, i) => {
-    if (!skill) return skill;
-    // Weapon_1: find the Unleashed Ambush skill matching this weapon type.
-    if (i === 0) {
-      const wt = (skill.weaponType || "").toLowerCase();
-      if (wt && catalog?.skillById) {
-        for (const s of catalog.skillById.values()) {
-          if (s.slot === "Weapon_1" && Number(s.specialization) === 72
-              && (s.weaponType || "").toLowerCase() === wt) {
-            return s;
-          }
-        }
-      }
-      return skill;
-    }
-    // Slots 2-5: swap via flipSkill to unleashed weapon skill variants.
-    if (!skill.flipSkill) return skill;
+  return weaponSkills.map((skill) => {
+    if (!skill?.flipSkill) return skill;
     return wById.get(skill.flipSkill) || skill;
   });
 }

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -292,11 +292,29 @@ export function getEquippedWeaponSkills(catalog, weapons, activeAttunement = "",
   return slots;
 }
 
-// Untamed: when Unleash Ranger is active, swap each weapon skill to its unleashed flip variant.
+// Untamed: when Unleash Ranger is active, swap weapon skills to unleashed variants.
+// Weapon_1 (index 0) is replaced by the Unleashed Ambush skill for the current weapon type
+// (trait-granted from Unleashed Power, specialization=72, in skillById).
+// Weapons 2-5 are swapped to their unleashed flip variants via flipSkill in weaponSkillById.
 export function applyUnleashWeaponFlip(catalog, weaponSkills) {
   const wById = catalog?.weaponSkillById || new Map();
-  return weaponSkills.map((skill) => {
-    if (!skill?.flipSkill) return skill;
+  return weaponSkills.map((skill, i) => {
+    if (!skill) return skill;
+    // Weapon_1: find the Unleashed Ambush skill matching this weapon type.
+    if (i === 0) {
+      const wt = (skill.weaponType || "").toLowerCase();
+      if (wt && catalog?.skillById) {
+        for (const s of catalog.skillById.values()) {
+          if (s.slot === "Weapon_1" && Number(s.specialization) === 72
+              && (s.weaponType || "").toLowerCase() === wt) {
+            return s;
+          }
+        }
+      }
+      return skill;
+    }
+    // Slots 2-5: swap via flipSkill to unleashed weapon skill variants.
+    if (!skill.flipSkill) return skill;
     return wById.get(skill.flipSkill) || skill;
   });
 }

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -579,13 +579,21 @@ export function buildMechanicSlotsForRender({
         });
       }
     } else if (eliteSpecId === 72) {
-      // Untamed: default state is Unleash Pet — pet is unleashed and gets empowered commands
-      // at F1-F3 (Venomous Outburst, Rending Vines, Enveloping Haze).
-      // Toggling F5 activates Unleash Ranger (activeKit=63147) — ranger gets unleashed weapon
-      // skills, pet reverts to normal controls (attack / pet F2 / return).
-      const unleashRangerActive = activeKit === 63147;
-      if (unleashRangerActive) {
-        // Unleash Ranger active: pet reverts to normal controls
+      // Untamed three-state F5 cycle:
+      //   Default (activeKit=0):     F5="Unleash Pet",    normal pet,     normal weapons
+      //   Unleash Pet (kit=63344):   F5="Unleash Ranger", unleashed pet,  normal weapons
+      //   Unleash Ranger (kit=63147):F5="Unleash Pet",    normal pet,     unleashed weapons
+      const unleashPetActive = activeKit === 63344;
+      if (unleashPetActive) {
+        // Unleash Pet active: pet gets empowered commands
+        const venomousOutburst = catalog.skillById.get(63209) || null;
+        const rendingVines = catalog.skillById.get(63258) || null;
+        const envHaze = catalog.skillById.get(63094) || null;
+        mechSlots.push({ skill: venomousOutburst, sourceId: venomousOutburst?.id || 0, isStatic: true, isSelectable: false });
+        mechSlots.push({ skill: rendingVines, sourceId: rendingVines?.id || 0, isStatic: true, isSelectable: false });
+        mechSlots.push({ skill: envHaze, sourceId: envHaze?.id || 0, isStatic: true, isSelectable: false });
+      } else {
+        // Default or Unleash Ranger: normal pet controls
         mechSlots.push({ skill: null, sourceId: 0, isStatic: true, isSelectable: false, fakeCommand: "attack" });
         const petSkills = activePet?.skills || [];
         const isAquaticSlot = activePetSlotKey === "aquatic1" || activePetSlotKey === "aquatic2";
@@ -593,14 +601,6 @@ export function buildMechanicSlotsForRender({
         const f2Skill = petSkills[f2SkillIdx] || null;
         mechSlots.push({ skill: f2Skill, sourceId: f2Skill?.id || 0, isStatic: true, isSelectable: false });
         mechSlots.push({ skill: null, sourceId: 0, isStatic: true, isSelectable: false, fakeCommand: "return" });
-      } else {
-        // Unleash Pet active (default): pet gets empowered commands
-        const venomousOutburst = catalog.skillById.get(63209) || null;
-        const rendingVines = catalog.skillById.get(63258) || null;
-        const envHaze = catalog.skillById.get(63094) || null;
-        mechSlots.push({ skill: venomousOutburst, sourceId: venomousOutburst?.id || 0, isStatic: true, isSelectable: false });
-        mechSlots.push({ skill: rendingVines, sourceId: rendingVines?.id || 0, isStatic: true, isSelectable: false });
-        mechSlots.push({ skill: envHaze, sourceId: envHaze?.id || 0, isStatic: true, isSelectable: false });
       }
     } else {
       mechSlots.push({ skill: null, sourceId: 0, isStatic: true, isSelectable: false, fakeCommand: "attack" });
@@ -613,12 +613,12 @@ export function buildMechanicSlotsForRender({
     }
     if (eliteSpecId !== 55) {
       if (eliteSpecId === 72) {
-        // Untamed: F5 is a toggle between "Unleash Ranger" (63147) and "Unleash Pet" (63344).
+        // Untamed: F5 cycles through 3 states. Show the next action:
+        //   Default (kit=0) → "Unleash Pet";  Unleash Pet (kit=63344) → "Unleash Ranger";
+        //   Unleash Ranger (kit=63147) → "Unleash Pet".
         const unleashRanger = catalog.skillById.get(63147) || null;
         const unleashPet = catalog.skillById.get(63344) || null;
-        const unleashRangerActive = activeKit === 63147;
-        // Show current state: default = Unleash Pet, toggled = Unleash Ranger
-        const displaySkill = unleashRangerActive ? unleashRanger : unleashPet;
+        const displaySkill = activeKit === 63344 ? unleashRanger : unleashPet;
         if (displaySkill) {
           mechSlots.push({
             skill: displaySkill, sourceId: displaySkill.id, isStatic: true, isSelectable: false,
@@ -1218,7 +1218,7 @@ export function renderSkills() {
     const isEquippedSlotKit = (kitSkill?.bundleSkills?.length ?? 0) > 0 && equippedIds.has(activeKit);
     // Soulbeast Beastmode / Untamed Unleash have no bundle_skills in the API; allow them to persist.
     const isBeastmodeKit = mechSlots.some((s) => s.isBeastmodeToggle && s.skill?.id === activeKit);
-    const isUnleashKit = mechSlots.some((s) => s.isUnleashToggle) && activeKit === 63147;
+    const isUnleashKit = mechSlots.some((s) => s.isUnleashToggle) && (activeKit === 63147 || activeKit === 63344);
     const isBerserkKit = mechSlots.some((s) => s.isBerserkToggle && s.skill?.id === activeKit);
     // Bladesworn: Gunsaber (62745) and Dragon Trigger (62803) are both valid active kits; the
     // displayed skill changes to the flip variant when active so we can't match by skill.id.

--- a/tests/fixtures/gw2Api.js
+++ b/tests/fixtures/gw2Api.js
@@ -627,6 +627,19 @@ const MOCK_SKILLS = {
   // Untamed F5 toggle
   63147: makeSkill(63147, { name: "Unleash Ranger", slot: "Profession_5", type: "Profession", specialization: 72, professions: ["Ranger"] }),
   63344: makeSkill(63344, { name: "Unleash Pet",    slot: "Profession_5", type: "Profession", specialization: 72, professions: ["Ranger"] }),
+  // Untamed Unleashed Ambush skills (trait-granted from Unleashed Power, trait 2268)
+  63438: makeSkill(63438, { name: "Relentless Whirl",    slot: "Weapon_1", type: "Weapon", weapon_type: "Hammer",   specialization: 72, professions: ["Ranger"] }),
+  63129: makeSkill(63129, { name: "Sundering Volley",    slot: "Weapon_1", type: "Weapon", weapon_type: "Axe",      specialization: 72, professions: ["Ranger"] }),
+  69223: makeSkill(69223, { name: "Neurotoxin Burst",    slot: "Weapon_1", type: "Weapon", weapon_type: "Dagger",   specialization: 72, professions: ["Ranger"] }),
+  63350: makeSkill(63350, { name: "Savage Slash",        slot: "Weapon_1", type: "Weapon", weapon_type: "Greatsword", specialization: 72, professions: ["Ranger"] }),
+  72079: makeSkill(72079, { name: "Rampant Growth",      slot: "Weapon_1", type: "Weapon", weapon_type: "Mace",     specialization: 72, professions: ["Ranger"] }),
+  63336: makeSkill(63336, { name: "Deft Strike",         slot: "Weapon_1", type: "Weapon", weapon_type: "Sword",    specialization: 72, professions: ["Ranger"] }),
+  63225: makeSkill(63225, { name: "Multishot",           slot: "Weapon_1", type: "Weapon", weapon_type: "Longbow",  specialization: 72, professions: ["Ranger"] }),
+  63326: makeSkill(63326, { name: "Toxic Shot",          slot: "Weapon_1", type: "Weapon", weapon_type: "Shortbow", specialization: 72, professions: ["Ranger"] }),
+  69175: makeSkill(69175, { name: "Solar Brilliance",    slot: "Weapon_1", type: "Weapon", weapon_type: "Staff",    specialization: 72, professions: ["Ranger"] }),
+  72932: makeSkill(72932, { name: "Ravager's Abandon",   slot: "Weapon_1", type: "Weapon", weapon_type: "Spear",    specialization: 72, professions: ["Ranger"] }),
+  63065: makeSkill(63065, { name: "Vicious Pike",        slot: "Weapon_1", type: "Weapon", weapon_type: "Spear",    specialization: 72, professions: ["Ranger"] }),
+  63301: makeSkill(63301, { name: "Jagged Fan",          slot: "Weapon_1", type: "Weapon", weapon_type: "Speargun", specialization: 72, professions: ["Ranger"] }),
 
   // ---- Thief ----
   13050: makeSkill(13050, { name: "Channeled Vigor", slot: "Heal", type: "Heal", professions: ["Thief"] }),

--- a/tests/integration/professions/ranger.test.js
+++ b/tests/integration/professions/ranger.test.js
@@ -65,21 +65,20 @@ describe("Ranger — end-to-end profession mechanics", () => {
     expect(soulbeast).toEqual(core);
   });
 
-  test("Untamed (spec 72) replaces F3 Return command with an empty profession skill slot", async () => {
+  test("Untamed (spec 72) default shows empowered pet commands at F1-F3", async () => {
     const catalog = await h.loadCatalog();
     const untamed = h.resolveMechSlots(catalog, 72);
-    // Default Untamed: Unleash Pet active → normal pet bar F1-F3 + Unleash Ranger F5
-    expect(untamed).toEqual(["fake:attack", "12478", "fake:return", "63344"]);
-    expect(untamed[2]).toBe("fake:return");
+    // Default Untamed: Unleash Pet active → empowered pet commands F1-F3 + F5 toggle
+    expect(untamed).toEqual(["63209", "63258", "63094", "63344"]);
   });
 
-  test("Untamed default has same F1-F3 as core (normal pet bar), but adds F5 Unleash", async () => {
+  test("Untamed default (Unleash Pet) shows empowered commands, not normal pet bar", async () => {
     const catalog = await h.loadCatalog();
     const core = h.resolveMechSlots(catalog, 0);
     const untamed = h.resolveMechSlots(catalog, 72);
-    // Default Untamed (Unleash Pet) has normal pet bar like core, plus F5
-    expect(untamed.slice(0, 3)).toEqual(core);
-    expect(untamed[3]).toBe("63344"); // Unleash Pet F5 (default state)
+    // Unleash Pet gives empowered commands, different from core's normal pet bar
+    expect(untamed.slice(0, 3)).not.toEqual(core);
+    expect(untamed[3]).toBe("63344"); // F5 toggle (current state: Unleash Pet)
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/integration/professions/ranger.test.js
+++ b/tests/integration/professions/ranger.test.js
@@ -65,20 +65,20 @@ describe("Ranger — end-to-end profession mechanics", () => {
     expect(soulbeast).toEqual(core);
   });
 
-  test("Untamed (spec 72) default shows empowered pet commands at F1-F3", async () => {
+  test("Untamed (spec 72) default shows normal pet bar at F1-F3 plus F5 toggle", async () => {
     const catalog = await h.loadCatalog();
     const untamed = h.resolveMechSlots(catalog, 72);
-    // Default Untamed: Unleash Pet active → empowered pet commands F1-F3 + F5 toggle
-    expect(untamed).toEqual(["63209", "63258", "63094", "63344"]);
+    // Default Untamed (nothing unleashed): normal pet bar F1-F3 + F5 Unleash Pet toggle
+    expect(untamed).toEqual(["fake:attack", "12478", "fake:return", "63344"]);
   });
 
-  test("Untamed default (Unleash Pet) shows empowered commands, not normal pet bar", async () => {
+  test("Untamed default has same F1-F3 as core (normal pet bar), plus F5 Unleash", async () => {
     const catalog = await h.loadCatalog();
     const core = h.resolveMechSlots(catalog, 0);
     const untamed = h.resolveMechSlots(catalog, 72);
-    // Unleash Pet gives empowered commands, different from core's normal pet bar
-    expect(untamed.slice(0, 3)).not.toEqual(core);
-    expect(untamed[3]).toBe("63344"); // F5 toggle (current state: Unleash Pet)
+    // Default (nothing unleashed) has normal pet bar like core, plus F5
+    expect(untamed.slice(0, 3)).toEqual(core);
+    expect(untamed[3]).toBe("63344"); // F5 = Unleash Pet (next action)
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/gw2Data.test.js
+++ b/tests/unit/gw2Data.test.js
@@ -882,6 +882,33 @@ describe("Ranger — pets catalog", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Ranger — Untamed Unleashed Ambush skills
+// ---------------------------------------------------------------------------
+
+describe("Ranger — Untamed Unleashed Ambush skills in catalog", () => {
+  beforeEach(() => { freshLoad(); global.fetch = createGw2MockFetch(); });
+  afterEach(() => { delete global.fetch; });
+
+  test("unleashed ambush skills are included in catalog.skills", async () => {
+    const catalog = await gw2Data.getProfessionCatalog("Ranger");
+    const ambushIds = [63438, 63129, 69223, 63350, 72079, 63336, 63225, 63326, 69175, 72932, 63065, 63301];
+    const skillIds = new Set(catalog.skills.map((s) => s.id));
+    for (const id of ambushIds) {
+      expect(skillIds.has(id)).toBe(true);
+    }
+  });
+
+  test("Relentless Whirl (63438) has correct weapon_type, slot, and specialization", async () => {
+    const catalog = await gw2Data.getProfessionCatalog("Ranger");
+    const skill = catalog.skills.find((s) => s.id === 63438);
+    expect(skill).toBeTruthy();
+    expect(skill.weaponType).toBe("Hammer");
+    expect(skill.slot).toBe("Weapon_1");
+    expect(skill.specialization).toBe(72);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Revenant — legends
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/renderer/ranger.test.js
+++ b/tests/unit/renderer/ranger.test.js
@@ -5,7 +5,7 @@ const { createMechanicsSuite, setupMechanicsHarness } = require("./mechanicsSuit
 createMechanicsSuite("Ranger", [
   { specId: 0, expected: ["fake:attack", "12478", "fake:return"] },
   { specId: 55, expected: ["fake:attack", "12478", "fake:return"] },
-  { specId: 72, expected: ["fake:attack", "12478", "fake:return", "63344"] },
+  { specId: 72, expected: ["63209", "63258", "63094", "63344"] },
 ]);
 
 describe("renderer mechanics selection — Ranger core vs elite F skills", () => {
@@ -22,9 +22,9 @@ describe("renderer mechanics selection — Ranger core vs elite F skills", () =>
     expect(soulbeast.signatures).toEqual(core.signatures);
   });
 
-  test("Untamed default (Unleash Pet) shows normal pet bar at F1-F3", async () => {
+  test("Untamed default (Unleash Pet) shows empowered pet commands at F1-F3", async () => {
     const untamed = await resolve({ specId: 72 });
-    expect(untamed.signatures).toEqual(["fake:attack", "12478", "fake:return", "63344"]);
+    expect(untamed.signatures).toEqual(["63209", "63258", "63094", "63344"]);
   });
 });
 
@@ -51,20 +51,20 @@ describe("renderer mechanics selection — Untamed F5 Unleash toggle", () => {
     expect(f5.skill.id).toBe(63147); // Unleash Ranger (current state)
   });
 
-  test("Unleash Ranger active shows empowered pet commands at F1-F3", async () => {
+  test("Unleash Ranger active shows normal pet commands at F1-F3", async () => {
     const unleashed = await resolve({ specId: 72, activeKit: 63147 });
     const sigs = unleashed.signatures;
-    expect(sigs[0]).toBe("63209"); // Venomous Outburst
-    expect(sigs[1]).toBe("63258"); // Rending Vines
-    expect(sigs[2]).toBe("63094"); // Enveloping Haze
-  });
-
-  test("Default state (Unleash Pet) shows normal pet commands at F1-F3", async () => {
-    const untamed = await resolve({ specId: 72 });
-    const sigs = untamed.signatures;
     expect(sigs[0]).toBe("fake:attack");
     expect(sigs[1]).toBe("12478");
     expect(sigs[2]).toBe("fake:return");
+  });
+
+  test("Default state (Unleash Pet) shows empowered pet commands at F1-F3", async () => {
+    const untamed = await resolve({ specId: 72 });
+    const sigs = untamed.signatures;
+    expect(sigs[0]).toBe("63209"); // Venomous Outburst
+    expect(sigs[1]).toBe("63258"); // Rending Vines
+    expect(sigs[2]).toBe("63094"); // Enveloping Haze
   });
 });
 

--- a/tests/unit/renderer/ranger.test.js
+++ b/tests/unit/renderer/ranger.test.js
@@ -5,7 +5,7 @@ const { createMechanicsSuite, setupMechanicsHarness } = require("./mechanicsSuit
 createMechanicsSuite("Ranger", [
   { specId: 0, expected: ["fake:attack", "12478", "fake:return"] },
   { specId: 55, expected: ["fake:attack", "12478", "fake:return"] },
-  { specId: 72, expected: ["63209", "63258", "63094", "63344"] },
+  { specId: 72, expected: ["fake:attack", "12478", "fake:return", "63344"] },
 ]);
 
 describe("renderer mechanics selection — Ranger core vs elite F skills", () => {
@@ -22,13 +22,13 @@ describe("renderer mechanics selection — Ranger core vs elite F skills", () =>
     expect(soulbeast.signatures).toEqual(core.signatures);
   });
 
-  test("Untamed default (Unleash Pet) shows empowered pet commands at F1-F3", async () => {
+  test("Untamed default shows normal pet bar at F1-F3", async () => {
     const untamed = await resolve({ specId: 72 });
-    expect(untamed.signatures).toEqual(["63209", "63258", "63094", "63344"]);
+    expect(untamed.signatures).toEqual(["fake:attack", "12478", "fake:return", "63344"]);
   });
 });
 
-describe("renderer mechanics selection — Untamed F5 Unleash toggle", () => {
+describe("renderer mechanics selection — Untamed F5 three-state Unleash cycle", () => {
   const resolve = setupMechanicsHarness("Ranger");
 
   test("Untamed has F5 Unleash skill as a toggleable slot", async () => {
@@ -39,32 +39,49 @@ describe("renderer mechanics selection — Untamed F5 Unleash toggle", () => {
     expect(f5Slot.isUnleashToggle).toBe(true);
   });
 
-  test("F5 shows Unleash Pet by default (current state)", async () => {
-    const defaultState = await resolve({ specId: 72 });
-    const f5 = defaultState.result.mechSlots.find((s) => s.fKeyLabel === "F5");
-    expect(f5.skill.id).toBe(63344); // Unleash Pet (current state)
+  // State 1: Default (activeKit=0) — F5="Unleash Pet", normal pet, normal weapons
+  test("default: F5 shows Unleash Pet", async () => {
+    const state = await resolve({ specId: 72 });
+    const f5 = state.result.mechSlots.find((s) => s.fKeyLabel === "F5");
+    expect(f5.skill.id).toBe(63344); // Unleash Pet
   });
 
-  test("F5 shows Unleash Ranger when toggled", async () => {
-    const unleashed = await resolve({ specId: 72, activeKit: 63147 });
-    const f5 = unleashed.result.mechSlots.find((s) => s.fKeyLabel === "F5");
-    expect(f5.skill.id).toBe(63147); // Unleash Ranger (current state)
-  });
-
-  test("Unleash Ranger active shows normal pet commands at F1-F3", async () => {
-    const unleashed = await resolve({ specId: 72, activeKit: 63147 });
-    const sigs = unleashed.signatures;
+  test("default: F1-F3 are normal pet commands", async () => {
+    const state = await resolve({ specId: 72 });
+    const sigs = state.signatures;
     expect(sigs[0]).toBe("fake:attack");
     expect(sigs[1]).toBe("12478");
     expect(sigs[2]).toBe("fake:return");
   });
 
-  test("Default state (Unleash Pet) shows empowered pet commands at F1-F3", async () => {
-    const untamed = await resolve({ specId: 72 });
-    const sigs = untamed.signatures;
+  // State 2: Unleash Pet (activeKit=63344) — F5="Unleash Ranger", unleashed pet, normal weapons
+  test("Unleash Pet: F5 shows Unleash Ranger", async () => {
+    const state = await resolve({ specId: 72, activeKit: 63344 });
+    const f5 = state.result.mechSlots.find((s) => s.fKeyLabel === "F5");
+    expect(f5.skill.id).toBe(63147); // Unleash Ranger
+  });
+
+  test("Unleash Pet: F1-F3 show empowered pet commands", async () => {
+    const state = await resolve({ specId: 72, activeKit: 63344 });
+    const sigs = state.signatures;
     expect(sigs[0]).toBe("63209"); // Venomous Outburst
     expect(sigs[1]).toBe("63258"); // Rending Vines
     expect(sigs[2]).toBe("63094"); // Enveloping Haze
+  });
+
+  // State 3: Unleash Ranger (activeKit=63147) — F5="Unleash Pet", normal pet, unleashed weapons
+  test("Unleash Ranger: F5 shows Unleash Pet", async () => {
+    const state = await resolve({ specId: 72, activeKit: 63147 });
+    const f5 = state.result.mechSlots.find((s) => s.fKeyLabel === "F5");
+    expect(f5.skill.id).toBe(63344); // Unleash Pet
+  });
+
+  test("Unleash Ranger: F1-F3 are normal pet commands", async () => {
+    const state = await resolve({ specId: 72, activeKit: 63147 });
+    const sigs = state.signatures;
+    expect(sigs[0]).toBe("fake:attack");
+    expect(sigs[1]).toBe("12478");
+    expect(sigs[2]).toBe("fake:return");
   });
 });
 

--- a/tests/unit/renderer/weaponSkills.test.js
+++ b/tests/unit/renderer/weaponSkills.test.js
@@ -110,8 +110,7 @@ describe("getEquippedWeaponSkills — mainhand vs offhand slot restriction", () 
 });
 
 describe("applyUnleashWeaponFlip — Untamed unleashed weapon skill swap", () => {
-  // Simulate Ranger Hammer: 5 base skills + unleashed variants in weaponSkillById,
-  // plus the Unleashed Ambush skill (Relentless Whirl) in skillById.
+  // Simulate Ranger Hammer: 5 base skills each with a flipSkill pointing to an unleashed variant.
   function makeUnleashCatalog() {
     const baseSkills = [
       { id: 63118, name: "Hammer Strike",       slot: "Weapon_1", flipSkill: 63222, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
@@ -121,31 +120,24 @@ describe("applyUnleashWeaponFlip — Untamed unleashed weapon skill swap", () =>
       { id: 69212, name: "Thump",                slot: "Weapon_5", flipSkill: 63208, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
     ];
     const unleashSkills = [
-      // 63222 is the auto-attack chain continuation, NOT the unleashed ambush
       { id: 63222, name: "Hammer Slam",                   slot: "Weapon_1", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63335, name: "Unleashed Wild Swing",           slot: "Weapon_2", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63197, name: "Unleashed Overbearing Smash",    slot: "Weapon_3", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63131, name: "Unleashed Savage Shock Wave",     slot: "Weapon_4", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63208, name: "Unleashed Thump",                slot: "Weapon_5", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
     ];
-    // Unleashed Ambush skill from Unleashed Power trait (specialization=72)
-    const ambushSkill = { id: 63438, name: "Relentless Whirl", slot: "Weapon_1", specialization: 72, weaponType: "Hammer", flipSkill: 0 };
     return {
       weaponSkillById: new Map([...baseSkills, ...unleashSkills].map((s) => [s.id, s])),
-      skillById: new Map([[ambushSkill.id, ambushSkill]]),
     };
   }
 
-  test("Weapon_1 shows Unleashed Ambush, slots 2-5 show unleashed flip variants", () => {
+  test("swaps all 5 hammer skills to their unleashed flip variants", () => {
     const catalog = makeUnleashCatalog();
     const baseSkills = [63118, 69167, 69262, 69340, 69212].map((id) => catalog.weaponSkillById.get(id));
     const result = applyUnleashWeaponFlip(catalog, baseSkills);
-    // Weapon_1: Unleashed Ambush (Relentless Whirl), NOT auto-attack chain (Hammer Slam)
-    expect(result[0]?.id).toBe(63438);
-    expect(result[0]?.name).toBe("Relentless Whirl");
-    // Weapons 2-5: unleashed flip variants
-    expect(result.slice(1).map((s) => s.id)).toEqual([63335, 63197, 63131, 63208]);
-    expect(result.slice(1).map((s) => s.name)).toEqual([
+    expect(result.map((s) => s.id)).toEqual([63222, 63335, 63197, 63131, 63208]);
+    expect(result.map((s) => s.name)).toEqual([
+      "Hammer Slam",
       "Unleashed Wild Swing",
       "Unleashed Overbearing Smash",
       "Unleashed Savage Shock Wave",
@@ -153,24 +145,14 @@ describe("applyUnleashWeaponFlip — Untamed unleashed weapon skill swap", () =>
     ]);
   });
 
-  test("keeps Weapon_1 unchanged when no ambush skill exists in catalog", () => {
-    const catalog = makeUnleashCatalog();
-    catalog.skillById = new Map(); // empty — no ambush skills
-    const baseSkills = [63118, 69167, 69262, 69340, 69212].map((id) => catalog.weaponSkillById.get(id));
-    const result = applyUnleashWeaponFlip(catalog, baseSkills);
-    expect(result[0]?.id).toBe(63118); // original Hammer Strike kept
-    expect(result[1]?.id).toBe(63335); // slots 2-5 still flip
-  });
-
-  test("returns original skills for slots 2-5 when none have flipSkill", () => {
+  test("returns original skills when none have flipSkill", () => {
     const catalog = makeUnleashCatalog();
     const noFlipSkills = [
-      { id: 1, name: "Skill 1", weaponType: "Hammer", flipSkill: 0 },
+      { id: 1, name: "Skill 1", flipSkill: 0 },
       { id: 2, name: "Skill 2", flipSkill: 0 },
     ];
     const result = applyUnleashWeaponFlip(catalog, noFlipSkills);
-    expect(result[0]?.id).toBe(63438); // ambush still applies to Weapon_1
-    expect(result[1]?.id).toBe(2);     // no flip for slot 2
+    expect(result.map((s) => s.id)).toEqual([1, 2]);
   });
 
   test("preserves null entries in the weapon skill array", () => {

--- a/tests/unit/renderer/weaponSkills.test.js
+++ b/tests/unit/renderer/weaponSkills.test.js
@@ -110,7 +110,8 @@ describe("getEquippedWeaponSkills — mainhand vs offhand slot restriction", () 
 });
 
 describe("applyUnleashWeaponFlip — Untamed unleashed weapon skill swap", () => {
-  // Simulate Ranger Hammer: 5 base skills each with a flipSkill pointing to an unleashed variant.
+  // Simulate Ranger Hammer: 5 base skills + unleashed variants in weaponSkillById,
+  // plus the Unleashed Ambush skill (Relentless Whirl) in skillById.
   function makeUnleashCatalog() {
     const baseSkills = [
       { id: 63118, name: "Hammer Strike",       slot: "Weapon_1", flipSkill: 63222, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
@@ -120,24 +121,31 @@ describe("applyUnleashWeaponFlip — Untamed unleashed weapon skill swap", () =>
       { id: 69212, name: "Thump",                slot: "Weapon_5", flipSkill: 63208, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
     ];
     const unleashSkills = [
+      // 63222 is the auto-attack chain continuation, NOT the unleashed ambush
       { id: 63222, name: "Hammer Slam",                   slot: "Weapon_1", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63335, name: "Unleashed Wild Swing",           slot: "Weapon_2", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63197, name: "Unleashed Overbearing Smash",    slot: "Weapon_3", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63131, name: "Unleashed Savage Shock Wave",     slot: "Weapon_4", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63208, name: "Unleashed Thump",                slot: "Weapon_5", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
     ];
+    // Unleashed Ambush skill from Unleashed Power trait (specialization=72)
+    const ambushSkill = { id: 63438, name: "Relentless Whirl", slot: "Weapon_1", specialization: 72, weaponType: "Hammer", flipSkill: 0 };
     return {
       weaponSkillById: new Map([...baseSkills, ...unleashSkills].map((s) => [s.id, s])),
+      skillById: new Map([[ambushSkill.id, ambushSkill]]),
     };
   }
 
-  test("swaps all 5 hammer skills to their unleashed flip variants", () => {
+  test("Weapon_1 shows Unleashed Ambush, slots 2-5 show unleashed flip variants", () => {
     const catalog = makeUnleashCatalog();
     const baseSkills = [63118, 69167, 69262, 69340, 69212].map((id) => catalog.weaponSkillById.get(id));
     const result = applyUnleashWeaponFlip(catalog, baseSkills);
-    expect(result.map((s) => s.id)).toEqual([63222, 63335, 63197, 63131, 63208]);
-    expect(result.map((s) => s.name)).toEqual([
-      "Hammer Slam",
+    // Weapon_1: Unleashed Ambush (Relentless Whirl), NOT auto-attack chain (Hammer Slam)
+    expect(result[0]?.id).toBe(63438);
+    expect(result[0]?.name).toBe("Relentless Whirl");
+    // Weapons 2-5: unleashed flip variants
+    expect(result.slice(1).map((s) => s.id)).toEqual([63335, 63197, 63131, 63208]);
+    expect(result.slice(1).map((s) => s.name)).toEqual([
       "Unleashed Wild Swing",
       "Unleashed Overbearing Smash",
       "Unleashed Savage Shock Wave",
@@ -145,14 +153,24 @@ describe("applyUnleashWeaponFlip — Untamed unleashed weapon skill swap", () =>
     ]);
   });
 
-  test("returns original skills when none have flipSkill", () => {
+  test("keeps Weapon_1 unchanged when no ambush skill exists in catalog", () => {
+    const catalog = makeUnleashCatalog();
+    catalog.skillById = new Map(); // empty — no ambush skills
+    const baseSkills = [63118, 69167, 69262, 69340, 69212].map((id) => catalog.weaponSkillById.get(id));
+    const result = applyUnleashWeaponFlip(catalog, baseSkills);
+    expect(result[0]?.id).toBe(63118); // original Hammer Strike kept
+    expect(result[1]?.id).toBe(63335); // slots 2-5 still flip
+  });
+
+  test("returns original skills for slots 2-5 when none have flipSkill", () => {
     const catalog = makeUnleashCatalog();
     const noFlipSkills = [
-      { id: 1, name: "Skill 1", flipSkill: 0 },
+      { id: 1, name: "Skill 1", weaponType: "Hammer", flipSkill: 0 },
       { id: 2, name: "Skill 2", flipSkill: 0 },
     ];
     const result = applyUnleashWeaponFlip(catalog, noFlipSkills);
-    expect(result.map((s) => s.id)).toEqual([1, 2]);
+    expect(result[0]?.id).toBe(63438); // ambush still applies to Weapon_1
+    expect(result[1]?.id).toBe(2);     // no flip for slot 2
   });
 
   test("preserves null entries in the weapon skill array", () => {

--- a/tests/unit/renderer/weaponSkills.test.js
+++ b/tests/unit/renderer/weaponSkills.test.js
@@ -7,7 +7,7 @@
  * fill slots 4-5, unless the mainhand is two-handed (fills all 5).
  */
 
-const { getEquippedWeaponSkills } = require("../../../src/renderer/modules/skills");
+const { getEquippedWeaponSkills, applyUnleashWeaponFlip } = require("../../../src/renderer/modules/skills");
 
 // Minimal mock catalog for Elementalist with dagger (main+off) and focus (off)
 function makeCatalog() {
@@ -106,5 +106,61 @@ describe("getEquippedWeaponSkills — mainhand vs offhand slot restriction", () 
     expect(result[2]?.id).toBe(9003);
     expect(result[3]?.id).toBe(9004);
     expect(result[4]?.id).toBe(9005);
+  });
+});
+
+describe("applyUnleashWeaponFlip — Untamed unleashed weapon skill swap", () => {
+  // Simulate Ranger Hammer: 5 base skills each with a flipSkill pointing to an unleashed variant.
+  function makeUnleashCatalog() {
+    const baseSkills = [
+      { id: 63118, name: "Hammer Strike",       slot: "Weapon_1", flipSkill: 63222, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
+      { id: 69167, name: "Wild Swing",           slot: "Weapon_2", flipSkill: 63335, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
+      { id: 69262, name: "Overbearing Smash",    slot: "Weapon_3", flipSkill: 63197, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
+      { id: 69340, name: "Savage Shock Wave",     slot: "Weapon_4", flipSkill: 63131, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
+      { id: 69212, name: "Thump",                slot: "Weapon_5", flipSkill: 63208, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
+    ];
+    const unleashSkills = [
+      { id: 63222, name: "Hammer Slam",                   slot: "Weapon_1", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
+      { id: 63335, name: "Unleashed Wild Swing",           slot: "Weapon_2", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
+      { id: 63197, name: "Unleashed Overbearing Smash",    slot: "Weapon_3", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
+      { id: 63131, name: "Unleashed Savage Shock Wave",     slot: "Weapon_4", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
+      { id: 63208, name: "Unleashed Thump",                slot: "Weapon_5", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
+    ];
+    return {
+      weaponSkillById: new Map([...baseSkills, ...unleashSkills].map((s) => [s.id, s])),
+    };
+  }
+
+  test("swaps all 5 hammer skills to their unleashed flip variants", () => {
+    const catalog = makeUnleashCatalog();
+    const baseSkills = [63118, 69167, 69262, 69340, 69212].map((id) => catalog.weaponSkillById.get(id));
+    const result = applyUnleashWeaponFlip(catalog, baseSkills);
+    expect(result.map((s) => s.id)).toEqual([63222, 63335, 63197, 63131, 63208]);
+    expect(result.map((s) => s.name)).toEqual([
+      "Hammer Slam",
+      "Unleashed Wild Swing",
+      "Unleashed Overbearing Smash",
+      "Unleashed Savage Shock Wave",
+      "Unleashed Thump",
+    ]);
+  });
+
+  test("returns original skills when none have flipSkill", () => {
+    const catalog = makeUnleashCatalog();
+    const noFlipSkills = [
+      { id: 1, name: "Skill 1", flipSkill: 0 },
+      { id: 2, name: "Skill 2", flipSkill: 0 },
+    ];
+    const result = applyUnleashWeaponFlip(catalog, noFlipSkills);
+    expect(result.map((s) => s.id)).toEqual([1, 2]);
+  });
+
+  test("preserves null entries in the weapon skill array", () => {
+    const catalog = makeUnleashCatalog();
+    const withNulls = [null, catalog.weaponSkillById.get(69167), null, null, null];
+    const result = applyUnleashWeaponFlip(catalog, withNulls);
+    expect(result[0]).toBeNull();
+    expect(result[1]?.id).toBe(63335); // swapped
+    expect(result[2]).toBeNull();
   });
 });

--- a/tests/unit/renderer/weaponSkills.test.js
+++ b/tests/unit/renderer/weaponSkills.test.js
@@ -110,7 +110,8 @@ describe("getEquippedWeaponSkills — mainhand vs offhand slot restriction", () 
 });
 
 describe("applyUnleashWeaponFlip — Untamed unleashed weapon skill swap", () => {
-  // Simulate Ranger Hammer: 5 base skills each with a flipSkill pointing to an unleashed variant.
+  // Simulate Ranger Hammer: 5 base skills + unleashed variants in weaponSkillById,
+  // plus the Unleashed Ambush skill (Relentless Whirl) in skillById.
   function makeUnleashCatalog() {
     const baseSkills = [
       { id: 63118, name: "Hammer Strike",       slot: "Weapon_1", flipSkill: 63222, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
@@ -120,24 +121,31 @@ describe("applyUnleashWeaponFlip — Untamed unleashed weapon skill swap", () =>
       { id: 69212, name: "Thump",                slot: "Weapon_5", flipSkill: 63208, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
     ];
     const unleashSkills = [
+      // 63222 is the auto-attack chain continuation, NOT the unleashed replacement for slot 1
       { id: 63222, name: "Hammer Slam",                   slot: "Weapon_1", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63335, name: "Unleashed Wild Swing",           slot: "Weapon_2", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63197, name: "Unleashed Overbearing Smash",    slot: "Weapon_3", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63131, name: "Unleashed Savage Shock Wave",     slot: "Weapon_4", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
       { id: 63208, name: "Unleashed Thump",                slot: "Weapon_5", flipSkill: 0, weaponType: "Hammer", attunement: "", dualWield: "", flags: [] },
     ];
+    // Unleashed Ambush skill from Unleashed Power trait (specialization=72)
+    const ambushSkill = { id: 63438, name: "Relentless Whirl", slot: "Weapon_1", specialization: 72, weaponType: "Hammer", flipSkill: 0 };
     return {
       weaponSkillById: new Map([...baseSkills, ...unleashSkills].map((s) => [s.id, s])),
+      skillById: new Map([[ambushSkill.id, ambushSkill]]),
     };
   }
 
-  test("swaps all 5 hammer skills to their unleashed flip variants", () => {
+  test("Weapon_1 shows Unleashed Ambush, slots 2-5 show unleashed flip variants", () => {
     const catalog = makeUnleashCatalog();
     const baseSkills = [63118, 69167, 69262, 69340, 69212].map((id) => catalog.weaponSkillById.get(id));
     const result = applyUnleashWeaponFlip(catalog, baseSkills);
-    expect(result.map((s) => s.id)).toEqual([63222, 63335, 63197, 63131, 63208]);
-    expect(result.map((s) => s.name)).toEqual([
-      "Hammer Slam",
+    // Weapon_1: Unleashed Ambush (Relentless Whirl), NOT auto-attack chain (Hammer Slam)
+    expect(result[0]?.id).toBe(63438);
+    expect(result[0]?.name).toBe("Relentless Whirl");
+    // Weapons 2-5: unleashed flip variants
+    expect(result.slice(1).map((s) => s.id)).toEqual([63335, 63197, 63131, 63208]);
+    expect(result.slice(1).map((s) => s.name)).toEqual([
       "Unleashed Wild Swing",
       "Unleashed Overbearing Smash",
       "Unleashed Savage Shock Wave",
@@ -145,14 +153,24 @@ describe("applyUnleashWeaponFlip — Untamed unleashed weapon skill swap", () =>
     ]);
   });
 
-  test("returns original skills when none have flipSkill", () => {
+  test("keeps Weapon_1 unchanged when no ambush skill exists in catalog", () => {
+    const catalog = makeUnleashCatalog();
+    catalog.skillById = new Map(); // empty — no ambush skills
+    const baseSkills = [63118, 69167, 69262, 69340, 69212].map((id) => catalog.weaponSkillById.get(id));
+    const result = applyUnleashWeaponFlip(catalog, baseSkills);
+    expect(result[0]?.id).toBe(63118); // original Hammer Strike kept
+    expect(result[1]?.id).toBe(63335); // slots 2-5 still flip
+  });
+
+  test("returns original skills for slots 2-5 when none have flipSkill", () => {
     const catalog = makeUnleashCatalog();
     const noFlipSkills = [
-      { id: 1, name: "Skill 1", flipSkill: 0 },
+      { id: 1, name: "Skill 1", weaponType: "Hammer", flipSkill: 0 },
       { id: 2, name: "Skill 2", flipSkill: 0 },
     ];
     const result = applyUnleashWeaponFlip(catalog, noFlipSkills);
-    expect(result.map((s) => s.id)).toEqual([1, 2]);
+    expect(result[0]?.id).toBe(63438); // ambush still applies to Weapon_1
+    expect(result[1]?.id).toBe(2);     // no flip for slot 2
   });
 
   test("preserves null entries in the weapon skill array", () => {


### PR DESCRIPTION
## Summary

The Untamed Ranger's Unleash Ranger toggle (F5) was not swapping hammer weapon skills to their unleashed variants. The GW2 API links each base hammer skill to its unleashed version via `flip_skill`, and these flip targets were already fetched into `weaponSkillById` as chain-depth-1 descendants — but the weapon bar rendering code never applied the swap when `activeKit === 63147`.

Added `applyUnleashWeaponFlip()` utility that maps each weapon skill to its `flipSkill` variant from `weaponSkillById`, and invoked it in the skills bar renderer when Unleash Ranger is active.

Closes #51