### PR TITLE
fix: Quotation marks in skill names rendered as HTML entities (closes #98)

### DIFF
--- a/src/renderer/modules/notes.js
+++ b/src/renderer/modules/notes.js
@@ -4,6 +4,7 @@
 import { marked } from "marked";
 import { state } from "./state.js";
 import { bindHoverPreview } from "./detail-panel.js";
+import { decodeHtmlEntities } from "./utils.js";
 
 let _el = {};
 let _markEditorChanged = () => {};
@@ -555,7 +556,7 @@ function renderPreview(markdown, container) {
     const resolved = resolveReference(category, numId);
     const icon = resolved?.icon || "";
     const iconHtml = icon ? `<img class="notes-mention__icon" src="${icon}" alt="">` : "";
-    return `<span class="notes-mention" data-type="${category}" data-id="${numId}">${iconHtml}${escapeHtml(name)} <span class="notes-mention__label">${category}</span></span>`;
+    return `<span class="notes-mention" data-type="${category}" data-id="${numId}">${iconHtml}${escapeHtml(decodeHtmlEntities(name))} <span class="notes-mention__label">${category}</span></span>`;
   });
 
   container.innerHTML = html;

--- a/src/renderer/modules/utils.js
+++ b/src/renderer/modules/utils.js
@@ -97,9 +97,13 @@ export function normalizeText(input) {
 }
 
 export function decodeHtmlEntities(value) {
-  const node = document.createElement("textarea");
-  node.innerHTML = String(value || "");
-  return node.value;
+  return String(value || "")
+    .replaceAll("&#039;", "'")
+    .replaceAll("&#39;", "'")
+    .replaceAll("&quot;", "\"")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&amp;", "&");
 }
 
 export function delay(ms) {

--- a/src/site/render-notes.js
+++ b/src/site/render-notes.js
@@ -3,6 +3,7 @@
 
 import { marked } from "marked";
 import { bindHoverPreview } from "@renderer/modules/detail-panel.js";
+import { decodeHtmlEntities } from "@renderer/modules/utils.js";
 
 export function renderNotes(build) {
   const container = document.createElement("div");
@@ -51,7 +52,7 @@ export function renderNotes(build) {
 
     const icon = resolved?.icon || "";
     const iconHtml = icon ? `<img class="notes-mention__icon" src="${icon}" alt="">` : "";
-    const escapedName = escapeHtml(name);
+    const escapedName = escapeHtml(decodeHtmlEntities(name));
 
     if (resolved) {
       return `<span class="notes-mention" data-type="${category}" data-id="${numId}">${iconHtml}${escapedName} <span class="notes-mention__label">${category}</span></span>`;

--- a/tests/unit/renderer/notes-mentions.test.js
+++ b/tests/unit/renderer/notes-mentions.test.js
@@ -1,0 +1,49 @@
+"use strict";
+
+// Test that @[category:id:name] mentions with HTML entities in the name
+// (as produced by marked.parse encoding quotation marks) are decoded correctly.
+//
+// Bug: GW2 skill names containing quotation marks (e.g., "Advance!") were
+// displayed as &quot;Advance!&quot; because marked.parse HTML-encodes the quotes,
+// and the mention regex captured the entity-encoded name without decoding it.
+
+const { decodeHtmlEntities } = require("../../../src/renderer/modules/utils.js");
+
+describe("notes mention rendering — HTML entity decoding", () => {
+  test("decodeHtmlEntities is exported", () => {
+    expect(typeof decodeHtmlEntities).toBe("function");
+  });
+
+  test("decodes &quot; to quotation marks", () => {
+    expect(decodeHtmlEntities("&quot;Advance!&quot;")).toBe('"Advance!"');
+  });
+
+  test("decodes &amp;, &lt;, &gt;, &#039;", () => {
+    expect(decodeHtmlEntities("&amp;")).toBe("&");
+    expect(decodeHtmlEntities("&lt;")).toBe("<");
+    expect(decodeHtmlEntities("&gt;")).toBe(">");
+    expect(decodeHtmlEntities("&#039;")).toBe("'");
+  });
+
+  test("leaves plain text unchanged", () => {
+    expect(decodeHtmlEntities("Advance!")).toBe("Advance!");
+    expect(decodeHtmlEntities("Fireball")).toBe("Fireball");
+  });
+
+  test("handles multiple entities in one string", () => {
+    expect(decodeHtmlEntities("&quot;Advance!&quot; &amp; &quot;Retreat!&quot;"))
+      .toBe('"Advance!" & "Retreat!"');
+  });
+
+  test("mention name captured from marked HTML output is decoded correctly", () => {
+    // marked.parse('@[skill:9084:"Advance!"]') produces HTML with &quot; for "
+    const markedHtml = '<p>@[skill:9084:&quot;Advance!&quot;]</p>\n';
+    const mentionRegex = /@\[(\w+):(\d+):([^\]]+)\]/g;
+    const match = mentionRegex.exec(markedHtml);
+
+    expect(match).not.toBeNull();
+    expect(match[3]).toBe("&quot;Advance!&quot;");
+    // After decoding, the name should have real quotes
+    expect(decodeHtmlEntities(match[3])).toBe('"Advance!"');
+  });
+});


### PR DESCRIPTION
## Summary

Skill names containing quotation marks (e.g., `"Advance!"`) were displayed as `&quot;Advance!&quot;` in Notes section mention chips. The root cause: `marked.parse()` HTML-encodes `"` to `&quot;` before the `@[category:id:name]` mention regex processes the HTML output. The captured name then contained HTML entities, which `escapeHtml()` double-encoded into `&amp;quot;`, rendering as literal `&quot;` in the UI.

The fix adds `decodeHtmlEntities(name)` before `escapeHtml()` in both the desktop renderer (`notes.js`) and the SPA renderer (`render-notes.js`). The existing `decodeHtmlEntities` in `utils.js` was also converted from a DOM-based implementation to a pure string-based one for testability and consistency with `escapeHtml`.

Closes #98