### PR TITLE
fix: Discord webhook and Forum channel preferences do not save (closes #93)

### DIFF
--- a/src/main/buildStore.js
+++ b/src/main/buildStore.js
@@ -3,6 +3,8 @@ const path = require("node:path");
 const crypto = require("node:crypto");
 
 class BuildStore {
+  #settingsQueue = Promise.resolve();
+
   constructor(baseDir) {
     this.baseDir = baseDir;
     this.buildsPath = path.join(baseDir, "builds.json");
@@ -124,10 +126,14 @@ class BuildStore {
     return data[key] ?? null;
   }
 
-  async setSetting(key, value) {
-    const data = await this.#readJson(this.settingsPath, {});
-    data[key] = value;
-    await this.#writeJson(this.settingsPath, data);
+  setSetting(key, value) {
+    const op = this.#settingsQueue.then(async () => {
+      const data = await this.#readJson(this.settingsPath, {});
+      data[key] = value;
+      await this.#writeJson(this.settingsPath, data);
+    });
+    this.#settingsQueue = op.catch(() => {});
+    return op;
   }
 }
 

--- a/tests/unit/buildStore.test.js
+++ b/tests/unit/buildStore.test.js
@@ -653,6 +653,21 @@ describe("BuildStore — settings", () => {
     expect(await store2.getSetting("lastGameMode")).toBe("wvw");
   });
 
+  test("concurrent setSetting calls do not lose values (issue #93)", async () => {
+    ({ dir } = (await makeTempStore()));
+    const store = new BuildStore(dir);
+    await store.init();
+    // Simulate the settings modal: three parallel setSetting calls
+    await Promise.all([
+      store.setSetting("discord.webhookUrl", "https://discord.com/api/webhooks/123/abc"),
+      store.setSetting("discord.threadMode", "auto"),
+      store.setSetting("discord.threadId", "999"),
+    ]);
+    expect(await store.getSetting("discord.webhookUrl")).toBe("https://discord.com/api/webhooks/123/abc");
+    expect(await store.getSetting("discord.threadMode")).toBe("auto");
+    expect(await store.getSetting("discord.threadId")).toBe("999");
+  });
+
   test("init creates settings.json if missing", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "axiforge-settings-test-"));
     dir = tmpDir;


### PR DESCRIPTION
## Summary

The settings modal saves Discord webhook URL, thread mode, and thread ID via three parallel `Promise.all` calls to `setSetting`. Each call reads the settings JSON file, modifies one key, and writes back — creating a race condition where the last writer overwrites the other two values. Fixed by adding a write queue (`#settingsQueue`) to `BuildStore.setSetting()` that serializes concurrent calls, ensuring each read-modify-write completes before the next begins.

Closes #93