### PR TITLE
fix: Missing Giver's Stats? (closes #122)

### DIFF
--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -27,6 +27,7 @@ const _STAT_COMBOS_ENTRIES = [
   ["Seraph", { stats: ["Precision", "ConditionDamage", "HealingPower", "Concentration"] }],
   ["Crusader", { stats: ["Power", "Toughness", "Ferocity", "HealingPower"] }],
   ["Zealot's", { stats: ["Power", "Precision", "HealingPower"] }],
+  ["Giver's", { stats: ["Toughness", "HealingPower", "Concentration"] }],
   ["Celestial", { stats: ["Power", "Precision", "Toughness", "Vitality", "ConditionDamage", "Ferocity", "HealingPower", "Expertise", "Concentration"] }],
 ];
 // Add aliases without "'s" so imported builds (e.g. "Wanderer") resolve correctly

--- a/src/renderer/modules/constants.js
+++ b/src/renderer/modules/constants.js
@@ -38,6 +38,7 @@ export const STAT_COMBOS = [
   { label: "Seraph",        stats: ["Precision", "ConditionDamage", "HealingPower", "Concentration"] },
   { label: "Crusader",       stats: ["Power", "Toughness", "Ferocity", "HealingPower"] },
   { label: "Zealot's",      stats: ["Power", "Precision", "HealingPower"] },
+  { label: "Giver's",       stats: ["Toughness", "HealingPower", "Concentration"] },
   { label: "Celestial",     stats: ["Power", "Precision", "Toughness", "Vitality", "ConditionDamage", "Ferocity", "HealingPower", "Expertise", "Concentration"] },
 ];
 

--- a/tests/unit/statsCompute.test.js
+++ b/tests/unit/statsCompute.test.js
@@ -111,6 +111,15 @@ describe("computePublishStats", () => {
     expect(result.stats.HealingPower).toBe(66);
   });
 
+  test("Giver's chest applies 3-stat formula (issue #122)", () => {
+    const equipment = { slots: { chest: "Giver's" }, runes: {}, infusions: {} };
+    const result = computePublishStats(equipment, null, "Guardian");
+    // Giver's: Toughness major (p=141), HealingPower + Concentration minor (s=101)
+    expect(result.stats.Toughness).toBe(1000 + 141);
+    expect(result.stats.HealingPower).toBe(101);
+    expect(result.stats.Concentration).toBe(101);
+  });
+
   test("equipment with no slots set returns only base stats", () => {
     const equipment = { slots: {}, runes: {}, infusions: {} };
     const result = computePublishStats(equipment, null, "Guardian");


### PR DESCRIPTION
## Summary

Giver's stat combo (Toughness / Healing Power / Concentration) was missing from both the renderer `STAT_COMBOS` list and the main-process `statsCompute.js` duplicate list. This meant it never appeared in the equipment stat dropdown and could not be selected for any armor or weapon slot.

Added Giver's to both stat combo arrays and added a regression test confirming stat computation works correctly.

Closes #122