### PR TITLE
feat: render combo finisher/field types in skill tooltips

### DIFF
--- a/lib/gw2-balance-splits/match.js
+++ b/lib/gw2-balance-splits/match.js
@@ -25,7 +25,7 @@ function splitGroupKey(f) {
   return `${splitNormalizeType(f.type)}:${f.target || f.status || ""}`;
 }
 
-const SPLIT_VALUE_KEYS = ["value", "distance", "duration", "apply_count", "dmg_multiplier", "hit_count", "percent", "coefficient"];
+const SPLIT_VALUE_KEYS = ["value", "distance", "duration", "apply_count", "dmg_multiplier", "hit_count", "percent", "coefficient", "finisher_type", "field_type"];
 
 // hit_count is metadata — skip it when the base didn't carry it (avoids false positives
 // from the wiki scraper always emitting hit_count:1). For all other keys (including

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -586,6 +586,21 @@ export function formatFactHtml(fact, dmgStats = null, { alacrity = false } = {})
     const iconUrl = fact.icon || FACT_TYPE_ICONS["Time"] || "";
     return iconUrl ? `<img class="fact-status-icon" src="${escapeHtml(iconUrl)}" alt="" aria-hidden="true">${escapeHtml(text)}` : escapeHtml(text);
   }
+  if (fact.type === "ComboFinisher") {
+    const label = String(fact.text || "Combo Finisher");
+    const finisher = fact.finisher_type || "";
+    const pct = fact.percent != null && fact.percent < 100 ? ` (${fact.percent}%)` : "";
+    const text = finisher ? `${label}: ${finisher}${pct}` : label;
+    const iconUrl = fact.icon || FACT_TYPE_ICONS["ComboFinisher"] || "";
+    return iconUrl ? `<img class="fact-status-icon" src="${escapeHtml(iconUrl)}" alt="" aria-hidden="true">${escapeHtml(text)}` : escapeHtml(text);
+  }
+  if (fact.type === "ComboField") {
+    const label = String(fact.text || "Combo Field");
+    const field = fact.field_type || "";
+    const text = field ? `${label}: ${field}` : label;
+    const iconUrl = fact.icon || FACT_TYPE_ICONS["ComboField"] || "";
+    return iconUrl ? `<img class="fact-status-icon" src="${escapeHtml(iconUrl)}" alt="" aria-hidden="true">${escapeHtml(text)}` : escapeHtml(text);
+  }
   // Recharge facts — apply Alacrity reduction when active
   if (fact.type === "Recharge" && fact.value != null) {
     const label = String(fact.text || "Recharge");

--- a/tests/unit/renderer/detail-panel.test.js
+++ b/tests/unit/renderer/detail-panel.test.js
@@ -384,3 +384,35 @@ describe("showHoverPreview — trait-associated skill cards", () => {
     expect(mockHover.innerHTML).not.toContain("hover-preview__trait-skill-divider");
   });
 });
+
+describe("formatFactHtml — ComboFinisher / ComboField", () => {
+  test("renders combo finisher with type name", () => {
+    const html = detailPanel.formatFactHtml({
+      type: "ComboFinisher", text: "Combo Finisher", finisher_type: "Blast", percent: 100,
+    });
+    expect(html).toContain("Combo Finisher: Blast");
+    expect(html).not.toContain("100");
+  });
+
+  test("renders combo finisher with percent when below 100", () => {
+    const html = detailPanel.formatFactHtml({
+      type: "ComboFinisher", text: "Combo Finisher", finisher_type: "Whirl", percent: 20,
+    });
+    expect(html).toContain("Combo Finisher: Whirl (20%)");
+  });
+
+  test("renders combo field with field type name", () => {
+    const html = detailPanel.formatFactHtml({
+      type: "ComboField", text: "Combo Field", field_type: "Fire",
+    });
+    expect(html).toContain("Combo Field: Fire");
+  });
+
+  test("renders combo field type name not a numeric fallback", () => {
+    const html = detailPanel.formatFactHtml({
+      type: "ComboField", text: "Combo Field", field_type: "Water",
+    });
+    expect(html).toContain("Combo Field: Water");
+    expect(html).not.toContain("Combo Field: 0");
+  });
+});

