### PR TITLE
fix: relic on equipment panel is missing facts (closes #125)

### DIFF
--- a/src/main/buildPublish.js
+++ b/src/main/buildPublish.js
@@ -265,6 +265,17 @@ function resolveEquipmentDisplay(equipment, upgradeCatalog) {
     return { name: label, icon: "" };
   }
 
+  function resolveRelicByName(label, relicByNameMap) {
+    if (!label) return null;
+    const item = relicByNameMap?.get(label);
+    if (!item) return { name: label, icon: "" };
+    return {
+      name: item.name, icon: item.icon || "",
+      ...(item.description ? { description: item.description } : {}),
+      ...(item.facts?.length ? { facts: item.facts } : {}),
+    };
+  }
+
   const runes = equipment.runes || {};
   const sigils = equipment.sigils || {};
   const infusions = equipment.infusions || {};
@@ -298,7 +309,7 @@ function resolveEquipmentDisplay(equipment, upgradeCatalog) {
     infusions: resolvedInfusions,
     food: resolveId(equipment.food, upgradeCatalog.foodById),
     utility: resolveId(equipment.utility, upgradeCatalog.utilityById),
-    relic: resolveByName(equipment.relic),
+    relic: resolveRelicByName(equipment.relic, upgradeCatalog.relicByName),
     enrichment: resolveId(equipment.enrichment, upgradeCatalog.enrichmentById),
   };
 }

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -329,6 +329,7 @@ async function init() {
     raw.foodById = new Map((raw.foods || []).map((f) => [f.id, f]));
     raw.utilityById = new Map((raw.utilities || []).map((u) => [u.id, u]));
     raw.relicById = new Map((raw.relics || []).map((r) => [r.id, r]));
+    raw.relicByName = new Map((raw.relics || []).map((r) => [r.name, r]));
     state.upgradeCatalog = raw;
   }).catch((err) => {
     console.warn("Failed to load upgrade catalog:", err);

--- a/src/site/render-build.js
+++ b/src/site/render-build.js
@@ -185,6 +185,7 @@ function populateStateFromBuild(build) {
     enrichmentById: new Map(eqd.enrichment ? [[eqd.enrichment.id, eqd.enrichment]] : []),
     foodById:       new Map(eqd.food ? [[eqd.food.id, eqd.food]] : []),
     utilityById:    new Map(eqd.utility ? [[eqd.utility.id, eqd.utility]] : []),
+    relicByName:    new Map(eqd.relic ? [[eqd.relic.name, eqd.relic]] : []),
   };
 }
 

--- a/tests/unit/buildPublish.test.js
+++ b/tests/unit/buildPublish.test.js
@@ -130,6 +130,11 @@ function makeMockUpgradeCatalog() {
     }]]),
     foodById: new Map([[91805, { id: 91805, name: "Bowl of Soup", icon: "soup.png" }]]),
     utilityById: new Map([[67528, { id: 67528, name: "Superior Sharpening Stone", icon: "stone.png" }]]),
+    relicByName: new Map([["Relic of the Thief", {
+      name: "Relic of the Thief", icon: "thief-relic.png",
+      description: "Steal health on hit.",
+      facts: [{ type: "Recharge", text: "Cooldown", value: 10 }],
+    }]]),
   };
 }
 
