### PR TITLE
feat: click version label to force update check

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -260,6 +260,23 @@ initSettingsCallbacks({ refreshOnboardingStatus, render });
     }, 5000);
   });
 
+  if (el.updateVersionLabel) {
+    el.updateVersionLabel.style.cursor = "pointer";
+    el.updateVersionLabel.title = "Click to check for updates";
+    el.updateVersionLabel.addEventListener("click", () => {
+      if (el.updateVersionLabel.classList.contains("titlebar__dev-badge")) return;
+      const prev = el.updateVersionLabel.textContent;
+      el.updateVersionLabel.textContent = "Checking...";
+      window.desktopApi.checkForUpdates?.();
+      // Restore after timeout if no update event fires
+      setTimeout(() => {
+        if (el.updateVersionLabel.textContent === "Checking...") {
+          el.updateVersionLabel.textContent = prev;
+        }
+      }, 10000);
+    });
+  }
+
   if (el.updateRestartBtn) {
     el.updateRestartBtn.addEventListener("click", () => {
       window.desktopApi.restartApp?.();

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -61,7 +61,11 @@
   font-weight: 600;
   letter-spacing: 0.06em;
   color: color-mix(in srgb, var(--text-dim, #7a9abf) 60%, transparent);
-  transition: opacity 0.3s ease, transform 0.3s ease;
+  transition: opacity 0.3s ease, transform 0.3s ease, color 0.2s ease;
+  cursor: pointer;
+}
+.titlebar__version:hover {
+  color: var(--text-dim, #7a9abf);
 }
 
 .titlebar__progress {


### PR DESCRIPTION
## Summary
- Clicking the version number in the titlebar now triggers a manual update check via `checkForUpdates()`
- Shows "Checking..." feedback while the check is in progress
- Hover state brightens the version label to indicate it's clickable
- No-op in dev mode (dev badge)