### PR TITLE
fix: filter profession skills by equipped weapon in party coverage

### DIFF
--- a/src/renderer/modules/boon-coverage.js
+++ b/src/renderer/modules/boon-coverage.js
@@ -190,11 +190,23 @@ function collectSkillIds(editor, catalog) {
   const selectedSpecIds = new Set(
     (editor.specializations || []).map((s) => Number(s?.specializationId || s?.id) || 0).filter(Boolean)
   );
+  // Collect equipped weapon types so weapon-specific profession skills (e.g. Warrior
+  // bursts) are filtered to only those matching an equipped weapon.
+  const equippedWeapons = editor.equipment?.weapons || {};
+  const equippedWeaponTypes = new Set(
+    ["mainhand1", "offhand1", "mainhand2", "offhand2", "aquatic1", "aquatic2"]
+      .map((k) => (equippedWeapons[k] || "").toLowerCase())
+      .filter(Boolean)
+  );
   for (const s of profSkills) {
     if ((s.type || "").toLowerCase() !== "profession") continue;
     const reqSpec = Number(s.specialization) || 0;
     if (reqSpec && !selectedSpecIds.has(reqSpec)) continue;
-    if (/^Profession_[1-5]$/.test(s.slot || "")) ids.add(s.id);
+    if (!/^Profession_[1-5]$/.test(s.slot || "")) continue;
+    // If the skill is tied to a specific weapon, only include it when that weapon is equipped.
+    const wt = (s.weaponType || "").toLowerCase();
+    if (wt && !equippedWeaponTypes.has(wt)) continue;
+    ids.add(s.id);
   }
   // Revenant legend skills (heal, utilities, elite) — fixed per legend stance
   for (const legendId of editor.selectedLegends || []) {

--- a/tests/unit/renderer/boon-coverage.test.js
+++ b/tests/unit/renderer/boon-coverage.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { computeBoonCoverage } = require("../../../src/renderer/modules/boon-coverage");
+const { computeBoonCoverage, computePartyCoverage } = require("../../../src/renderer/modules/boon-coverage");
 
 function makeCatalog(overrides = {}) {
   return {
@@ -411,5 +411,89 @@ describe("computeBoonCoverage", () => {
     expect(result.boons.find((b) => b.name === "Swiftness").sources[0]).toMatchObject({
       type: "skill", name: "Chapter 3: Azure Sun",
     });
+  });
+});
+
+describe("computePartyCoverage", () => {
+  test("only includes profession skills for equipped weapons (Warrior burst filtering)", () => {
+    // Earthshaker = Hammer burst (Blast finisher), Scorched Earth = Longbow Berserker burst (Fire field)
+    const earthshaker = makeSkill(14387, "Earthshaker", [
+      { type: "ComboFinisher", finisher_type: "Blast", percent: 100 },
+    ], { type: "Profession", slot: "Profession_1", weaponType: "Hammer" });
+    const scorched = makeSkill(29923, "Scorched Earth", [
+      { type: "ComboField", field_type: "Fire" },
+    ], { type: "Profession", slot: "Profession_1", weaponType: "Longbow", specialization: 18 });
+    const harriers = makeSkill(73024, "Harrier's Toss", [
+      { type: "ComboFinisher", finisher_type: "Blast", percent: 100 },
+    ], { type: "Profession", slot: "Profession_1", weaponType: "Spear" });
+
+    const catalog = makeCatalog({
+      skills: [earthshaker, scorched, harriers],
+      skillById: new Map([
+        [14387, earthshaker],
+        [29923, scorched],
+        [73024, harriers],
+      ]),
+      specializationById: new Map([[18, { id: 18, elite: true, name: "Berserker", minorTraits: [] }]]),
+    });
+
+    // Build has Hammer equipped (mainhand1) and Berserker spec selected
+    const editor = makeEditor({
+      equipment: { weapons: { mainhand1: "Hammer" } },
+      specializations: [{ specializationId: 18, majorChoices: { 1: 0, 2: 0, 3: 0 } }],
+    });
+
+    const result = computePartyCoverage(catalog, editor);
+
+    // Earthshaker (Hammer) should be included — Blast finisher
+    const blastSources = result.comboFinishers.filter((f) => f.finisherType === "Blast");
+    expect(blastSources.some((f) => f.sourceName === "Earthshaker")).toBe(true);
+
+    // Harrier's Toss (Spear) should NOT be included — Spear is not equipped
+    expect(blastSources.some((f) => f.sourceName === "Harrier's Toss")).toBe(false);
+
+    // Scorched Earth (Longbow) should NOT be included — Longbow is not equipped
+    const fireFields = result.comboFields.filter((f) => f.fieldType === "Fire");
+    expect(fireFields.some((f) => f.sourceName === "Scorched Earth")).toBe(false);
+  });
+
+  test("includes weapon-agnostic profession skills regardless of equipped weapons", () => {
+    // A profession skill with no weaponType should always be included
+    const genericF2 = makeSkill(999, "Generic Mechanic", [
+      { type: "ComboFinisher", finisher_type: "Blast", percent: 100 },
+    ], { type: "Profession", slot: "Profession_2", weaponType: "" });
+
+    const catalog = makeCatalog({
+      skills: [genericF2],
+      skillById: new Map([[999, genericF2]]),
+    });
+
+    const editor = makeEditor({
+      equipment: { weapons: { mainhand1: "Sword" } },
+    });
+
+    const result = computePartyCoverage(catalog, editor);
+    const blastSources = result.comboFinishers.filter((f) => f.finisherType === "Blast");
+    expect(blastSources.some((f) => f.sourceName === "Generic Mechanic")).toBe(true);
+  });
+
+  test("includes profession skills for second weapon set", () => {
+    const burstSkill = makeSkill(14506, "Combustive Shot", [
+      { type: "ComboField", field_type: "Fire" },
+    ], { type: "Profession", slot: "Profession_1", weaponType: "Longbow" });
+
+    const catalog = makeCatalog({
+      skills: [burstSkill],
+      skillById: new Map([[14506, burstSkill]]),
+    });
+
+    // Longbow only on weapon set 2
+    const editor = makeEditor({
+      equipment: { weapons: { mainhand1: "Hammer", mainhand2: "Longbow" } },
+    });
+
+    const result = computePartyCoverage(catalog, editor);
+    const fireFields = result.comboFields.filter((f) => f.fieldType === "Fire");
+    expect(fireFields.some((f) => f.sourceName === "Combustive Shot")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- `collectSkillIds` was adding all profession mechanic skills (F1-F5 bursts) without checking if the skill's weapon type matched an equipped weapon
- Warrior has different F1 bursts per weapon (Earthshaker for Hammer, Scorched Earth for Longbow/Berserker, Harrier's Toss for Spear, etc.), and all variants were showing in combo fields/finishers
- Now filters weapon-specific profession skills against equipped weapon slots (mainhand1/2, offhand1/2, aquatic1/2); weapon-agnostic skills are still always included

## Test plan
- [x] Added 3 unit tests for `computePartyCoverage` weapon filtering
- [x] All 1345 tests pass