### PR TITLE
fix: Celestial Stats (closes #132)

### DIFF
--- a/src/main/buildPublish.js
+++ b/src/main/buildPublish.js
@@ -577,7 +577,7 @@ function serializeForPublish(build, catalog, upgradeCatalog) {
   const equipmentDisplay = resolveEquipmentDisplay(build.equipment, upgradeCatalog);
   const equipmentIcons = resolveEquipmentIcons(build);
   const { stats: computedStats, modifiers: statModifiers } = computePublishStats(
-    build.equipment, upgradeCatalog, build.profession
+    build.equipment, upgradeCatalog, build.profession, build.gameMode
   );
 
   return {

--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -83,9 +83,19 @@ const PROFESSION_BASE_HP = {
   Guardian: 11645, Thief: 11645, Elementalist: 11645,
 };
 
-function computePublishStats(equipment, upgradeCatalog, profession) {
+// In WvW, Celestial gear does not grant Expertise or Concentration.
+const _WVW_CELESTIAL_EXCLUDED = new Set(["Expertise", "Concentration"]);
+function _getEffectiveStats(comboLabel, combo, gameMode) {
+  if (gameMode === "wvw" && comboLabel === "Celestial") {
+    return combo.stats.filter((s) => !_WVW_CELESTIAL_EXCLUDED.has(s));
+  }
+  return combo.stats;
+}
+
+function computePublishStats(equipment, upgradeCatalog, profession, gameMode) {
   if (!equipment) return { stats: {}, modifiers: [] };
 
+  const gm = gameMode || "pve";
   const slots = equipment.slots || {};
   const totals = {
     Power: 1000, Precision: 1000, Toughness: 1000, Vitality: 1000,
@@ -98,18 +108,19 @@ function computePublishStats(equipment, upgradeCatalog, profession) {
     const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
     const w = SLOT_WEIGHTS[slotKey];
     if (!combo || !w) continue;
-    const n = combo.stats.length;
+    const stats = _getEffectiveStats(comboLabel, combo, gm);
+    const n = stats.length;
     if (n <= 3) {
-      totals[combo.stats[0]] = (totals[combo.stats[0]] || 0) + w.p;
-      for (let i = 1; i < n; i++) totals[combo.stats[i]] = (totals[combo.stats[i]] || 0) + w.s;
+      totals[stats[0]] = (totals[stats[0]] || 0) + w.p;
+      for (let i = 1; i < n; i++) totals[stats[i]] = (totals[stats[i]] || 0) + w.s;
     } else if (n === 4) {
       // 2-2 pattern: first 2 stats are major, last 2 are minor
-      totals[combo.stats[0]] = (totals[combo.stats[0]] || 0) + w.p4;
-      totals[combo.stats[1]] = (totals[combo.stats[1]] || 0) + w.p4;
-      totals[combo.stats[2]] = (totals[combo.stats[2]] || 0) + w.s4;
-      totals[combo.stats[3]] = (totals[combo.stats[3]] || 0) + w.s4;
+      totals[stats[0]] = (totals[stats[0]] || 0) + w.p4;
+      totals[stats[1]] = (totals[stats[1]] || 0) + w.p4;
+      totals[stats[2]] = (totals[stats[2]] || 0) + w.s4;
+      totals[stats[3]] = (totals[stats[3]] || 0) + w.s4;
     } else {
-      for (const stat of combo.stats) totals[stat] = (totals[stat] || 0) + w.c;
+      for (const stat of stats) totals[stat] = (totals[stat] || 0) + w.c;
     }
   }
 

--- a/src/renderer/modules/constants.js
+++ b/src/renderer/modules/constants.js
@@ -58,6 +58,21 @@ export const STAT_COMBOS = [
   { label: "Commander's",   stats: ["Power", "Precision", "Toughness", "Concentration"] },
 ];
 
+// In WvW, Celestial gear does not grant Expertise or Concentration.
+const WVW_CELESTIAL_EXCLUDED = new Set(["Expertise", "Concentration"]);
+
+/**
+ * Return the effective stats array for a combo, accounting for game-mode restrictions.
+ * In WvW, Celestial excludes Expertise and Concentration.
+ */
+export function getEffectiveStats(combo, gameMode) {
+  if (!combo) return [];
+  if (gameMode === "wvw" && combo.label === "Celestial") {
+    return combo.stats.filter((s) => !WVW_CELESTIAL_EXCLUDED.has(s));
+  }
+  return combo.stats;
+}
+
 export const STAT_COMBOS_BY_LABEL = new Map(
   STAT_COMBOS.flatMap((c) => {
     const entries = [[c.label, c]];

--- a/src/renderer/modules/equipment.js
+++ b/src/renderer/modules/equipment.js
@@ -7,6 +7,7 @@ import {
   LEGENDARY_ARMOR_ICONS, _WK,
   PROFESSION_BASE_HP,
   FURY_CRIT_CHANCE, FURY_CRIT_CHANCE_WVW, MIGHT_MAX_STACKS, MIGHT_POWER_PER_STACK, MIGHT_CONDI_PER_STACK, STABILITY_MAX_STACKS, STACKING_SIGIL_DEFS, BOON_CONDITION_ICONS,
+  getEffectiveStats,
 } from "./constants.js";
 import { escapeHtml } from "./utils.js";
 import { computeSlotStats, computeEquipmentStats, computeUpgradeModifiers, computeStatBreakdown, computeTraitConversions, computeFuryCritModifier, computeFuryStatBonuses, computeMightPerStack } from "./stats.js";
@@ -109,7 +110,7 @@ export function openSlotPicker(anchorEl, currentValue, onSelect, { items = null,
 
   const allOptions = items ?? [
     { value: "", label: "— Empty —", subtitle: "" },
-    ...STAT_COMBOS.map((c) => ({ value: c.label, label: c.label, subtitle: c.stats.join(" · ") })),
+    ...STAT_COMBOS.map((c) => ({ value: c.label, label: c.label, subtitle: getEffectiveStats(c, state.editor?.gameMode || "pve").join(" · ") })),
   ];
 
   function renderPickerList(query) {
@@ -372,7 +373,7 @@ export function renderEquipmentPanel() {
     valueEl.className = "equip-slot__value" + (currentCombo ? "" : " equip-slot__value--empty");
     if (currentCombo) {
       const combo = STAT_COMBOS_BY_LABEL.get(currentCombo);
-      valueEl.innerHTML = `<span class="equip-slot__combo-name">${escapeHtml(currentCombo)}</span>${combo ? `<span class="equip-slot__combo-stats">${combo.stats.join(" · ")}</span>` : ""}`;
+      valueEl.innerHTML = `<span class="equip-slot__combo-name">${escapeHtml(currentCombo)}</span>${combo ? `<span class="equip-slot__combo-stats">${getEffectiveStats(combo, state.editor?.gameMode || "pve").join(" · ")}</span>` : ""}`;
     } else {
       valueEl.textContent = _readOnly ? "—" : "Select stats…";
     }
@@ -511,7 +512,7 @@ export function renderEquipmentPanel() {
       statBtn.style.display = "none";
     } else if (currentCombo) {
       const combo = STAT_COMBOS_BY_LABEL.get(currentCombo);
-      statBtn.innerHTML = `<span class="equip-slot__combo-name">${escapeHtml(currentCombo)}</span>${combo ? `<span class="equip-slot__combo-stats">${combo.stats.join(" · ")}</span>` : ""}`;
+      statBtn.innerHTML = `<span class="equip-slot__combo-name">${escapeHtml(currentCombo)}</span>${combo ? `<span class="equip-slot__combo-stats">${getEffectiveStats(combo, state.editor?.gameMode || "pve").join(" · ")}</span>` : ""}`;
     } else {
       statBtn.textContent = _readOnly ? "—" : "Select stats…";
     }

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -2,7 +2,7 @@
 import { state } from "./state.js";
 import {
   STAT_COMBOS_BY_LABEL, SLOT_WEIGHTS, LAND_ONLY_SLOTS, AQUATIC_SLOTS,
-  MIGHT_POWER_PER_STACK, MIGHT_CONDI_PER_STACK, STACKING_SIGIL_DEFS,
+  MIGHT_POWER_PER_STACK, MIGHT_CONDI_PER_STACK, STACKING_SIGIL_DEFS, getEffectiveStats,
 } from "./constants.js";
 
 /**
@@ -205,19 +205,21 @@ export function computeSlotStats(comboLabel, slotKey) {
   const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
   const w = SLOT_WEIGHTS[slotKey];
   if (!combo || !w) return [];
-  const n = combo.stats.length;
+  const gameMode = state.editor?.gameMode || "pve";
+  const stats = getEffectiveStats(combo, gameMode);
+  const n = stats.length;
   const result = [];
   if (n <= 3) {
-    result.push({ stat: combo.stats[0], value: w.p });
-    for (let i = 1; i < n; i++) result.push({ stat: combo.stats[i], value: w.s });
+    result.push({ stat: stats[0], value: w.p });
+    for (let i = 1; i < n; i++) result.push({ stat: stats[i], value: w.s });
   } else if (n === 4) {
     // 2-2 pattern: first 2 stats are major, last 2 are minor
-    result.push({ stat: combo.stats[0], value: w.p4 });
-    result.push({ stat: combo.stats[1], value: w.p4 });
-    result.push({ stat: combo.stats[2], value: w.s4 });
-    result.push({ stat: combo.stats[3], value: w.s4 });
+    result.push({ stat: stats[0], value: w.p4 });
+    result.push({ stat: stats[1], value: w.p4 });
+    result.push({ stat: stats[2], value: w.s4 });
+    result.push({ stat: stats[3], value: w.s4 });
   } else {
-    for (const stat of combo.stats) result.push({ stat, value: w.c });
+    for (const stat of stats) result.push({ stat, value: w.c });
   }
   return result;
 }
@@ -230,25 +232,27 @@ export function computeEquipmentStats(assumedBoons = null, sigilStacks = null) {
   };
   const isUnderwater = Boolean(state.editor.underwaterMode);
   const EXCLUDED_SLOTS = getExcludedSlots();
+  const gameMode = state.editor?.gameMode || "pve";
   for (const [slotKey, comboLabel] of Object.entries(slots)) {
     if (!comboLabel || EXCLUDED_SLOTS.has(slotKey)) continue;
     const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
     const w = SLOT_WEIGHTS[slotKey];
     if (!combo || !w) continue;
-    const n = combo.stats.length;
+    const stats = getEffectiveStats(combo, gameMode);
+    const n = stats.length;
     if (n <= 3) {
-      totals[combo.stats[0]] = (totals[combo.stats[0]] || 0) + w.p;
-      for (let i = 1; i < combo.stats.length; i++) {
-        totals[combo.stats[i]] = (totals[combo.stats[i]] || 0) + w.s;
+      totals[stats[0]] = (totals[stats[0]] || 0) + w.p;
+      for (let i = 1; i < stats.length; i++) {
+        totals[stats[i]] = (totals[stats[i]] || 0) + w.s;
       }
     } else if (n === 4) {
       // 2-2 pattern: first 2 stats are major, last 2 are minor
-      totals[combo.stats[0]] = (totals[combo.stats[0]] || 0) + w.p4;
-      totals[combo.stats[1]] = (totals[combo.stats[1]] || 0) + w.p4;
-      totals[combo.stats[2]] = (totals[combo.stats[2]] || 0) + w.s4;
-      totals[combo.stats[3]] = (totals[combo.stats[3]] || 0) + w.s4;
+      totals[stats[0]] = (totals[stats[0]] || 0) + w.p4;
+      totals[stats[1]] = (totals[stats[1]] || 0) + w.p4;
+      totals[stats[2]] = (totals[stats[2]] || 0) + w.s4;
+      totals[stats[3]] = (totals[stats[3]] || 0) + w.s4;
     } else {
-      for (const stat of combo.stats) {
+      for (const stat of stats) {
         totals[stat] = (totals[stat] || 0) + w.c;
       }
     }

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -155,6 +155,50 @@ describe("computeSlotStats — 9-stat combo (Celestial)", () => {
   });
 });
 
+describe("computeSlotStats — Celestial in WvW excludes Expertise/Concentration", () => {
+  test("WvW Celestial chest returns 7 stats (no Expertise or Concentration)", () => {
+    state.editor = makeEditor({});
+    state.editor.gameMode = "wvw";
+    const result = computeSlotStats("Celestial", "chest");
+    expect(result).toHaveLength(7);
+    const stats = result.map((r) => r.stat);
+    expect(stats).toContain("Power");
+    expect(stats).toContain("HealingPower");
+    expect(stats).not.toContain("Expertise");
+    expect(stats).not.toContain("Concentration");
+    for (const r of result) expect(r.value).toBe(66); // still uses c weight
+  });
+
+  test("PvE Celestial chest still returns all 9 stats", () => {
+    state.editor = makeEditor({});
+    state.editor.gameMode = "pve";
+    const result = computeSlotStats("Celestial", "chest");
+    expect(result).toHaveLength(9);
+    const stats = result.map((r) => r.stat);
+    expect(stats).toContain("Expertise");
+    expect(stats).toContain("Concentration");
+  });
+});
+
+describe("computeEquipmentStats — Celestial WvW excludes Expertise/Concentration", () => {
+  test("WvW Celestial gear does not contribute Expertise or Concentration", () => {
+    state.editor = makeEditor({ chest: "Celestial" });
+    state.editor.gameMode = "wvw";
+    const result = computeEquipmentStats();
+    expect(result.Expertise).toBe(0);
+    expect(result.Concentration).toBe(0);
+    expect(result.Power).toBe(1000 + 66); // base + celestial c weight
+  });
+
+  test("PvE Celestial gear contributes Expertise and Concentration", () => {
+    state.editor = makeEditor({ chest: "Celestial" });
+    state.editor.gameMode = "pve";
+    const result = computeEquipmentStats();
+    expect(result.Expertise).toBe(66);
+    expect(result.Concentration).toBe(66);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // computeEquipmentStats
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
In GW2, WvW Celestial gear grants only 7 stats — Expertise and Concentration are excluded. The app was showing all 9 stats regardless of game mode.

Added `getEffectiveStats()` helper that filters Expertise and Concentration from Celestial when WvW is selected. Applied to:
- Stat computation (renderer `computeSlotStats`/`computeEquipmentStats`)
- Equipment UI display (stat picker, slot labels, weapon stat labels)
- Published build stat computation (`computePublishStats` in main process)

Closes #132