### PR TITLE
fix: can't collapse boon coverage on SPA comp view (closes #87)

### DIFF
--- a/src/site/render-comp.js
+++ b/src/site/render-comp.js
@@ -357,6 +357,17 @@ export function renderCompPage(app, comp) {
   // Bind boon coverage interactions after DOM is rendered
   if (comp.boonCoverageHtml) {
     bindBoonEvents(app, comp.builds || {});
+
+    // Collapse/expand toggle for boon coverage header
+    const boonHeader = app.querySelector(".comp-boon-cov__header");
+    const boonBody = app.querySelector(".comp-boon-cov__body");
+    const boonChevron = app.querySelector(".comp-boon-cov__chevron");
+    if (boonHeader && boonBody && boonChevron) {
+      boonHeader.addEventListener("click", () => {
+        const collapsed = boonBody.classList.toggle("comp-boon-cov__body--hidden");
+        boonChevron.textContent = collapsed ? "\u25b8" : "\u25be";
+      });
+    }
   }
 
   initMobileDetection();

--- a/tests/spa/specs/comp-boon-collapse.spec.js
+++ b/tests/spa/specs/comp-boon-collapse.spec.js
@@ -1,0 +1,42 @@
+const { test, expect } = require("playwright/test");
+const { generateCompPayload, makeTestBuild, makeTestComp } = require("../helpers/fixture-gen");
+const { loadCompPage } = require("../helpers/route-mock");
+
+test.describe("Boon coverage collapse toggle on SPA comp view", () => {
+  let payload;
+
+  test.beforeAll(() => {
+    const builds = [
+      makeTestBuild({ profession: "Guardian", title: "Firebrand" }),
+    ];
+    const comp = makeTestComp({
+      name: "Boon Collapse Test",
+      buildIds: builds.map((b) => b.id),
+      partyLines: [{ id: "pl-1", capacity: 5, slots: builds.map((b) => b.id) }],
+      boonCoverageHtml: '<div class="comp-boon-cov__squad-label">SQUAD</div><div class="comp-boon-cov__icons"><span>test</span></div>',
+    });
+    payload = generateCompPayload(comp, builds);
+  });
+
+  test("clicking boon coverage header collapses and expands the body", async ({ page }) => {
+    await loadCompPage(page, payload);
+
+    const header = page.locator(".comp-boon-cov__header");
+    const body = page.locator(".comp-boon-cov__body");
+    const chevron = page.locator(".comp-boon-cov__chevron");
+
+    // Body should be visible initially
+    await expect(body).toBeVisible();
+    await expect(chevron).toHaveText("\u25be"); // ▾ (expanded)
+
+    // Click header to collapse
+    await header.click();
+    await expect(body).toBeHidden();
+    await expect(chevron).toHaveText("\u25b8"); // ▸ (collapsed)
+
+    // Click header again to expand
+    await header.click();
+    await expect(body).toBeVisible();
+    await expect(chevron).toHaveText("\u25be"); // ▾ (expanded)
+  });
+});


### PR DESCRIPTION
## Summary
The SPA comp view rendered the boon coverage header with a chevron but never wired up a click handler to toggle collapse/expand. The desktop renderer handles this via `data-action="toggle-boon-coverage"` but the SPA's `render-comp.js` had no equivalent.

Added a click listener on `.comp-boon-cov__header` in `renderCompPage()` that toggles `.comp-boon-cov__body--hidden` and swaps the chevron character (▸/▾).

Closes #87