### PR TITLE
fix: traits not respecting boons (closes #126)

### DIFF
--- a/src/renderer/modules/equipment.js
+++ b/src/renderer/modules/equipment.js
@@ -9,7 +9,7 @@ import {
   FURY_CRIT_CHANCE, FURY_CRIT_CHANCE_WVW, MIGHT_MAX_STACKS, MIGHT_POWER_PER_STACK, MIGHT_CONDI_PER_STACK, STABILITY_MAX_STACKS, STACKING_SIGIL_DEFS, BOON_CONDITION_ICONS,
 } from "./constants.js";
 import { escapeHtml } from "./utils.js";
-import { computeSlotStats, computeEquipmentStats, computeUpgradeModifiers, computeStatBreakdown, computeTraitConversions, computeFuryCritModifier } from "./stats.js";
+import { computeSlotStats, computeEquipmentStats, computeUpgradeModifiers, computeStatBreakdown, computeTraitConversions, computeFuryCritModifier, computeFuryStatBonuses, computeMightPerStack } from "./stats.js";
 import { bindHoverPreview, selectDetail } from "./detail-panel.js";
 import { getProfessionSvg } from "./profession-icons.js";
 import { getSlotSvg } from "./slot-icons.js";
@@ -1207,22 +1207,35 @@ export function renderEquipmentPanel() {
   function buildBoonTooltipHTML(def) {
     const val = _assumedBoons[def.key];
     if (def.key === "might") {
+      const mightValues = computeMightPerStack();
       if (val > 0) {
-        const power = val * MIGHT_POWER_PER_STACK;
-        const condi = val * MIGHT_CONDI_PER_STACK;
+        const power = val * mightValues.power;
+        const condi = val * mightValues.condi;
         return `<div class="equip-boons__tip-title">Might ×${val}</div>` +
           `<div class="equip-boons__tip-effect">+${power} Power</div>` +
           `<div class="equip-boons__tip-effect">+${condi} Condition Damage</div>` +
-          `<div class="equip-boons__tip-note">+${MIGHT_POWER_PER_STACK} Power and +${MIGHT_CONDI_PER_STACK} Condition Damage per stack (max ${MIGHT_MAX_STACKS})</div>`;
+          `<div class="equip-boons__tip-note">+${mightValues.power} Power and +${mightValues.condi} Condition Damage per stack (max ${MIGHT_MAX_STACKS})</div>`;
       }
       return `<div class="equip-boons__tip-title">Might</div>` +
-        `<div class="equip-boons__tip-note">Click to add stacks. +${MIGHT_POWER_PER_STACK} Power and +${MIGHT_CONDI_PER_STACK} Condition Damage per stack (max ${MIGHT_MAX_STACKS}).</div>`;
+        `<div class="equip-boons__tip-note">Click to add stacks. +${mightValues.power} Power and +${mightValues.condi} Condition Damage per stack (max ${MIGHT_MAX_STACKS}).</div>`;
     }
     if (def.key === "fury") {
-      const furyPct = (state.editor.gameMode === "wvw" ? FURY_CRIT_CHANCE_WVW : FURY_CRIT_CHANCE) + computeFuryCritModifier();
-      return val
-        ? `<div class="equip-boons__tip-title">Fury</div><div class="equip-boons__tip-effect">+${furyPct}% Critical Chance</div><div class="equip-boons__tip-note">Added to Crit Chance derived stat</div>`
-        : `<div class="equip-boons__tip-title">Fury</div><div class="equip-boons__tip-note">Click to enable. Grants +${furyPct}% Critical Chance.</div>`;
+      const gm = state.editor.gameMode || "pve";
+      const furyPct = (gm === "wvw" ? FURY_CRIT_CHANCE_WVW : FURY_CRIT_CHANCE) + computeFuryCritModifier(gm);
+      const furyStats = computeFuryStatBonuses(gm);
+      const STAT_LABELS = { Ferocity: "Ferocity", Precision: "Precision", Expertise: "Expertise", Concentration: "Concentration", HealingPower: "Healing Power" };
+      const statLines = Object.entries(furyStats)
+        .filter(([, v]) => v > 0)
+        .map(([k, v]) => `+${v} ${STAT_LABELS[k] || k}`);
+      if (val) {
+        let html = `<div class="equip-boons__tip-title">Fury</div><div class="equip-boons__tip-effect">+${furyPct}% Critical Chance</div>`;
+        for (const line of statLines) html += `<div class="equip-boons__tip-effect">${line}</div>`;
+        html += `<div class="equip-boons__tip-note">Added to derived stats</div>`;
+        return html;
+      }
+      let hint = `Grants +${furyPct}% Critical Chance`;
+      if (statLines.length) hint += `, ${statLines.join(", ")}`;
+      return `<div class="equip-boons__tip-title">Fury</div><div class="equip-boons__tip-note">Click to enable. ${hint}.</div>`;
     }
     if (def.key === "alacrity") {
       return val
@@ -1472,7 +1485,8 @@ export function renderEquipmentPanel() {
   // Collect upgrade modifiers and apply ones that map to derived stats
   const modifiers = computeUpgradeModifiers();
   const popMod = (key) => { const v = modifiers.get(key) || 0; modifiers.delete(key); return v; };
-  const furyCritPct = (state.editor.gameMode === "wvw" ? FURY_CRIT_CHANCE_WVW : FURY_CRIT_CHANCE) + computeFuryCritModifier();
+  const gm = state.editor.gameMode || "pve";
+  const furyCritPct = (gm === "wvw" ? FURY_CRIT_CHANCE_WVW : FURY_CRIT_CHANCE) + computeFuryCritModifier(gm);
   const furyCrit = _assumedBoons.fury ? furyCritPct : 0;
   const critChance = Math.min(100, 5 + ((computed.Precision || 1000) - 895) / 21.0 + popMod("Critical Chance") + furyCrit);
   const critDamage = 150 + (computed.Ferocity || 0) / 15.0 + popMod("Critical Damage");

--- a/src/renderer/modules/equipment.js
+++ b/src/renderer/modules/equipment.js
@@ -9,7 +9,7 @@ import {
   FURY_CRIT_CHANCE, FURY_CRIT_CHANCE_WVW, MIGHT_MAX_STACKS, MIGHT_POWER_PER_STACK, MIGHT_CONDI_PER_STACK, STABILITY_MAX_STACKS, STACKING_SIGIL_DEFS, BOON_CONDITION_ICONS,
 } from "./constants.js";
 import { escapeHtml } from "./utils.js";
-import { computeSlotStats, computeEquipmentStats, computeUpgradeModifiers, computeStatBreakdown, computeTraitConversions } from "./stats.js";
+import { computeSlotStats, computeEquipmentStats, computeUpgradeModifiers, computeStatBreakdown, computeTraitConversions, computeFuryCritModifier } from "./stats.js";
 import { bindHoverPreview, selectDetail } from "./detail-panel.js";
 import { getProfessionSvg } from "./profession-icons.js";
 import { getSlotSvg } from "./slot-icons.js";
@@ -1219,7 +1219,7 @@ export function renderEquipmentPanel() {
         `<div class="equip-boons__tip-note">Click to add stacks. +${MIGHT_POWER_PER_STACK} Power and +${MIGHT_CONDI_PER_STACK} Condition Damage per stack (max ${MIGHT_MAX_STACKS}).</div>`;
     }
     if (def.key === "fury") {
-      const furyPct = state.editor.gameMode === "wvw" ? FURY_CRIT_CHANCE_WVW : FURY_CRIT_CHANCE;
+      const furyPct = (state.editor.gameMode === "wvw" ? FURY_CRIT_CHANCE_WVW : FURY_CRIT_CHANCE) + computeFuryCritModifier();
       return val
         ? `<div class="equip-boons__tip-title">Fury</div><div class="equip-boons__tip-effect">+${furyPct}% Critical Chance</div><div class="equip-boons__tip-note">Added to Crit Chance derived stat</div>`
         : `<div class="equip-boons__tip-title">Fury</div><div class="equip-boons__tip-note">Click to enable. Grants +${furyPct}% Critical Chance.</div>`;
@@ -1472,7 +1472,7 @@ export function renderEquipmentPanel() {
   // Collect upgrade modifiers and apply ones that map to derived stats
   const modifiers = computeUpgradeModifiers();
   const popMod = (key) => { const v = modifiers.get(key) || 0; modifiers.delete(key); return v; };
-  const furyCritPct = state.editor.gameMode === "wvw" ? FURY_CRIT_CHANCE_WVW : FURY_CRIT_CHANCE;
+  const furyCritPct = (state.editor.gameMode === "wvw" ? FURY_CRIT_CHANCE_WVW : FURY_CRIT_CHANCE) + computeFuryCritModifier();
   const furyCrit = _assumedBoons.fury ? furyCritPct : 0;
   const critChance = Math.min(100, 5 + ((computed.Precision || 1000) - 895) / 21.0 + popMod("Critical Chance") + furyCrit);
   const critDamage = 150 + (computed.Ferocity || 0) / 15.0 + popMod("Critical Damage");

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -60,6 +60,50 @@ export function computeTraitConversions(baseStats) {
 }
 
 /**
+ * Compute additional fury crit-chance modifier from active traits.
+ * Some traits (e.g. Warrior's Furious Burst) grant extra crit chance when Fury
+ * is active.  The GW2 API represents this as a trait with both a Buff fact
+ * (status "Fury") and a Percent fact (text "Critical Chance Increase").
+ *
+ * @returns {number} Extra crit-chance percentage points from traits (0 if none)
+ */
+export function computeFuryCritModifier() {
+  const catalog = state.activeCatalog;
+  if (!catalog?.traitById) return 0;
+
+  // Collect active trait IDs — both major choices and minor (auto-selected) traits
+  const activeTraitIds = new Set();
+  for (const spec of state.editor.specializations || []) {
+    for (const id of Object.values(spec?.majorChoices || {})) {
+      const n = Number(id);
+      if (n) activeTraitIds.add(n);
+    }
+    const specId = Number(spec?.specializationId || spec?.id) || 0;
+    const specData = specId ? catalog.specializationById?.get(specId) : null;
+    for (const minorId of specData?.minorTraits || []) {
+      if (minorId) activeTraitIds.add(Number(minorId));
+    }
+  }
+  if (!activeTraitIds.size) return 0;
+
+  let modifier = 0;
+  for (const traitId of activeTraitIds) {
+    const trait = catalog.traitById.get(traitId);
+    if (!trait?.facts) continue;
+    const hasFuryBuff = trait.facts.some(
+      (f) => f.type === "Buff" && f.status === "Fury"
+    );
+    if (!hasFuryBuff) continue;
+    for (const fact of trait.facts) {
+      if (fact.type === "Percent" && fact.text === "Critical Chance Increase" && fact.percent) {
+        modifier += fact.percent;
+      }
+    }
+  }
+  return modifier;
+}
+
+/**
  * Build the set of equipment slot keys to exclude from stat calculations.
  * Excludes the opposite environment's slots AND the inactive weapon set.
  */

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -16,6 +16,38 @@ const CONVERSION_TARGET_MAP = {
   Healing: "HealingPower",
 };
 
+// --- Boon-modifier trait constants ---
+// Roiling Mists: has fury crit bonus but no Buff(Fury) fact in the API
+const IMPLICIT_FURY_TRAITS = new Set([1719]);
+// Fang and Claw: AttributeAdjust facts apply to pets, not the player
+const PET_STAT_TRAITS = new Set([1016]);
+// Notoriety: modifies Might per-stack values (+40P/+20CD instead of +30P/+30CD)
+const NOTORIETY_TRAIT_ID = 1765;
+const NOTORIETY_MIGHT_POWER = 40;
+const NOTORIETY_MIGHT_CONDI = 20;
+
+/**
+ * Collect all active trait IDs — major choices + minor (auto-selected) traits.
+ * Shared by computeTraitConversions, computeFuryCritModifier, etc.
+ */
+function collectActiveTraitIds() {
+  const catalog = state.activeCatalog;
+  if (!catalog) return new Set();
+  const ids = new Set();
+  for (const spec of state.editor.specializations || []) {
+    for (const id of Object.values(spec?.majorChoices || {})) {
+      const n = Number(id);
+      if (n) ids.add(n);
+    }
+    const specId = Number(spec?.specializationId || spec?.id) || 0;
+    const specData = specId ? catalog.specializationById?.get(specId) : null;
+    for (const minorId of specData?.minorTraits || []) {
+      if (minorId) ids.add(Number(minorId));
+    }
+  }
+  return ids;
+}
+
 /**
  * Compute stat bonuses from active trait AttributeConversion facts.
  * Reads base stats (before conversions) and returns a map of bonus stats to add.
@@ -29,13 +61,7 @@ export function computeTraitConversions(baseStats) {
   const catalog = state.activeCatalog;
   if (!catalog?.traitById) return bonuses;
 
-  // Collect active trait IDs from selected specializations
-  const activeTraitIds = new Set(
-    (state.editor.specializations || [])
-      .flatMap((s) => Object.values(s?.majorChoices || {}))
-      .map(Number)
-      .filter(Boolean)
-  );
+  const activeTraitIds = collectActiveTraitIds();
   if (!activeTraitIds.size) return bonuses;
 
   for (const traitId of activeTraitIds) {
@@ -60,47 +86,97 @@ export function computeTraitConversions(baseStats) {
 }
 
 /**
+ * Check whether a trait is fury-related: has a Buff(Fury) fact or is in IMPLICIT_FURY_TRAITS.
+ */
+function isFuryTrait(trait, traitId) {
+  if (IMPLICIT_FURY_TRAITS.has(traitId)) return true;
+  return trait.facts?.some((f) => f.type === "Buff" && f.status === "Fury") || false;
+}
+
+/**
  * Compute additional fury crit-chance modifier from active traits.
  * Some traits (e.g. Warrior's Furious Burst) grant extra crit chance when Fury
  * is active.  The GW2 API represents this as a trait with both a Buff fact
  * (status "Fury") and a Percent fact (text "Critical Chance Increase").
  *
+ * When multiple "Critical Chance Increase" facts exist on a trait, they represent
+ * game-mode splits: first = PvE, second = WvW.
+ *
+ * @param {string} [gameMode="pve"] - "pve" or "wvw"
  * @returns {number} Extra crit-chance percentage points from traits (0 if none)
  */
-export function computeFuryCritModifier() {
+export function computeFuryCritModifier(gameMode = "pve") {
   const catalog = state.activeCatalog;
   if (!catalog?.traitById) return 0;
 
-  // Collect active trait IDs — both major choices and minor (auto-selected) traits
-  const activeTraitIds = new Set();
-  for (const spec of state.editor.specializations || []) {
-    for (const id of Object.values(spec?.majorChoices || {})) {
-      const n = Number(id);
-      if (n) activeTraitIds.add(n);
-    }
-    const specId = Number(spec?.specializationId || spec?.id) || 0;
-    const specData = specId ? catalog.specializationById?.get(specId) : null;
-    for (const minorId of specData?.minorTraits || []) {
-      if (minorId) activeTraitIds.add(Number(minorId));
-    }
-  }
+  const activeTraitIds = collectActiveTraitIds();
   if (!activeTraitIds.size) return 0;
 
   let modifier = 0;
   for (const traitId of activeTraitIds) {
     const trait = catalog.traitById.get(traitId);
     if (!trait?.facts) continue;
-    const hasFuryBuff = trait.facts.some(
-      (f) => f.type === "Buff" && f.status === "Fury"
+    if (!isFuryTrait(trait, traitId)) continue;
+    const critFacts = trait.facts.filter(
+      (f) => f.type === "Percent" && f.text === "Critical Chance Increase" && f.percent
     );
-    if (!hasFuryBuff) continue;
-    for (const fact of trait.facts) {
-      if (fact.type === "Percent" && fact.text === "Critical Chance Increase" && fact.percent) {
-        modifier += fact.percent;
-      }
+    if (critFacts.length > 0) {
+      const idx = gameMode === "wvw" ? Math.min(1, critFacts.length - 1) : 0;
+      modifier += critFacts[idx].percent;
     }
   }
   return modifier;
+}
+
+/**
+ * Compute flat stat bonuses from traits that activate while Fury is active.
+ * Reads AttributeAdjust facts from fury-related traits.
+ * Excludes PET_STAT_TRAITS where the bonuses apply to pets, not the player.
+ *
+ * @param {string} [gameMode="pve"] - "pve" or "wvw"
+ * @returns {Object} Map of stat key → bonus value (e.g. { Ferocity: 180 })
+ */
+export function computeFuryStatBonuses(gameMode = "pve") {
+  const catalog = state.activeCatalog;
+  if (!catalog?.traitById) return {};
+
+  const activeTraitIds = collectActiveTraitIds();
+  if (!activeTraitIds.size) return {};
+
+  const bonuses = {};
+  for (const traitId of activeTraitIds) {
+    if (PET_STAT_TRAITS.has(traitId)) continue;
+    const trait = catalog.traitById.get(traitId);
+    if (!trait?.facts) continue;
+    if (!isFuryTrait(trait, traitId)) continue;
+
+    // Group AttributeAdjust facts by target for game-mode selection
+    const byTarget = new Map();
+    for (const fact of trait.facts) {
+      if (fact.type !== "AttributeAdjust" || !fact.target || !fact.value) continue;
+      if (!byTarget.has(fact.target)) byTarget.set(fact.target, []);
+      byTarget.get(fact.target).push(fact.value);
+    }
+
+    for (const [target, values] of byTarget) {
+      const statKey = CONVERSION_TARGET_MAP[target] || target;
+      const idx = gameMode === "wvw" ? Math.min(1, values.length - 1) : 0;
+      bonuses[statKey] = (bonuses[statKey] || 0) + values[idx];
+    }
+  }
+  return bonuses;
+}
+
+/**
+ * Compute effective Might per-stack values, accounting for Notoriety trait.
+ * @returns {{ power: number, condi: number }}
+ */
+export function computeMightPerStack() {
+  const activeTraitIds = collectActiveTraitIds();
+  if (activeTraitIds.has(NOTORIETY_TRAIT_ID)) {
+    return { power: NOTORIETY_MIGHT_POWER, condi: NOTORIETY_MIGHT_CONDI };
+  }
+  return { power: MIGHT_POWER_PER_STACK, condi: MIGHT_CONDI_PER_STACK };
 }
 
 /**
@@ -317,8 +393,16 @@ export function computeEquipmentStats(assumedBoons = null, sigilStacks = null) {
 
   // Assumed boon contributions (session-only, not persisted)
   if (assumedBoons) {
-    totals.Power += (assumedBoons.might || 0) * MIGHT_POWER_PER_STACK;
-    totals.ConditionDamage += (assumedBoons.might || 0) * MIGHT_CONDI_PER_STACK;
+    const mightValues = computeMightPerStack();
+    totals.Power += (assumedBoons.might || 0) * mightValues.power;
+    totals.ConditionDamage += (assumedBoons.might || 0) * mightValues.condi;
+
+    if (assumedBoons.fury) {
+      const furyBonuses = computeFuryStatBonuses(state.editor.gameMode);
+      for (const [key, val] of Object.entries(furyBonuses)) {
+        totals[key] = (totals[key] || 0) + val;
+      }
+    }
   }
 
   // Stacking sigil contributions
@@ -631,11 +715,18 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
   if (assumedBoons) {
     const mightStacks = assumedBoons.might || 0;
     if (mightStacks > 0) {
+      const mightValues = computeMightPerStack();
       if (statKey === "Power") {
-        entries.push({ source: `Boon (Might ×${mightStacks})`, value: mightStacks * MIGHT_POWER_PER_STACK });
+        entries.push({ source: `Boon (Might ×${mightStacks})`, value: mightStacks * mightValues.power });
       }
       if (statKey === "ConditionDamage") {
-        entries.push({ source: `Boon (Might ×${mightStacks})`, value: mightStacks * MIGHT_CONDI_PER_STACK });
+        entries.push({ source: `Boon (Might ×${mightStacks})`, value: mightStacks * mightValues.condi });
+      }
+    }
+    if (assumedBoons.fury) {
+      const furyBonuses = computeFuryStatBonuses(state.editor.gameMode);
+      if (furyBonuses[statKey]) {
+        entries.push({ source: "Boon (Fury)", value: furyBonuses[statKey] });
       }
     }
   }

--- a/tests/unit/renderer/assumed-boons.test.js
+++ b/tests/unit/renderer/assumed-boons.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { computeEquipmentStats, computeStatBreakdown, computeTraitConversions } = require("../../../src/renderer/modules/stats");
+const { computeEquipmentStats, computeStatBreakdown, computeTraitConversions, computeFuryCritModifier } = require("../../../src/renderer/modules/stats");
 const { state } = require("../../../src/renderer/modules/state");
 
 function makeEditor(slots = {}, food = "", utility = "") {
@@ -280,5 +280,90 @@ describe("computeTraitConversions", () => {
     const result = computeTraitConversions({ Power: 1000 });
     expect(result.Vitality).toBe(100);
     expect(result.Ferocity).toBe(100);
+  });
+});
+
+describe("computeFuryCritModifier — trait-based fury crit bonus", () => {
+  beforeEach(() => {
+    state.editor = makeEditor();
+    state.upgradeCatalog = null;
+  });
+
+  test("returns 0 when no specializations are selected", () => {
+    state.editor.specializations = [];
+    state.activeCatalog = { traitById: new Map(), specializationById: new Map() };
+    expect(computeFuryCritModifier()).toBe(0);
+  });
+
+  test("returns 0 when active traits have no fury crit modifier", () => {
+    const fakeTrait = {
+      id: 9999,
+      facts: [{ type: "AttributeConversion", source: "Power", target: "Vitality", percent: 10 }],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[9999, fakeTrait]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 9999 } },
+    ];
+    expect(computeFuryCritModifier()).toBe(0);
+  });
+
+  test("returns modifier from a minor trait with Fury buff + Percent fact", () => {
+    // Simulates Furious Burst: minor trait that grants Fury and adds 5% crit
+    const furiousBurst = {
+      id: 1342,
+      facts: [
+        { text: "Recharge", type: "Recharge", value: 4 },
+        { text: "Apply Buff/Condition", type: "Buff", status: "Fury", duration: 3, apply_count: 1 },
+        { text: "Critical Chance Increase", type: "Percent", percent: 5 },
+        { text: "Combat Only", type: "NoData" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1342, furiousBurst]]),
+      specializationById: new Map([[36, { id: 36, minorTraits: [1342] }]]),
+    };
+    state.editor.specializations = [
+      { specializationId: 36, majorChoices: {} },
+    ];
+    expect(computeFuryCritModifier()).toBe(5);
+  });
+
+  test("returns modifier from a major trait with Fury buff + Percent fact", () => {
+    const fakeTrait = {
+      id: 5000,
+      facts: [
+        { text: "Apply Buff/Condition", type: "Buff", status: "Fury", duration: 5, apply_count: 1 },
+        { text: "Critical Chance Increase", type: "Percent", percent: 7 },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[5000, fakeTrait]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 5000 } },
+    ];
+    expect(computeFuryCritModifier()).toBe(7);
+  });
+
+  test("ignores Percent facts on traits without a Fury Buff fact", () => {
+    const nonFuryTrait = {
+      id: 6000,
+      facts: [
+        { text: "Apply Buff/Condition", type: "Buff", status: "Might", duration: 5, apply_count: 1 },
+        { text: "Critical Chance Increase", type: "Percent", percent: 10 },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[6000, nonFuryTrait]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 6000 } },
+    ];
+    expect(computeFuryCritModifier()).toBe(0);
   });
 });

--- a/tests/unit/renderer/assumed-boons.test.js
+++ b/tests/unit/renderer/assumed-boons.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { computeEquipmentStats, computeStatBreakdown, computeTraitConversions, computeFuryCritModifier } = require("../../../src/renderer/modules/stats");
+const { computeEquipmentStats, computeStatBreakdown, computeTraitConversions, computeFuryCritModifier, computeFuryStatBonuses, computeMightPerStack } = require("../../../src/renderer/modules/stats");
 const { state } = require("../../../src/renderer/modules/state");
 
 function makeEditor(slots = {}, food = "", utility = "") {
@@ -365,5 +365,280 @@ describe("computeFuryCritModifier — trait-based fury crit bonus", () => {
       { specializationId: 1, majorChoices: { 1: 6000 } },
     ];
     expect(computeFuryCritModifier()).toBe(0);
+  });
+
+  test("detects Roiling Mists (1719) without Buff fact via IMPLICIT_FURY_TRAITS", () => {
+    // Roiling Mists has no Buff(Fury) fact — detected by hardcoded ID
+    const roilingMists = {
+      id: 1719,
+      facts: [
+        { text: "Critical Chance Increase", type: "Percent", percent: 25 },
+        { text: "Critical Chance Increase", type: "Percent", percent: 20 },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1719, roilingMists]]),
+      specializationById: new Map([[63, { id: 63, minorTraits: [1719] }]]),
+    };
+    state.editor.specializations = [
+      { specializationId: 63, majorChoices: {} },
+    ];
+    expect(computeFuryCritModifier("pve")).toBe(25);
+    expect(computeFuryCritModifier("wvw")).toBe(20);
+  });
+
+  test("game-mode split picks first value for PvE, second for WvW", () => {
+    const trait = {
+      id: 2193,
+      facts: [
+        { type: "Buff", status: "Fury", duration: 5, apply_count: 1 },
+        { text: "Critical Chance Increase", type: "Percent", percent: 15 },
+        { text: "Critical Chance Increase", type: "Percent", percent: 10 },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[2193, trait]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 2193 } },
+    ];
+    expect(computeFuryCritModifier("pve")).toBe(15);
+    expect(computeFuryCritModifier("wvw")).toBe(10);
+  });
+});
+
+describe("computeFuryStatBonuses — flat stat bonuses while Fury active", () => {
+  beforeEach(() => {
+    state.editor = makeEditor();
+    state.upgradeCatalog = null;
+  });
+
+  test("returns empty when no specializations selected", () => {
+    state.editor.specializations = [];
+    state.activeCatalog = { traitById: new Map(), specializationById: new Map() };
+    expect(computeFuryStatBonuses()).toEqual({});
+  });
+
+  test("returns Ferocity from Raging Storm (Elementalist)", () => {
+    const ragingStorm = {
+      id: 214,
+      facts: [
+        { type: "AttributeAdjust", value: 180, target: "CritDamage" },
+        { type: "Buff", status: "Fury", duration: 4, apply_count: 1 },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[214, ragingStorm]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 214 } },
+    ];
+    expect(computeFuryStatBonuses()).toEqual({ Ferocity: 180 });
+  });
+
+  test("handles game-mode split for AttributeAdjust (No Quarter)", () => {
+    const noQuarter = {
+      id: 1904,
+      facts: [
+        { type: "Buff", status: "Fury", duration: 2, apply_count: 1 },
+        { type: "AttributeAdjust", value: 250, target: "CritDamage" },
+        { type: "AttributeAdjust", value: 300, target: "CritDamage" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1904, noQuarter]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 1904 } },
+    ];
+    expect(computeFuryStatBonuses("pve")).toEqual({ Ferocity: 250 });
+    expect(computeFuryStatBonuses("wvw")).toEqual({ Ferocity: 300 });
+  });
+
+  test("returns Precision from Furious Demise (Necromancer)", () => {
+    const furiousDemise = {
+      id: 803,
+      facts: [
+        { type: "Buff", status: "Fury", duration: 8, apply_count: 1 },
+        { type: "AttributeAdjust", value: 180, target: "Precision" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[803, furiousDemise]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 803 } },
+    ];
+    expect(computeFuryStatBonuses()).toEqual({ Precision: 180 });
+  });
+
+  test("maps ConditionDuration target to Expertise (Sharpening Sorrow)", () => {
+    const sharpeningSorrow = {
+      id: 2207,
+      facts: [
+        { type: "Buff", status: "Fury", duration: 5, apply_count: 1 },
+        { type: "AttributeAdjust", value: 150, target: "ConditionDuration" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[2207, sharpeningSorrow]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 2207 } },
+    ];
+    expect(computeFuryStatBonuses()).toEqual({ Expertise: 150 });
+  });
+
+  test("excludes Fang and Claw (pet stats, not player)", () => {
+    const fangAndClaw = {
+      id: 1016,
+      facts: [
+        { type: "Buff", status: "Fury", duration: 8, apply_count: 1 },
+        { type: "AttributeAdjust", value: 420, target: "Precision" },
+        { type: "AttributeAdjust", value: 450, target: "CritDamage" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1016, fangAndClaw]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 1016 } },
+    ];
+    expect(computeFuryStatBonuses()).toEqual({});
+  });
+
+  test("ignores traits without Fury buff", () => {
+    const nonFuryTrait = {
+      id: 9999,
+      facts: [
+        { type: "Buff", status: "Might", duration: 5, apply_count: 1 },
+        { type: "AttributeAdjust", value: 200, target: "CritDamage" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[9999, nonFuryTrait]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 9999 } },
+    ];
+    expect(computeFuryStatBonuses()).toEqual({});
+  });
+
+  test("fury stat bonuses applied to computeEquipmentStats when fury assumed", () => {
+    const ragingStorm = {
+      id: 214,
+      facts: [
+        { type: "AttributeAdjust", value: 180, target: "CritDamage" },
+        { type: "Buff", status: "Fury", duration: 4, apply_count: 1 },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[214, ragingStorm]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 214 } },
+    ];
+    const baseline = computeEquipmentStats({ might: 0, fury: false, alacrity: false });
+    const withFury = computeEquipmentStats({ might: 0, fury: true, alacrity: false });
+    expect(withFury.Ferocity).toBe(baseline.Ferocity + 180);
+  });
+
+  test("fury stat bonuses appear in stat breakdown", () => {
+    const ragingStorm = {
+      id: 214,
+      facts: [
+        { type: "AttributeAdjust", value: 180, target: "CritDamage" },
+        { type: "Buff", status: "Fury", duration: 4, apply_count: 1 },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[214, ragingStorm]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 214 } },
+    ];
+    const entries = computeStatBreakdown("Ferocity", { might: 0, fury: true, alacrity: false });
+    const furyEntry = entries.find((e) => e.source === "Boon (Fury)");
+    expect(furyEntry).toBeDefined();
+    expect(furyEntry.value).toBe(180);
+  });
+});
+
+describe("computeMightPerStack — Notoriety trait", () => {
+  beforeEach(() => {
+    state.editor = makeEditor();
+    state.upgradeCatalog = null;
+  });
+
+  test("returns default 30/30 when no specializations", () => {
+    state.editor.specializations = [];
+    state.activeCatalog = { traitById: new Map(), specializationById: new Map() };
+    expect(computeMightPerStack()).toEqual({ power: 30, condi: 30 });
+  });
+
+  test("returns 40/20 when Notoriety (1765) is active", () => {
+    const notoriety = {
+      id: 1765,
+      facts: [
+        { type: "Buff", status: "Might", duration: 5, apply_count: 2 },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1765, notoriety]]),
+      specializationById: new Map([[63, { id: 63, minorTraits: [1765] }]]),
+    };
+    state.editor.specializations = [
+      { specializationId: 63, majorChoices: {} },
+    ];
+    expect(computeMightPerStack()).toEqual({ power: 40, condi: 20 });
+  });
+
+  test("Notoriety modifies Might in computeEquipmentStats", () => {
+    const notoriety = {
+      id: 1765,
+      facts: [
+        { type: "Buff", status: "Might", duration: 5, apply_count: 2 },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1765, notoriety]]),
+      specializationById: new Map([[63, { id: 63, minorTraits: [1765] }]]),
+    };
+    state.editor.specializations = [
+      { specializationId: 63, majorChoices: {} },
+    ];
+    const base = computeEquipmentStats(); // no boons
+    const withMight = computeEquipmentStats({ might: 25, fury: false, alacrity: false });
+    expect(withMight.Power).toBe(base.Power + 25 * 40);
+    expect(withMight.ConditionDamage).toBe(base.ConditionDamage + 25 * 20);
+  });
+
+  test("Notoriety modifies Might in stat breakdown", () => {
+    const notoriety = {
+      id: 1765,
+      facts: [
+        { type: "Buff", status: "Might", duration: 5, apply_count: 2 },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1765, notoriety]]),
+      specializationById: new Map([[63, { id: 63, minorTraits: [1765] }]]),
+    };
+    state.editor.specializations = [
+      { specializationId: 63, majorChoices: {} },
+    ];
+    const entries = computeStatBreakdown("Power", { might: 10, fury: false, alacrity: false });
+    const mightEntry = entries.find((e) => e.source.includes("Might"));
+    expect(mightEntry).toBeDefined();
+    expect(mightEntry.value).toBe(10 * 40); // 400, not 300
   });
 });


### PR DESCRIPTION
## Summary

The Fury boon's crit chance bonus was hardcoded from constants (`FURY_CRIT_CHANCE` / `FURY_CRIT_CHANCE_WVW`) and never modified by trait effects. Traits like Warrior's Furious Burst (Arms minor) add +5% crit chance to Fury via a `Percent` fact in the GW2 API, but this was ignored.

Added `computeFuryCritModifier()` in `stats.js` that scans all active traits (both major selections and minor/auto-selected traits) for the Fury buff + "Critical Chance Increase" pattern, returning the total additional crit percentage. This modifier is now applied to both the crit chance calculation and the Fury boon tooltip in `equipment.js`.

Closes #126