### PR TITLE
fix: Builds do not appear in the Smart Folders section other than All Builds and All Comps (closes #109)

### DIFF
--- a/src/renderer/modules/library/folder-store.js
+++ b/src/renderer/modules/library/folder-store.js
@@ -65,17 +65,18 @@ export function getVisibleBuilds() {
     } else if (folder.id === "__all-comps") {
       // "All Comps" smart folder: no builds shown
       return [];
+    } else if (folder.type === "smart-profession") {
+      // Smart folders aggregate ALL matching builds, including those in comps
+      builds = builds.filter((b) => b.profession === folder.id);
+    } else if (folder.type === "smart-gamemode") {
+      builds = builds.filter(
+        (b) => (b.gameMode || "pve") === folder.id,
+      );
     } else {
-      // Non-comp views: exclude builds that are inside any comp
+      // Non-smart views: exclude builds that are inside any comp
       builds = builds.filter((b) => !b.compId);
       if (folder.type === "custom") {
         builds = builds.filter((b) => b.folderId === folder.id);
-      } else if (folder.type === "smart-profession") {
-        builds = builds.filter((b) => b.profession === folder.id);
-      } else if (folder.type === "smart-gamemode") {
-        builds = builds.filter(
-          (b) => (b.gameMode || "pve") === folder.id,
-        );
       } else if (folder.type === "all") {
         // "all" type: show only root-level builds at top level;
         // builds inside folders appear under their expanded folder rows

--- a/tests/unit/renderer/smart-folder-filtering.test.js
+++ b/tests/unit/renderer/smart-folder-filtering.test.js
@@ -1,0 +1,161 @@
+/**
+ * @jest-environment jsdom
+ */
+"use strict";
+
+// Tests for smart folder filtering (By Profession / By Game Mode).
+// Verifies that getVisibleBuilds() returns the correct builds when
+// the user navigates to a profession or game mode smart folder,
+// including builds that belong to comps.
+
+jest.mock("../../../src/renderer/modules/state", () => ({
+  state: {
+    builds: [],
+    folders: [],
+    comps: [],
+    currentFolder: null,
+    buildSearch: "",
+    libraryPrefs: {
+      viewMode: "list",
+      sortField: "sortOrder",
+      sortDirection: "asc",
+      activeFilters: {},
+    },
+  },
+}));
+
+const { state } = require("../../../src/renderer/modules/state");
+const {
+  getVisibleBuilds,
+  getVisibleComps,
+} = require("../../../src/renderer/modules/library/folder-store");
+
+function makeBuild(overrides) {
+  return {
+    id: overrides.id || "b-" + Math.random().toString(36).slice(2, 8),
+    title: overrides.title || "Test Build",
+    profession: overrides.profession || "Guardian",
+    gameMode: overrides.gameMode || "pve",
+    folderId: overrides.folderId || null,
+    compId: overrides.compId || null,
+    pinned: overrides.pinned || false,
+    sortOrder: overrides.sortOrder || 0,
+    tags: overrides.tags || [],
+    specializations: overrides.specializations || [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  state.builds = [];
+  state.folders = [];
+  state.comps = [];
+  state.currentFolder = null;
+  state.buildSearch = "";
+  state.libraryPrefs = {
+    viewMode: "list",
+    sortField: "sortOrder",
+    sortDirection: "asc",
+    activeFilters: {},
+  };
+});
+
+describe("getVisibleBuilds — smart-profession folder", () => {
+  test("shows non-comp builds matching profession", () => {
+    state.builds = [
+      makeBuild({ id: "g1", profession: "Guardian" }),
+      makeBuild({ id: "g2", profession: "Guardian" }),
+      makeBuild({ id: "w1", profession: "Warrior" }),
+    ];
+    state.currentFolder = { type: "smart-profession", id: "Guardian" };
+
+    const result = getVisibleBuilds();
+    expect(result.map((b) => b.id)).toEqual(["g1", "g2"]);
+  });
+
+  test("shows builds that are inside comps", () => {
+    state.builds = [
+      makeBuild({ id: "g1", profession: "Guardian", compId: null }),
+      makeBuild({ id: "g2", profession: "Guardian", compId: "comp-1" }),
+    ];
+    state.comps = [{ id: "comp-1", name: "Raid Comp" }];
+    state.currentFolder = { type: "smart-profession", id: "Guardian" };
+
+    const result = getVisibleBuilds();
+    expect(result.map((b) => b.id)).toEqual(["g1", "g2"]);
+  });
+
+  test("shows builds that are inside custom folders", () => {
+    state.builds = [
+      makeBuild({ id: "g1", profession: "Guardian", folderId: null }),
+      makeBuild({ id: "g2", profession: "Guardian", folderId: "folder-1" }),
+    ];
+    state.folders = [{ id: "folder-1", name: "Raid", parentId: null, sortOrder: 0 }];
+    state.currentFolder = { type: "smart-profession", id: "Guardian" };
+
+    const result = getVisibleBuilds();
+    expect(result.map((b) => b.id)).toEqual(["g1", "g2"]);
+  });
+
+  test("does not show builds from other professions", () => {
+    state.builds = [
+      makeBuild({ id: "g1", profession: "Guardian" }),
+      makeBuild({ id: "w1", profession: "Warrior" }),
+    ];
+    state.currentFolder = { type: "smart-profession", id: "Guardian" };
+
+    const result = getVisibleBuilds();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("g1");
+  });
+});
+
+describe("getVisibleBuilds — smart-gamemode folder", () => {
+  test("shows non-comp builds matching game mode", () => {
+    state.builds = [
+      makeBuild({ id: "p1", gameMode: "pvp" }),
+      makeBuild({ id: "p2", gameMode: "pve" }),
+    ];
+    state.currentFolder = { type: "smart-gamemode", id: "pvp" };
+
+    const result = getVisibleBuilds();
+    expect(result.map((b) => b.id)).toEqual(["p1"]);
+  });
+
+  test("shows builds that are inside comps", () => {
+    state.builds = [
+      makeBuild({ id: "p1", gameMode: "wvw", compId: null }),
+      makeBuild({ id: "p2", gameMode: "wvw", compId: "comp-1" }),
+    ];
+    state.comps = [{ id: "comp-1", name: "WvW Comp" }];
+    state.currentFolder = { type: "smart-gamemode", id: "wvw" };
+
+    const result = getVisibleBuilds();
+    expect(result.map((b) => b.id)).toEqual(["p1", "p2"]);
+  });
+
+  test("defaults missing gameMode to pve", () => {
+    state.builds = [
+      makeBuild({ id: "b1", gameMode: "" }),
+      makeBuild({ id: "b2", gameMode: "pve" }),
+      makeBuild({ id: "b3", gameMode: "pvp" }),
+    ];
+    state.currentFolder = { type: "smart-gamemode", id: "pve" };
+
+    const result = getVisibleBuilds();
+    expect(result.map((b) => b.id)).toEqual(["b1", "b2"]);
+  });
+});
+
+describe("getVisibleBuilds — all-builds folder", () => {
+  test("excludes builds inside comps", () => {
+    state.builds = [
+      makeBuild({ id: "b1", compId: null }),
+      makeBuild({ id: "b2", compId: "comp-1" }),
+    ];
+    state.currentFolder = { type: "all" };
+
+    const result = getVisibleBuilds();
+    expect(result.map((b) => b.id)).toEqual(["b1"]);
+  });
+});


### PR DESCRIPTION
## Summary

Smart folder views (By Profession, By Game Mode) were incorrectly filtering out builds that belong to comps. The `getVisibleBuilds()` function applied a blanket `!b.compId` filter to all non-comp views, including smart folders. This meant the sidebar showed the correct count (e.g., "Guardian (2)") but the content area showed "No builds found" because all matching builds happened to be inside comps.

The fix restructures the filtering logic so that smart-profession and smart-gamemode folders aggregate ALL matching builds regardless of comp membership, while custom folders and "All Builds" continue to exclude comp builds as before.

Closes #109