### PR TITLE
feat: Mouseover on traits that trigger skill variants (closes #110)

### DIFF
--- a/src/main/gw2Data/catalog.js
+++ b/src/main/gw2Data/catalog.js
@@ -401,6 +401,18 @@ async function getProfessionCatalog(professionId, lang = "en", gameMode = "pve")
     }
   }
 
+  // Collect ALL trait skill IDs (including non-elite spec traits) so that
+  // trait-associated skills (e.g. Lesser Signet of the Locust from Malicious Swarm)
+  // are available in skillById for hover preview display.
+  const allTraitSkillIds = new Set();
+  for (const trait of traits) {
+    if (!Array.isArray(trait.skills)) continue;
+    for (const ts of trait.skills) {
+      const skillId = Number(ts?.id);
+      if (skillId) allTraitSkillIds.add(skillId);
+    }
+  }
+
   // Merge profession reference metadata into fetched skill objects (needs traitSkillTagMap).
   // Prefer the reference's slot/specialization/type over the skill's own values.
   // Also apply traitSkillTagMap specialization as a fallback for elite spec skills whose
@@ -527,7 +539,7 @@ async function getProfessionCatalog(professionId, lang = "en", gameMode = "pve")
     ...professionSkillsRaw.map((s) => s.id),
     ...extraSkillsRaw.map((s) => s.id),
   ]);
-  const traitSkillIdsToFetch = [...traitSkillTagMap.keys()].filter((id) => !alreadyFetchedForTraits.has(id));
+  const traitSkillIdsToFetch = [...new Set([...traitSkillTagMap.keys(), ...allTraitSkillIds])].filter((id) => !alreadyFetchedForTraits.has(id));
 
   const [weaponChainDepth2Raw, traitSkillsRaw, morphPoolSkillsRaw] = await Promise.all([
     weaponChainDepth2Ids.length ? fetchGw2ByIds("skills", weaponChainDepth2Ids, lang) : Promise.resolve([]),

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -381,6 +381,25 @@ export function showHoverPreview(kind, entity, x, y) {
     }
   }
 
+  // For traits with associated skills (traitSkillIds), append skill cards below.
+  // Use the icon from traitSkillIcons (embedded in the trait API response) when available,
+  // since the separately-fetched /v2/skills object often shares the trait's icon instead
+  // of the distinct trait-skill icon (e.g. Chilling Nova trait vs Chilling Nova trait skill).
+  if (kind === "trait" && Array.isArray(entity.traitSkillIds) && entity.traitSkillIds.length) {
+    const catalog = state.activeCatalog;
+    const iconOverrides = entity.traitSkillIcons || {};
+    for (const skillId of entity.traitSkillIds) {
+      const skill = catalog?.skillById?.get(skillId);
+      if (!skill) continue;
+      const overrideIcon = iconOverrides[skillId];
+      const displaySkill = overrideIcon ? { ...skill, icon: overrideIcon } : skill;
+      chainCards.push(
+        `<div class="hover-preview__trait-skill-divider">Trait skill</div>`
+        + buildSkillCard(displaySkill, "skill", false, null)
+      );
+    }
+  }
+
   if (_el.hoverPreview) {
     _el.hoverPreview.innerHTML = chainCards.join("");
     _el.hoverPreview.classList.remove("hidden");

--- a/src/renderer/styles/detail-panel.css
+++ b/src/renderer/styles/detail-panel.css
@@ -293,6 +293,32 @@ li.fact-item--split {
   padding-top: 5px;
 }
 
+.hover-preview__trait-skill-divider {
+  text-align: center;
+  color: #6a8a5a;
+  font-size: 0.55rem;
+  margin: 8px 0 4px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  border-top: 1px solid rgba(100, 140, 90, 0.3);
+  padding-top: 5px;
+}
+
+.hover-preview__trait-skill-divider + .hover-preview__head {
+  grid-template-columns: 36px 1fr;
+  gap: 8px;
+}
+
+.hover-preview__trait-skill-divider + .hover-preview__head .hover-preview__icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 7px;
+}
+
+.hover-preview__trait-skill-divider + .hover-preview__head .hover-preview__title {
+  font-size: 0.82rem;
+}
+
 .hover-preview__head--chained {
   margin-top: 2px;
 }

--- a/tests/unit/renderer/detail-panel.test.js
+++ b/tests/unit/renderer/detail-panel.test.js
@@ -259,3 +259,128 @@ describe("showHoverPreview — flip-chain suppression for mismatched elite spec"
     expect(mockHover.innerHTML).not.toContain("Overload Fire (Weaver target)");
   });
 });
