### PR TITLE
fix: Build exists within a profession smart folder but is not visible under All Builds (closes #117)

### DIFF
--- a/src/main/buildStore.js
+++ b/src/main/buildStore.js
@@ -88,6 +88,16 @@ class BuildStore {
     await this.#writeJson(this.buildsPath, builds);
   }
 
+  async clearCompFromBuilds(compIds) {
+    const builds = await this.#readJson(this.buildsPath, []);
+    for (const build of builds) {
+      if (compIds.includes(build.compId)) {
+        build.compId = null;
+      }
+    }
+    await this.#writeJson(this.buildsPath, builds);
+  }
+
   async getAuth() {
     return this.#readJson(this.authPath, {});
   }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -379,9 +379,17 @@ app.whenReady().then(async () => {
   // Comp CRUD
   ipcMain.handle("comps:list", () => compStore.listComps());
   ipcMain.handle("comps:save", (_e, comp) => compStore.upsertComp(comp));
-  ipcMain.handle("comps:delete", (_e, id) => compStore.deleteComp(id));
+  ipcMain.handle("comps:delete", async (_e, id) => {
+    await compStore.deleteComp(id);
+    await store.clearCompFromBuilds([id]);
+  });
   ipcMain.handle("comps:reorder", (_e, updates) => compStore.reorderComps(updates));
-  ipcMain.handle("comps:delete-batch", (_e, ids) => compStore.deleteComps(ids));
+  ipcMain.handle("comps:delete-batch", async (_e, ids) => {
+    await compStore.deleteComps(ids);
+    if (ids.length) {
+      await store.clearCompFromBuilds(ids);
+    }
+  });
   ipcMain.handle("comps:add-tags", (_e, ids, tags) => compStore.addTagsToComps(ids, tags));
   ipcMain.handle("comps:remove-tags", (_e, ids, tags) => compStore.removeTagsFromComps(ids, tags));
 

--- a/src/renderer/modules/library/folder-store.js
+++ b/src/renderer/modules/library/folder-store.js
@@ -73,8 +73,9 @@ export function getVisibleBuilds() {
         (b) => (b.gameMode || "pve") === folder.id,
       );
     } else {
-      // Non-smart views: exclude builds that are inside any comp
-      builds = builds.filter((b) => !b.compId);
+      // Non-smart views: exclude builds that are inside an existing comp
+      const compIds = new Set((state.comps || []).map((c) => c.id));
+      builds = builds.filter((b) => !b.compId || !compIds.has(b.compId));
       if (folder.type === "custom") {
         builds = builds.filter((b) => b.folderId === folder.id);
       } else if (folder.type === "all") {

--- a/tests/unit/buildStore.test.js
+++ b/tests/unit/buildStore.test.js
@@ -867,6 +867,19 @@ describe("BuildStore — move builds", () => {
     expect(builds.find((b) => b.id === b1.id).folderId).toBe(null);
     expect(builds.find((b) => b.id === b2.id).folderId).toBe("folder-xyz");
   });
+
+  test("clearCompFromBuilds sets compId to null for matching builds", async () => {
+    const b1 = await store.upsertBuild(
+      makeBuild({ title: "B1", compId: "comp-abc" }),
+    );
+    const b2 = await store.upsertBuild(
+      makeBuild({ title: "B2", compId: "comp-xyz" }),
+    );
+    await store.clearCompFromBuilds(["comp-abc"]);
+    const builds = await store.listBuilds();
+    expect(builds.find((b) => b.id === b1.id).compId).toBe(null);
+    expect(builds.find((b) => b.id === b2.id).compId).toBe("comp-xyz");
+  });
 });
 
 describe("BuildStore — pin builds", () => {

--- a/tests/unit/renderer/smart-folder-filtering.test.js
+++ b/tests/unit/renderer/smart-folder-filtering.test.js
@@ -153,9 +153,22 @@ describe("getVisibleBuilds — all-builds folder", () => {
       makeBuild({ id: "b1", compId: null }),
       makeBuild({ id: "b2", compId: "comp-1" }),
     ];
+    state.comps = [{ id: "comp-1", name: "Test Comp" }];
     state.currentFolder = { type: "all" };
 
     const result = getVisibleBuilds();
     expect(result.map((b) => b.id)).toEqual(["b1"]);
+  });
+
+  test("shows builds with orphaned compId (comp no longer exists)", () => {
+    state.builds = [
+      makeBuild({ id: "b1", compId: null }),
+      makeBuild({ id: "b2", compId: "deleted-comp" }),
+    ];
+    state.comps = [];
+    state.currentFolder = { type: "all" };
+
+    const result = getVisibleBuilds();
+    expect(result.map((b) => b.id)).toEqual(["b1", "b2"]);
   });
 });


### PR DESCRIPTION
## Summary

When a comp was deleted, builds that belonged to it retained their `compId` field. The "All Builds" view filters out any build with a non-null `compId`, so these orphaned builds became invisible there — while still appearing in profession smart folders (which don't filter by `compId`).

**Three-part fix:**
1. Added `clearCompFromBuilds()` to `BuildStore` (mirrors existing `clearFolderFromBuilds()`)
2. Updated `comps:delete` and `comps:delete-batch` IPC handlers to clear `compId` from builds when a comp is deleted
3. Made `getVisibleBuilds()` treat builds with orphaned `compId` (pointing to a non-existent comp) as root-level builds, so any previously orphaned data self-heals on display

Closes #117