### PR TITLE
fix: UI cleanup, Missing Stats, Incorrect Values (closes #121)

### DIFF
--- a/lib/gw2-balance-splits/data/splits.json
+++ b/lib/gw2-balance-splits/data/splits.json
@@ -72723,19 +72723,17 @@
         "wvw": {
           "facts": [
             {
-              "type": "Buff",
-              "text": "Life siphon damage",
-              "status": "Life siphon damage",
-              "duration": 586,
-              "apply_count": 1,
+              "type": "AttributeAdjust",
+              "text": "Life Siphon Damage",
+              "value": 586,
+              "target": "Power",
               "icon": "https://render.guildwars2.com/file/61AA4919C4A7990903241B680A69530121E994C7/156657.png"
             },
             {
-              "type": "Buff",
-              "text": "Life siphon healing",
-              "status": "Life siphon healing",
-              "duration": 581,
-              "apply_count": 1,
+              "type": "AttributeAdjust",
+              "text": "Life Siphon Healing",
+              "value": 581,
+              "target": "Healing",
               "icon": "https://render.guildwars2.com/file/61AA4919C4A7990903241B680A69530121E994C7/156657.png"
             }
           ],

--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -25,6 +25,7 @@ const _STAT_COMBOS_ENTRIES = [
   ["Harrier's", { stats: ["Power", "HealingPower", "Concentration"] }],
   ["Ritualist's", { stats: ["Vitality", "ConditionDamage", "Expertise", "Concentration"] }],
   ["Seraph", { stats: ["Precision", "ConditionDamage", "HealingPower", "Concentration"] }],
+  ["Crusader", { stats: ["Power", "Toughness", "Ferocity", "HealingPower"] }],
   ["Zealot's", { stats: ["Power", "Precision", "HealingPower"] }],
   ["Celestial", { stats: ["Power", "Precision", "Toughness", "Vitality", "ConditionDamage", "Ferocity", "HealingPower", "Expertise", "Concentration"] }],
 ];

--- a/src/renderer/modules/constants.js
+++ b/src/renderer/modules/constants.js
@@ -36,6 +36,7 @@ export const STAT_COMBOS = [
   { label: "Harrier's",     stats: ["Power", "HealingPower", "Concentration"] },
   { label: "Ritualist's",   stats: ["Vitality", "ConditionDamage", "Expertise", "Concentration"] },
   { label: "Seraph",        stats: ["Precision", "ConditionDamage", "HealingPower", "Concentration"] },
+  { label: "Crusader",       stats: ["Power", "Toughness", "Ferocity", "HealingPower"] },
   { label: "Zealot's",      stats: ["Power", "Precision", "HealingPower"] },
   { label: "Celestial",     stats: ["Power", "Precision", "Toughness", "Vitality", "ConditionDamage", "Ferocity", "HealingPower", "Expertise", "Concentration"] },
 ];

--- a/src/renderer/styles/specializations.css
+++ b/src/renderer/styles/specializations.css
@@ -281,7 +281,7 @@
 }
 
 .trait-btn--active img {
-  filter: drop-shadow(0 0 5px rgba(103, 226, 255, 0.9)) drop-shadow(0 0 2px rgba(200, 248, 255, 0.7));
+  filter: drop-shadow(0 0 6px rgba(255, 196, 56, 0.95)) drop-shadow(0 0 3px rgba(255, 230, 140, 0.8));
 }
 
 .trait-btn--active:hover {

--- a/tests/unit/balance-splits.test.js
+++ b/tests/unit/balance-splits.test.js
@@ -125,6 +125,21 @@ describe("splits.json schema validation", () => {
     }
   });
 
+  test("Carnivore trait skill (72369) WvW split uses value field matching API AttributeAdjust type (issue #121)", () => {
+    const entry = realSplits.skills["72369"];
+    expect(entry).toBeDefined();
+    expect(entry.name).toBe("Carnivore (trait skill)");
+    expect(entry.modes.wvw.complete).toBe(true);
+    // Facts must use "value" field (not "duration") to correctly merge with
+    // the GW2 API's AttributeAdjust facts — otherwise the PvE value persists.
+    for (const fact of entry.modes.wvw.facts) {
+      expect(fact.type).toBe("AttributeAdjust");
+      expect(fact).toHaveProperty("value");
+      expect(fact).not.toHaveProperty("duration");
+      expect(fact.value).toBeLessThan(1000); // WvW values are 586/581, not PvE 3205
+    }
+  });
+
   test("trait entries have valid structure", () => {
     for (const [id, entry] of Object.entries(realSplits.traits)) {
       expect(id).toMatch(/^\d+$/);

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -122,6 +122,26 @@ describe("computeSlotStats — missing stat combos (issue #29)", () => {
   });
 });
 
+describe("computeSlotStats — Crusader stats (issue #121)", () => {
+  test("Crusader is defined as a 4-stat combo with Power+Toughness major, Ferocity+HealingPower minor", () => {
+    const result = computeSlotStats("Crusader", "chest");
+    expect(result).toHaveLength(4);
+    expect(result[0]).toEqual({ stat: "Power",        value: 121 }); // p4 for chest
+    expect(result[1]).toEqual({ stat: "Toughness",    value: 121 }); // p4 for chest
+    expect(result[2]).toEqual({ stat: "Ferocity",     value: 66 });  // s4 for chest
+    expect(result[3]).toEqual({ stat: "HealingPower", value: 66 });  // s4 for chest
+  });
+
+  test("Crusader ring1 applies 4-stat formula", () => {
+    const result = computeSlotStats("Crusader", "ring1");
+    expect(result).toHaveLength(4);
+    expect(result[0]).toEqual({ stat: "Power",        value: 105 }); // p4 for ring1
+    expect(result[1]).toEqual({ stat: "Toughness",    value: 105 }); // p4 for ring1
+    expect(result[2]).toEqual({ stat: "Ferocity",     value: 56 });  // s4 for ring1
+    expect(result[3]).toEqual({ stat: "HealingPower", value: 56 });  // s4 for ring1
+  });
+});
+
 describe("computeSlotStats — 9-stat combo (Celestial)", () => {
   test("Celestial chest uses per-stat Celestial weight", () => {
     // chest: c=66 (Celestial per-stat weight)

--- a/tests/unit/statsCompute.test.js
+++ b/tests/unit/statsCompute.test.js
@@ -101,6 +101,16 @@ describe("computePublishStats", () => {
     expect(result.stats.Concentration).toBe(66);
   });
 
+  test("Crusader chest applies 4-stat formula (issue #121)", () => {
+    const equipment = { slots: { chest: "Crusader" }, runes: {}, infusions: {} };
+    const result = computePublishStats(equipment, null, "Guardian");
+    // Crusader: Power + Toughness major (p4=121), Ferocity + HealingPower minor (s4=66)
+    expect(result.stats.Power).toBe(1000 + 121);
+    expect(result.stats.Toughness).toBe(1000 + 121);
+    expect(result.stats.Ferocity).toBe(66);
+    expect(result.stats.HealingPower).toBe(66);
+  });
+
   test("equipment with no slots set returns only base stats", () => {
     const equipment = { slots: {}, runes: {}, infusions: {} };
     const result = computePublishStats(equipment, null, "Guardian");


### PR DESCRIPTION
## Summary

Fixes two bugs reported in #121:

1. **Missing Crusader stats** — Added the Crusader stat combo (Power/Toughness major, Ferocity/HealingPower minor) to both the renderer `STAT_COMBOS` and server-side `_STAT_COMBOS_ENTRIES` definitions. Crusader gear can now be selected in the equipment panel.

2. **Carnivore trait showing PvE values in WvW** (from issue comment) — The WvW balance split for Carnivore trait skill (72369) used `Buff` type with `duration` field, but the GW2 API returns `AttributeAdjust` type with `value` field. The merge function copies split value keys onto the base fact, so the PvE `value: 3205` was never overwritten. Fixed by changing the split data to use `AttributeAdjust` type with `value` field (586/581).

**Note:** The issue also mentions Celestial gear giving Expertise/Concentration in WvW. This is actually correct GW2 behavior — Celestial gives all 9 stats in all game modes. No change needed.

Closes #121