### PR TITLE
feat: add 15 missing stat sets for PvE and WvW (closes #133)

### DIFF
--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -28,6 +28,22 @@ const _STAT_COMBOS_ENTRIES = [
   ["Crusader", { stats: ["Power", "Toughness", "Ferocity", "HealingPower"] }],
   ["Zealot's", { stats: ["Power", "Precision", "HealingPower"] }],
   ["Celestial", { stats: ["Power", "Precision", "Toughness", "Vitality", "ConditionDamage", "Ferocity", "HealingPower", "Expertise", "Concentration"] }],
+  // Added in issue #133 — missing PvE / WvW stat sets
+  ["Apothecary's", { stats: ["HealingPower", "Toughness", "ConditionDamage"] }],
+  ["Magi's", { stats: ["HealingPower", "Precision", "Vitality"] }],
+  ["Shaman's", { stats: ["Vitality", "ConditionDamage", "HealingPower"] }],
+  ["Rampager's", { stats: ["Precision", "Power", "ConditionDamage"] }],
+  ["Cavalier's", { stats: ["Toughness", "Power", "Ferocity"] }],
+  ["Nomad's", { stats: ["Toughness", "Vitality", "HealingPower"] }],
+  ["Settler's", { stats: ["Toughness", "ConditionDamage", "HealingPower"] }],
+  ["Giver's", { stats: ["Toughness", "HealingPower", "Concentration"] }],
+  ["Captain's", { stats: ["Toughness", "Power", "HealingPower"] }],
+  ["Vigilant", { stats: ["Power", "Toughness", "Concentration"] }],
+  ["Apostate's", { stats: ["ConditionDamage", "Toughness", "HealingPower"] }],
+  ["Plaguedoctor's", { stats: ["ConditionDamage", "Vitality", "HealingPower", "Concentration"] }],
+  ["Marshal's", { stats: ["Power", "HealingPower", "Precision", "ConditionDamage"] }],
+  ["Demolisher", { stats: ["Power", "Precision", "Toughness", "Ferocity"] }],
+  ["Commander's", { stats: ["Power", "Precision", "Toughness", "Concentration"] }],
 ];
 // Add aliases without "'s" so imported builds (e.g. "Wanderer") resolve correctly
 const STAT_COMBOS_BY_LABEL = new Map(

--- a/src/renderer/modules/constants.js
+++ b/src/renderer/modules/constants.js
@@ -39,6 +39,22 @@ export const STAT_COMBOS = [
   { label: "Crusader",       stats: ["Power", "Toughness", "Ferocity", "HealingPower"] },
   { label: "Zealot's",      stats: ["Power", "Precision", "HealingPower"] },
   { label: "Celestial",     stats: ["Power", "Precision", "Toughness", "Vitality", "ConditionDamage", "Ferocity", "HealingPower", "Expertise", "Concentration"] },
+  // Added in issue #133 — missing PvE / WvW stat sets
+  { label: "Apothecary's",  stats: ["HealingPower", "Toughness", "ConditionDamage"] },
+  { label: "Magi's",        stats: ["HealingPower", "Precision", "Vitality"] },
+  { label: "Shaman's",      stats: ["Vitality", "ConditionDamage", "HealingPower"] },
+  { label: "Rampager's",    stats: ["Precision", "Power", "ConditionDamage"] },
+  { label: "Cavalier's",    stats: ["Toughness", "Power", "Ferocity"] },
+  { label: "Nomad's",       stats: ["Toughness", "Vitality", "HealingPower"] },
+  { label: "Settler's",     stats: ["Toughness", "ConditionDamage", "HealingPower"] },
+  { label: "Giver's",       stats: ["Toughness", "HealingPower", "Concentration"] },
+  { label: "Captain's",     stats: ["Toughness", "Power", "HealingPower"] },
+  { label: "Vigilant",      stats: ["Power", "Toughness", "Concentration"] },
+  { label: "Apostate's",    stats: ["ConditionDamage", "Toughness", "HealingPower"] },
+  { label: "Plaguedoctor's", stats: ["ConditionDamage", "Vitality", "HealingPower", "Concentration"] },
+  { label: "Marshal's",     stats: ["Power", "HealingPower", "Precision", "ConditionDamage"] },
+  { label: "Demolisher",    stats: ["Power", "Precision", "Toughness", "Ferocity"] },
+  { label: "Commander's",   stats: ["Power", "Precision", "Toughness", "Concentration"] },
 ];
 
 export const STAT_COMBOS_BY_LABEL = new Map(

--- a/tests/unit/statsCompute.test.js
+++ b/tests/unit/statsCompute.test.js
@@ -195,6 +195,54 @@ describe("computePublishStats", () => {
     expect(result.stats.Precision).toBe(1000 + 756);
   });
 
+  // ── New stat sets (issue #133) ──────────────────────────────────────────
+
+  test("Apothecary's chest: 3-stat healing set", () => {
+    const equipment = { slots: { chest: "Apothecary's" }, runes: {}, infusions: {} };
+    const result = computePublishStats(equipment, null, "Guardian");
+    // Apothecary's: HealingPower (major), Toughness, ConditionDamage (minor)
+    expect(result.stats.HealingPower).toBe(141);
+    expect(result.stats.Toughness).toBe(1000 + 101);
+    expect(result.stats.ConditionDamage).toBe(101);
+  });
+
+  test("Commander's chest: 4-stat combo", () => {
+    const equipment = { slots: { chest: "Commander's" }, runes: {}, infusions: {} };
+    const result = computePublishStats(equipment, null, "Guardian");
+    // Commander's: Power + Precision (major p4=121), Toughness + Concentration (minor s4=66)
+    expect(result.stats.Power).toBe(1000 + 121);
+    expect(result.stats.Precision).toBe(1000 + 121);
+    expect(result.stats.Toughness).toBe(1000 + 66);
+    expect(result.stats.Concentration).toBe(66);
+  });
+
+  test("Plaguedoctor's chest: 4-stat condi-heal combo", () => {
+    const equipment = { slots: { chest: "Plaguedoctor's" }, runes: {}, infusions: {} };
+    const result = computePublishStats(equipment, null, "Guardian");
+    // Plaguedoctor's: ConditionDamage + Vitality (major p4=121), HealingPower + Concentration (minor s4=66)
+    expect(result.stats.ConditionDamage).toBe(121);
+    expect(result.stats.Vitality).toBe(1000 + 121);
+    expect(result.stats.HealingPower).toBe(66);
+    expect(result.stats.Concentration).toBe(66);
+  });
+
+  test("Rampager's chest: 3-stat precision set", () => {
+    const equipment = { slots: { chest: "Rampager's" }, runes: {}, infusions: {} };
+    const result = computePublishStats(equipment, null, "Guardian");
+    // Rampager's: Precision (major), Power, ConditionDamage (minor)
+    expect(result.stats.Precision).toBe(1000 + 141);
+    expect(result.stats.Power).toBe(1000 + 101);
+    expect(result.stats.ConditionDamage).toBe(101);
+  });
+
+  test("Nomad's without apostrophe resolves correctly", () => {
+    const equipment = { slots: { chest: "Nomad" }, runes: {}, infusions: {} };
+    const result = computePublishStats(equipment, null, "Guardian");
+    expect(result.stats.Toughness).toBe(1000 + 141);
+    expect(result.stats.Vitality).toBe(1000 + 101);
+    expect(result.stats.HealingPower).toBe(101);
+  });
+
   test("food with 'to All Attributes' adds to every stat", () => {
     const equipment = { slots: {}, runes: {}, infusions: {}, food: "91713", utility: "" };
     const upgradeCatalog = {


### PR DESCRIPTION
## Summary

Adds 15 missing stat sets requested in #133: Apothecary's, Magi's, Shaman's, Rampager's, Cavalier's, Nomad's, Settler's, Giver's, Captain's, Vigilant, Apostate's, Plaguedoctor's, Marshal's, Demolisher, and Commander's.

Changes made to both `src/renderer/modules/constants.js` (UI dropdown) and `src/main/statsCompute.js` (server-side stat computation) with matching stat attribute definitions. All stat orderings follow GW2 wiki conventions (first stat = major for 3-stat, first two = major for 4-stat).

**Note:** "Forsaken" from the original request was omitted as it does not appear to be a recognized GW2 stat prefix. If it is a valid set, please provide the attribute breakdown and we can add it in a follow-up.

Closes #133