### PR TITLE
fix: the Columns view in Build Library will duplicate build lists if drilled down all the way (closes #103)

### DIFF
--- a/src/renderer/modules/library/content.js
+++ b/src/renderer/modules/library/content.js
@@ -693,8 +693,9 @@ function bindContentEvents(container) {
         }
         renderContent();
       });
-    } else {
+    } else if (!el.closest(".lib-columns")) {
       // List/grid/icon views: single click selects, double-click navigates into comp
+      // (columns view handles comp clicks via bindColumnsEvents)
       el.addEventListener("click", (e) => {
         e.stopPropagation();
         handleCompClick(el.dataset.compId, e);

--- a/tests/unit/renderer/columns-view-comp-dblclick.test.js
+++ b/tests/unit/renderer/columns-view-comp-dblclick.test.js
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+"use strict";
+
+// Test: double-clicking a comp in columns view must NOT call onOpenComp
+// (which would navigate into the comp and duplicate the build list).
+
+// ── Mock all imports consumed by content.js ──────────────────────────────────
+jest.mock("../../../src/renderer/modules/state", () => ({
+  state: {
+    builds: [],
+    folders: [],
+    comps: [],
+    libraryPrefs: { viewMode: "columns" },
+    upgradeCatalog: {},
+  },
+}));
+jest.mock("../../../src/renderer/modules/utils", () => ({
+  escapeHtml: (s) => s,
+  formatRelativeTime: () => "",
+}));
+jest.mock("../../../src/renderer/modules/roleEstimator", () => ({
+  roleBadgeHtml: () => "",
+}));
+jest.mock("../../../src/renderer/modules/library/folder-store", () => ({
+  getVisibleFolders: () => [],
+  getVisibleBuilds: () => [],
+  getVisibleComps: jest.fn(() => []),
+}));
+jest.mock("../../../src/renderer/modules/profession-icons", () => ({
+  getProfessionSvg: () => "",
+}));
+jest.mock("../../../src/renderer/modules/library/selection", () => ({
+  clearSelection: jest.fn(),
+  handleBuildClick: jest.fn(),
+  handleCompClick: jest.fn(),
+  updateSelectionVisuals: jest.fn(),
+}));
+jest.mock("../../../src/renderer/modules/library/drag-drop", () => ({
+  wireDragDropEvents: jest.fn(),
+}));
+jest.mock("../../../src/renderer/modules/library/heroicons", () => ({
+  folderIcon: "",
+  starIcon: "",
+  chevronUpDownIcon: "",
+  chevronUpIcon: "",
+  chevronDownIcon: "",
+  chevronRightIcon: "",
+  compIcon: "",
+}));
+
+const { state } = require("../../../src/renderer/modules/state");
+const { getVisibleComps } = require("../../../src/renderer/modules/library/folder-store");
+const { initContent, renderContent } = require("../../../src/renderer/modules/library/content");
+
+describe("Columns view — comp double-click", () => {
+  let onOpenComp;
+
+  beforeEach(() => {
+    // Set up DOM container
+    document.body.innerHTML = `<div id="lib-content"></div>`;
+
+    onOpenComp = jest.fn();
+    initContent({ onOpenComp });
+
+    // Set up state: one comp with one build
+    state.comps = [{ id: "comp-1", name: "Test Comp", folderId: null, sortOrder: 0 }];
+    state.builds = [
+      { id: "build-1", title: "Build A", compId: "comp-1", profession: "Guardian" },
+    ];
+    state.folders = [];
+    state.libraryPrefs = { viewMode: "columns" };
+
+    getVisibleComps.mockReturnValue(state.comps);
+  });
+
+  test("double-clicking a comp in columns view should NOT call onOpenComp", () => {
+    renderContent();
+
+    const container = document.getElementById("lib-content");
+    const compEl = container.querySelector("[data-comp-id='comp-1']");
+    expect(compEl).not.toBeNull();
+    expect(compEl.closest(".lib-columns")).not.toBeNull();
+
+    // Simulate double-click
+    compEl.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+
+    expect(onOpenComp).not.toHaveBeenCalled();
+  });
+
+  test("single-clicking a comp in columns view shows its builds in next column", () => {
+    renderContent();
+
+    const container = document.getElementById("lib-content");
+    const compEl = container.querySelector("[data-comp-id='comp-1']");
+
+    // Single click the comp to drill down
+    compEl.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    // After re-render, the comp's builds should appear in a second column
+    const columns = container.querySelectorAll(".lib-col");
+    expect(columns.length).toBe(2);
+
+    const buildEl = container.querySelector("[data-build-id='build-1']");
+    expect(buildEl).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
In the Columns (Miller columns) view, `bindContentEvents` was binding a `dblclick` handler on comp elements that called `onOpenComp`, which navigates into the comp by setting `state.currentFolder`. This caused `getVisibleBuilds()` to return the comp's builds at the root column level, duplicating the builds already shown in the drilled-down column. The fix adds a `.lib-columns` guard (matching the existing pattern used for folder elements) so that comp elements in columns view only use the columns-specific click handlers from `bindColumnsEvents`.

Closes #103