### PR TITLE
fix: display relic inner cooldowns in tooltips (closes #53)

### DIFF
--- a/src/main/gw2Data/catalog.js
+++ b/src/main/gw2Data/catalog.js
@@ -854,6 +854,7 @@ async function getUpgradeCatalog(lang = "en") {
   _upgradeCatalogPromise = (async () => {
     const { RUNE_ITEM_IDS, SIGIL_ITEM_IDS, INFUSION_ITEM_IDS, WVW_INFUSION_IDS, ENRICHMENT_ITEM_IDS, FOOD_ITEM_IDS, UTILITY_ITEM_IDS, RELIC_ITEM_IDS } = require("./upgradeIds");
     const { FOOD_BUFF_OVERRIDES } = require("./foodOverrides");
+    const { RELIC_ICD_OVERRIDES } = require("./relicOverrides");
 
     const [runeItems, sigilItems, infusionItems, enrichmentItems, foodItems, utilityItems, relicItems] = await Promise.all([
       fetchGw2ByIds("items", RUNE_ITEM_IDS, lang),
@@ -908,7 +909,12 @@ async function getUpgradeCatalog(lang = "en") {
       sigils: sigilItems.map(mapItem).sort((a, b) => a.name.localeCompare(b.name)),
       infusions: infusionItems.map((item) => ({ ...mapItem(item), category: WVW_INFUSION_IDS.has(item.id) ? "wvw" : "pve" })).sort((a, b) => a.name.localeCompare(b.name)),
       enrichments: enrichmentItems.map(mapItem).sort((a, b) => a.name.localeCompare(b.name)),
-      relics: relicItems.map(mapItem).sort((a, b) => a.name.localeCompare(b.name)),
+      relics: relicItems.map((item) => {
+        const mapped = mapItem(item);
+        const cd = RELIC_ICD_OVERRIDES.get(item.id);
+        if (cd != null) mapped.facts = [{ type: "Recharge", text: "Cooldown", value: cd }];
+        return mapped;
+      }).sort((a, b) => a.name.localeCompare(b.name)),
       foods: foodItems.filter((item) => item.details?.type === "Food").map(mapFood).sort((a, b) => a.name.localeCompare(b.name)),
       utilities: utilityItems.filter((item) => item.details?.type === "Utility").map(mapUtility).sort((a, b) => a.name.localeCompare(b.name)),
     };

--- a/src/main/gw2Data/relicOverrides.js
+++ b/src/main/gw2Data/relicOverrides.js
@@ -1,0 +1,69 @@
+// Relic inner cooldown (ICD) overrides.
+// The GW2 /v2/items endpoint does not expose internal cooldowns for relics.
+// Values are sourced from the GW2 Wiki relic infobox templates.
+// Format: Map<itemId, cooldownSeconds>
+const RELIC_ICD_OVERRIDES = new Map([
+  [100048,  30],    // Relic of the Ice
+  [100063,  30],    // Relic of Surging
+  [100074,  30],    // Relic of Cerus
+  [100115,   2],    // Relic of Mabon
+  [100158,   1],    // Relic of the Mirage
+  [100177,   4],    // Relic of Peitha
+  [100230,  30],    // Relic of the Krait
+  [100238,  60],    // Relic of the Lich
+  [100248,  30],    // Relic of the Citadel
+  [100311,  60],    // Relic of the Ogre
+  [100345,   1],    // Relic of the Daredevil
+  [100368,   1],    // Relic of the Scourge
+  [100385,  20],    // Relic of the Centaur
+  [100400,  30],    // Relic of the Sunless
+  [100403,  60],    // Relic of the Golemancer
+  [100432,  10],    // Relic of Akeem
+  [100435,  30],    // Relic of the Earth
+  [100455,  15],    // Relic of Durability
+  [100461,  15],    // Relic of Lyhr
+  [100479,  60],    // Relic of the Privateer
+  [100527,   8],    // Relic of the Brawler
+  [100531,  20],    // Relic of the Water
+  [100542,   1],    // Relic of the Cavalier
+  [100557,  30],    // Relic of the Wizard's Tower
+  [100561,  20],    // Relic of the Adventurer
+  [100614,   1],    // Relic of Evasion
+  [100625,  30],    // Relic of Leadership
+  [100633,  10],    // Relic of the Flock
+  [100676,  20],    // Relic of Vampirism
+  [100693,  10],    // Relic of the Afflicted
+  [100694,   5],    // Relic of the Unseen Invasion
+  [100752,  30],    // Relic of the Pack
+  [100775,  10],    // Relic of Vass
+  [100794,  10],    // Relic of Resistance
+  [100849,   1],    // Relic of the Aristocracy
+  [100893,  30],    // Relic of the Zephyrite
+  [100908,  30],    // Relic of the Holosmith
+  [100934,   1],    // Relic of the Defender
+  [100942,  30],    // Relic of Dagda
+  [101116,  10],    // Relic of Febe
+  [101139,   1],    // Relic of the Midnight King
+  [101166,   1],    // Relic of the Demon Queen
+  [101191,   0.25], // Relic of Nourys
+  [101767,  10],    // Relic of the Twin Generals
+  [101801,   1],    // Relic of Mosyn
+  [101863,   1],    // Relic of the Sorcerer
+  [102199,   8],    // Relic of the Blightbringer
+  [102595,   3],    // Relic of the Stormsinger
+  [103424,  30],    // Relic of Sorrow
+  [103763,   5],    // Relic of Geysers
+  [103872,  30],    // Relic of Mount Balrior
+  [103977,  30],    // Relic of the Beehive
+  [103984,  20],    // Relic of Reunification
+  [104256,  20],    // Relic of Altruism
+  [104424,   5],    // Relic of Thorns
+  [104501,  20],    // Relic of Fire
+  [104928,  30],    // Relic of the Living City
+  [104994,   1],    // Relic of Mistburn
+  [106916,  10],    // Relic of Shackles
+  [107061,  20],    // Relic of the Coral Heart
+  [107124,  30],    // Relic of the Forest Dweller
+]);
+
+module.exports = { RELIC_ICD_OVERRIDES };

--- a/src/renderer/modules/equipment.js
+++ b/src/renderer/modules/equipment.js
@@ -1631,7 +1631,7 @@ export function renderEquipmentPanel() {
       const rDef = GW2_RELICS_BY_LABEL.get(equip.relic || "");
       if (!rDef) return null;
       const catalogRelic = state.upgradeCatalog?.relicByName?.get(rDef.label);
-      return { name: rDef.label, icon: rDef.icon, description: catalogRelic?.description || "" };
+      return { name: rDef.label, icon: rDef.icon, description: catalogRelic?.description || "", facts: catalogRelic?.facts || [] };
     });
 
     return wrapper;

--- a/tests/unit/renderer/relic-cooldowns.test.js
+++ b/tests/unit/renderer/relic-cooldowns.test.js
@@ -1,0 +1,126 @@
+"use strict";
+
+const detailPanel = require("../../../src/renderer/modules/detail-panel");
+const { state } = require("../../../src/renderer/modules/state");
+
+let savedWindow, savedDocument, savedEditor, savedCatalog;
+let mockHover;
+
+beforeEach(() => {
+  savedWindow   = global.window;
+  savedDocument = global.document;
+  savedEditor   = state.editor;
+  savedCatalog  = state.activeCatalog;
+
+  global.window = { innerWidth: 1920, innerHeight: 1080 };
+  global.document = {
+    createElement(tag) {
+      if (tag === "textarea") {
+        const el = { _html: "", value: "" };
+        Object.defineProperty(el, "innerHTML", {
+          set(v) { el._html = v; el.value = v; },
+          get() { return el._html; },
+        });
+        return el;
+      }
+      return {};
+    },
+  };
+
+  mockHover = {
+    innerHTML: "",
+    style: {},
+    classList: {
+      _classes: new Set(),
+      add(c)      { this._classes.add(c); },
+      remove(c)   { this._classes.delete(c); },
+      contains(c) { return this._classes.has(c); },
+    },
+    getBoundingClientRect: () => ({ width: 200, height: 100 }),
+  };
+
+  detailPanel.initDetailPanel({ hoverPreview: mockHover }, {});
+  state.editor = {
+    profession: "",
+    specializations: [],
+    skills: { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 },
+    activeWeaponSet: 1,
+    equipment: { slots: {}, weapons: {} },
+  };
+  state.activeCatalog = null;
+});
+
+afterEach(() => {
+  global.window       = savedWindow;
+  global.document     = savedDocument;
+  state.editor        = savedEditor;
+  state.activeCatalog = savedCatalog;
+});
+
+describe("Relic inner cooldown display", () => {
+  test("buildSkillCard renders a Recharge fact for a relic entity with facts", () => {
+    const entity = {
+      name: "Relic of Cerus",
+      icon: "https://example.com/cerus.png",
+      description: "Upon using an elite skill, summon an Eye of Cerus.",
+      facts: [{ type: "Recharge", text: "Cooldown", value: 30 }],
+    };
+
+    const html = detailPanel.buildSkillCard(entity, "equip-relic");
+
+    expect(html).toContain("Cooldown: 30s");
+  });
+
+  test("showHoverPreview renders cooldown fact for relic with facts", () => {
+    const entity = {
+      name: "Relic of Cerus",
+      icon: "https://example.com/cerus.png",
+      description: "Upon using an elite skill, summon an Eye of Cerus.",
+      facts: [{ type: "Recharge", text: "Cooldown", value: 30 }],
+    };
+
+    detailPanel.showHoverPreview("equip-relic", entity, 100, 100);
+
+    expect(mockHover.innerHTML).toContain("Cooldown: 30s");
+  });
+
+  test("relic without facts shows no cooldown", () => {
+    const entity = {
+      name: "Relic of Speed",
+      icon: "https://example.com/speed.png",
+      description: "Increase movement speed when under the effect of swiftness.",
+    };
+
+    detailPanel.showHoverPreview("equip-relic", entity, 100, 100);
+
+    expect(mockHover.innerHTML).not.toContain("Cooldown:");
+    expect(mockHover.innerHTML).not.toContain("Recharge:");
+  });
+
+  test("buildSkillCard renders fractional cooldown values", () => {
+    const entity = {
+      name: "Relic of Nourys",
+      icon: "https://example.com/nourys.png",
+      description: "Gain barrier.",
+      facts: [{ type: "Recharge", text: "Cooldown", value: 0.25 }],
+    };
+
+    const html = detailPanel.buildSkillCard(entity, "equip-relic");
+
+    expect(html).toContain("Cooldown: 0.25s");
+  });
+});
+
+describe("Relic override data", () => {
+  test("RELIC_ICD_OVERRIDES maps item IDs to cooldown seconds", () => {
+    const { RELIC_ICD_OVERRIDES } = require("../../../src/main/gw2Data/relicOverrides");
+
+    expect(RELIC_ICD_OVERRIDES).toBeInstanceOf(Map);
+    // Relic of Cerus should have 30s ICD
+    expect(RELIC_ICD_OVERRIDES.get(100074)).toBe(30);
+    // Relic of the Aristocracy should have 1s ICD
+    expect(RELIC_ICD_OVERRIDES.get(100849)).toBe(1);
+    // Relic of Speed has no ICD
+    expect(RELIC_ICD_OVERRIDES.has(100148)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
The GW2 API `/v2/items` endpoint does not expose internal cooldown (ICD) values for relics, so relic tooltips were missing this information. This fix adds a `relicOverrides.js` data file with ICD values for all 61 relics that have one (sourced from the GW2 Wiki), wires the data through the upgrade catalog as Recharge facts, and passes them through the relic hover preview entity so they render as "Cooldown: Xs" in tooltips.

**Changes:**
- **`src/main/gw2Data/relicOverrides.js`** (new) — Map of relic item IDs to their inner cooldown in seconds
- **`src/main/gw2Data/catalog.js`** — Merges ICD overrides into relic catalog entries as Recharge facts
- **`src/renderer/modules/equipment.js`** — Passes `facts` from catalog relic data through to the hover preview entity
- **`tests/unit/renderer/relic-cooldowns.test.js`** (new) — 5 tests covering cooldown rendering and override data

Closes #53