### PR TITLE
fix: SPA background splashes cut off on short pages (closes #89)

### DIFF
--- a/src/renderer/styles/base.css
+++ b/src/renderer/styles/base.css
@@ -47,7 +47,7 @@
 html,
 body {
   margin: 0;
-  min-height: 100%;
+  min-height: 100vh;
   font-family: "Exo 2", system-ui, sans-serif;
   background:
     radial-gradient(1300px 550px at -5% -10%, rgba(79, 216, 151, 0.2), transparent 55%),

--- a/tests/spa/specs/bg-viewport-fill.spec.js
+++ b/tests/spa/specs/bg-viewport-fill.spec.js
@@ -1,0 +1,24 @@
+const { test, expect } = require("playwright/test");
+
+test.describe("Background fills viewport on short pages", () => {
+  test("landing page body covers full viewport height", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(".site-landing", { timeout: 10_000 });
+
+    const bodyHeight = await page.evaluate(() => document.body.getBoundingClientRect().height);
+    const viewportHeight = page.viewportSize().height;
+
+    expect(bodyHeight).toBeGreaterThanOrEqual(viewportHeight);
+  });
+
+  test("error page body covers full viewport height", async ({ page }) => {
+    // Navigate with an invalid build param to trigger the error state
+    await page.goto("/?b=invalid");
+    await page.waitForSelector(".site-error", { timeout: 10_000 });
+
+    const bodyHeight = await page.evaluate(() => document.body.getBoundingClientRect().height);
+    const viewportHeight = page.viewportSize().height;
+
+    expect(bodyHeight).toBeGreaterThanOrEqual(viewportHeight);
+  });
+});


### PR DESCRIPTION
## Summary
The radial gradient background splashes on `html, body` used `min-height: 100%`, but percentage-based `min-height` on `body` doesn't resolve properly when `html` only has `min-height` set (not `height`). On short-content pages (loading, error, landing), the body was only as tall as its content, clipping the gradients.

Changed `min-height: 100%` to `min-height: 100vh` in `base.css` so the body always fills the viewport regardless of content height.

Closes #89