+
+// ── showHoverPreview — trait-associated skill cards ─────────────────────────
+//
+// When hovering over a trait that has traitSkillIds (skills triggered by the
+// trait), the hover preview should show the associated skill card(s) below the
+// trait card, separated by a "Trait skill" divider.
+
+describe("showHoverPreview — trait-associated skill cards", () => {
+  const LESSER_SIGNET = {
+    id: 79344, name: "Lesser Signet of the Locust", specialization: 0,
+    icon: "", iconFallback: "", description: "Strikes nearby foes", facts: [],
+    traitedFacts: [], slot: "", type: "", professions: [],
+    attunement: "", weaponType: "", hasSplit: false,
+  };
+
+  const TRAIT_WITH_SKILLS = {
+    id: 916, name: "Malicious Swarm", tier: 3, slot: "Major",
+    specialization: 53, icon: "", iconFallback: "",
+    description: "Minions have a chance to inflict poison.",
+    facts: [], traitedFacts: [],
+    traitSkillIds: [79344],
+    traitSkillIcons: { 79344: "" },
+  };
+
+  const TRAIT_WITHOUT_SKILLS = {
+    id: 900, name: "Plain Trait", tier: 1, slot: "Major",
+    specialization: 53, icon: "", iconFallback: "",
+    description: "A basic trait.", facts: [], traitedFacts: [],
+    traitSkillIds: [],
+    traitSkillIcons: {},
+  };
+
+  const MOCK_CATALOG = {
+    specializationById: new Map(),
+    skillById: new Map([
+      [79344, LESSER_SIGNET],
+    ]),
+    weaponSkillById: new Map(),
+  };
+
+  let savedEditor;
+  let savedCatalog;
+  let savedWindow;
+  let savedDocument;
+  let mockHover;
+
+  beforeEach(() => {
+    savedEditor   = state.editor;
+    savedCatalog  = state.activeCatalog;
+    savedWindow   = global.window;
+    savedDocument = global.document;
+
+    global.window = { innerWidth: 1920, innerHeight: 1080 };
+    global.document = {
+      createElement(tag) {
+        if (tag === "textarea") {
+          const el = { _html: "", value: "" };
+          Object.defineProperty(el, "innerHTML", {
+            set(v) { el._html = v; el.value = v; },
+            get() { return el._html; },
+          });
+          return el;
+        }
+        return {};
+      },
+    };
+
+    mockHover = {
+      innerHTML: "",
+      style: {},
+      classList: {
+        _classes: new Set(),
+        add(c)      { this._classes.add(c); },
+        remove(c)   { this._classes.delete(c); },
+        contains(c) { return this._classes.has(c); },
+      },
+      getBoundingClientRect: () => ({ width: 200, height: 100 }),
+    };
+
+    detailPanel.initDetailPanel({ hoverPreview: mockHover }, {});
+
+    state.activeCatalog = MOCK_CATALOG;
+    state.editor = {
+      profession: "Necromancer",
+      specializations: [{ specializationId: 53, majorChoices: { 3: 916 } }],
+      skills: { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 },
+      activeWeaponSet: 1,
+      equipment: {
+        slots: {},
+        weapons: { mainhand1: "", offhand1: "", mainhand2: "", offhand2: "" },
+      },
+    };
+  });
+
+  afterEach(() => {
+    state.editor        = savedEditor;
+    state.activeCatalog = savedCatalog;
+    global.window       = savedWindow;
+    global.document     = savedDocument;
+  });
+
+  test("shows associated skill card when trait has traitSkillIds", () => {
+    detailPanel.showHoverPreview("trait", TRAIT_WITH_SKILLS, 100, 100);
+    expect(mockHover.innerHTML).toContain("Lesser Signet of the Locust");
+    expect(mockHover.innerHTML).toContain("hover-preview__trait-skill-divider");
+  });
+
+  test("does not show trait-skill divider when trait has no traitSkillIds", () => {
+    detailPanel.showHoverPreview("trait", TRAIT_WITHOUT_SKILLS, 100, 100);
+    expect(mockHover.innerHTML).not.toContain("hover-preview__trait-skill-divider");
+    expect(mockHover.innerHTML).not.toContain("Lesser Signet of the Locust");
+  });
+
+  test("does not show trait-skill divider when traitSkillIds is absent", () => {
+    const traitNoField = { ...TRAIT_WITH_SKILLS, traitSkillIds: undefined };
+    detailPanel.showHoverPreview("trait", traitNoField, 100, 100);
+    expect(mockHover.innerHTML).not.toContain("hover-preview__trait-skill-divider");
+  });
+
+  test("gracefully skips skill IDs not found in skillById", () => {
+    const traitMissing = { ...TRAIT_WITH_SKILLS, traitSkillIds: [99999] };
+    detailPanel.showHoverPreview("trait", traitMissing, 100, 100);
+    expect(mockHover.innerHTML).not.toContain("hover-preview__trait-skill-divider");
+  });
+});


### PR DESCRIPTION
## Summary

- Expands the catalog to fetch **all** trait-associated skill objects (not just elite spec traits), so skills like Lesser Signet of the Locust and Lesser Guard are available in `skillById`
- Appends associated skill cards below the trait card in the hover preview, separated by a "Trait skill" divider
- Trait skill cards are visually smaller (36px icon, reduced title font) to distinguish them from the primary trait card
- Uses `traitSkillIcons` from the embedded trait API data to prefer the correct skill icon when the `/v2/skills` endpoint returns the wrong one

Closes #110