--- a/tests/unit/wiki-audit-compare.test.js
+++ b/tests/unit/wiki-audit-compare.test.js
@@ -73,6 +73,44 @@ describe("compareEntity", () => {
     expect(result.category).toBe("missing_from_wiki");
     expect(result.splits_only_facts).toHaveLength(1);
   });
+
+  test("detects mismatch when combo finisher_type differs", () => {
+    const wikiFacts = [
+      { type: "ComboFinisher", text: "Combo Finisher", finisher_type: "Blast", percent: 100 },
+    ];
+    const splitEntry = {
+      facts: [{ type: "ComboFinisher", text: "Combo Finisher", finisher_type: "Whirl", percent: 100 }],
+      complete: true,
+    };
+    const result = compareEntity(wikiFacts, splitEntry);
+    expect(result.category).toBe("mismatch");
+    expect(result.fact_diffs[0].fields.finisher_type).toEqual({ wiki: "Blast", splits: "Whirl" });
+  });
+
+  test("detects mismatch when combo field_type differs", () => {
+    const wikiFacts = [
+      { type: "ComboField", text: "Combo Field", field_type: "Fire" },
+    ];
+    const splitEntry = {
+      facts: [{ type: "ComboField", text: "Combo Field", field_type: "Water" }],
+      complete: true,
+    };
+    const result = compareEntity(wikiFacts, splitEntry);
+    expect(result.category).toBe("mismatch");
+    expect(result.fact_diffs[0].fields.field_type).toEqual({ wiki: "Fire", splits: "Water" });
+  });
+
+  test("returns match when combo finisher facts agree", () => {
+    const wikiFacts = [
+      { type: "ComboFinisher", text: "Combo Finisher", finisher_type: "Blast", percent: 100 },
+    ];
+    const splitEntry = {
+      facts: [{ type: "ComboFinisher", text: "Combo Finisher", finisher_type: "Blast", percent: 100 }],
+      complete: true,
+    };
+    const result = compareEntity(wikiFacts, splitEntry);
+    expect(result.category).toBe("match");
+  });
 });
 
 const { compareRelicFacts } = require("../wiki-audit/compare");
@@ -127,5 +165,37 @@ describe("compareRelicFacts", () => {
   test("returns no_split when wiki is empty and stored is null", () => {
     const result = compareRelicFacts([], null);
     expect(result.category).toBe("no_split");
+  });
+});
+
+const { splitValueChanged, SPLIT_VALUE_KEYS } = require("../../lib/gw2-balance-splits/match");
+
+describe("SPLIT_VALUE_KEYS includes combo keys", () => {
+  test("includes finisher_type", () => {
+    expect(SPLIT_VALUE_KEYS).toContain("finisher_type");
+  });
+
+  test("includes field_type", () => {
+    expect(SPLIT_VALUE_KEYS).toContain("field_type");
+  });
+});
+
+describe("splitValueChanged detects combo type changes", () => {
+  test("detects finisher_type change", () => {
+    const before = { type: "ComboFinisher", finisher_type: "Blast", percent: 100 };
+    const after = { type: "ComboFinisher", finisher_type: "Whirl", percent: 100 };
+    expect(splitValueChanged(before, after)).toBe(true);
+  });
+
+  test("detects field_type change", () => {
+    const before = { type: "ComboField", field_type: "Fire" };
+    const after = { type: "ComboField", field_type: "Water" };
+    expect(splitValueChanged(before, after)).toBe(true);
+  });
+
+  test("no change when combo facts match", () => {
+    const before = { type: "ComboFinisher", finisher_type: "Blast", percent: 100 };
+    const after = { type: "ComboFinisher", finisher_type: "Blast", percent: 100 };
+    expect(splitValueChanged(before, after)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- ComboFinisher/ComboField facts now display their type name (e.g. "Combo Finisher: Blast", "Combo Field: Fire") instead of a numeric fallback like "Combo Finisher: 100"
- Added `finisher_type` and `field_type` to `SPLIT_VALUE_KEYS` so the wiki audit comparison can detect combo type mismatches and fix-splits can patch them
- Sub-100% finishers show the percentage (e.g. "Physical Projectile (20%)")

## Test plan
- [x] All 1339 tests pass
- [ ] Verify combo finisher skills (e.g. Whirling Axe) show type name in detail panel
- [ ] Verify combo field skills show field type name in detail panel
- [ ] Verify sub-100% finishers display percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)