@@ -235,6 +240,25 @@ describe("serializeForPublish", () => {
     expect(result.equipmentDisplay.enrichment.infixUpgrade).toEqual({
       attributes: [{ attribute: "Vitality", modifier: 15 }],
     });
+  });
+
+  test("resolves relic name to display object with description and facts", () => {
+    const build = makeMockBuild();
+    build.equipment.relic = "Relic of the Thief";
+    const result = serializeForPublish(build, makeMockCatalog(), makeMockUpgradeCatalog());
+    expect(result.equipmentDisplay.relic).toEqual({
+      name: "Relic of the Thief",
+      icon: "thief-relic.png",
+      description: "Steal health on hit.",
+      facts: [{ type: "Recharge", text: "Cooldown", value: 10 }],
+    });
+  });
+
+  test("resolves unknown relic name to minimal display object", () => {
+    const build = makeMockBuild();
+    build.equipment.relic = "Relic of the Unknown";
+    const result = serializeForPublish(build, makeMockCatalog(), makeMockUpgradeCatalog());
+    expect(result.equipmentDisplay.relic).toEqual({ name: "Relic of the Unknown", icon: "" });
   });
 
   test("handles missing upgrade catalog gracefully", () => {

--- a/tests/unit/renderer/relic-facts-equipment.test.js
+++ b/tests/unit/renderer/relic-facts-equipment.test.js
@@ -1,0 +1,147 @@
+"use strict";
+
+/**
+ * Regression test for #125: relic on equipment panel is missing facts.
+ *
+ * The upgrade catalog sent over IPC loses its Maps. The renderer reconstructs
+ * id-keyed Maps (relicById) but was missing the name-keyed relicByName Map
+ * that the equipment hover preview uses to look up relic descriptions and facts.
+ */
+
+const detailPanel = require("../../../src/renderer/modules/detail-panel");
+const { state } = require("../../../src/renderer/modules/state");
+
+let savedWindow, savedDocument, savedEditor, savedCatalog, savedUpgradeCatalog;
+let mockHover;
+
+beforeEach(() => {
+  savedWindow          = global.window;
+  savedDocument        = global.document;
+  savedEditor          = state.editor;
+  savedCatalog         = state.activeCatalog;
+  savedUpgradeCatalog  = state.upgradeCatalog;
+
+  global.window = { innerWidth: 1920, innerHeight: 1080 };
+  global.document = {
+    createElement(tag) {
+      if (tag === "textarea") {
+        const el = { _html: "", value: "" };
+        Object.defineProperty(el, "innerHTML", {
+          set(v) { el._html = v; el.value = v; },
+          get() { return el._html; },
+        });
+        return el;
+      }
+      return {};
+    },
+  };
+
+  mockHover = {
+    innerHTML: "",
+    style: {},
+    classList: {
+      _classes: new Set(),
+      add(c)      { this._classes.add(c); },
+      remove(c)   { this._classes.delete(c); },
+      contains(c) { return this._classes.has(c); },
+    },
+    getBoundingClientRect: () => ({ width: 200, height: 100 }),
+  };
+
+  detailPanel.initDetailPanel({ hoverPreview: mockHover }, {});
+  state.editor = {
+    profession: "",
+    specializations: [],
+    skills: { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 },
+    activeWeaponSet: 1,
+    equipment: { slots: {}, weapons: {} },
+  };
+  state.activeCatalog = null;
+});
+
+afterEach(() => {
+  global.window          = savedWindow;
+  global.document        = savedDocument;
+  state.editor           = savedEditor;
+  state.activeCatalog    = savedCatalog;
+  state.upgradeCatalog   = savedUpgradeCatalog;
+});
+
+describe("Relic facts on equipment panel (#125)", () => {
+  test("upgradeCatalog with relicByName allows relic facts to be resolved", () => {
+    // Simulate the catalog as reconstructed by renderer.js after IPC.
+    // The bug: relicByName was never created, so the equipment hover
+    // preview could not look up relic data by name.
+    const relics = [
+      {
+        id: 99965,
+        name: "Relic of Cerus",
+        icon: "https://example.com/cerus.png",
+        facts: [
+          { type: "Recharge", text: "Cooldown", value: 30 },
+          { type: "Percent", text: "Damage Increase", percent: 10 },
+        ],
+      },
+    ];
+
+    const catalog = {
+      relics,
+      relicById: new Map(relics.map((r) => [r.id, r])),
+      relicByName: new Map(relics.map((r) => [r.name, r])),
+    };
+
+    // Verify the name-based lookup works (this is what equipment.js uses)
+    const found = catalog.relicByName.get("Relic of Cerus");
+    expect(found).toBeDefined();
+    expect(found.facts).toHaveLength(2);
+
+    // Build a skill card using the looked-up relic data — simulates what
+    // the equipment panel hover does
+    const entity = {
+      name: found.name,
+      icon: found.icon,
+      description: "",
+      facts: found.facts,
+    };
+
+    const html = detailPanel.buildSkillCard(entity, "equip-relic");
+    expect(html).toContain("Cooldown: 30s");
+    expect(html).toContain("Damage Increase");
+  });
+
+  test("missing relicByName causes relic facts lookup to fail", () => {
+    // Simulates the buggy state where relicByName is not constructed
+    const relics = [
+      {
+        id: 99965,
+        name: "Relic of Cerus",
+        icon: "https://example.com/cerus.png",
+        facts: [
+          { type: "Recharge", text: "Cooldown", value: 30 },
+        ],
+      },
+    ];
+
+    const catalog = {
+      relics,
+      relicById: new Map(relics.map((r) => [r.id, r])),
+      // relicByName intentionally omitted — this is the bug
+    };
+
+    // This is what equipment.js line 1637 does:
+    const catalogRelic = catalog.relicByName?.get("Relic of Cerus");
+    expect(catalogRelic).toBeUndefined();
+
+    // Without relicByName, entity gets empty facts
+    const entity = {
+      name: "Relic of Cerus",
+      icon: "https://example.com/cerus.png",
+      description: catalogRelic?.description || "",
+      facts: catalogRelic?.facts || [],
+    };
+
+    const html = detailPanel.buildSkillCard(entity, "equip-relic");
+    // Facts are missing — the bug
+    expect(html).not.toContain("Cooldown: 30s");
+  });
+});

--- a/tests/unit/renderer/relic-facts-equipment.test.js
+++ b/tests/unit/renderer/relic-facts-equipment.test.js
@@ -109,6 +109,40 @@ describe("Relic facts on equipment panel (#125)", () => {
     expect(html).toContain("Damage Increase");
   });
 
+  test("SPA-style catalog with relicByName from equipmentDisplay resolves facts", () => {
+    // Simulates the SPA path: relic data comes from the published build's
+    // equipmentDisplay, reconstructed in render-build.js as relicByName.
+    const relic = {
+      name: "Relic of Cerus",
+      icon: "https://example.com/cerus.png",
+      description: "Upon using an elite skill, summon an Eye of Cerus.",
+      facts: [
+        { type: "Recharge", text: "Cooldown", value: 30 },
+        { type: "Percent", text: "Damage Increase", percent: 10 },
+      ],
+    };
+
+    // This mirrors what render-build.js now does:
+    const catalog = {
+      relicByName: new Map([[relic.name, relic]]),
+    };
+
+    const found = catalog.relicByName.get("Relic of Cerus");
+    expect(found).toBeDefined();
+    expect(found.facts).toHaveLength(2);
+
+    const entity = {
+      name: found.name,
+      icon: found.icon,
+      description: found.description || "",
+      facts: found.facts,
+    };
+
+    const html = detailPanel.buildSkillCard(entity, "equip-relic");
+    expect(html).toContain("Cooldown: 30s");
+    expect(html).toContain("Damage Increase");
+  });
+
   test("missing relicByName causes relic facts lookup to fail", () => {
     // Simulates the buggy state where relicByName is not constructed
     const relics = [


### PR DESCRIPTION
## Summary
The upgrade catalog's `relicByName` Map was not being reconstructed after IPC serialization in the renderer process. The main process (`catalog.js`) creates `relicByName`, but Maps don't survive IPC transfer. The renderer (`renderer.js`) was reconstructing all other Maps (`runeById`, `sigilById`, `relicById`, etc.) but missed `relicByName`. This caused the equipment panel's relic hover preview to fail its lookup at `state.upgradeCatalog.relicByName.get(name)`, resulting in no description or facts being shown.

The fix adds the missing `relicByName` Map reconstruction alongside the existing `relicById` line.

Closes #125