### PR TITLE
fix: Relic of the Thief missing tooltip info (closes #136)

### DIFF
--- a/src/main/gw2Data/relicFacts.json
+++ b/src/main/gw2Data/relicFacts.json
@@ -1173,6 +1173,18 @@
           "type": "Percent",
           "text": "Damage Increase",
           "percent": 1
+        },
+        {
+          "type": "Time",
+          "text": "Stack Duration",
+          "icon": "https://render.guildwars2.com/file/7B2193ACCF77E56C13E608191B082D68AA0FAA71/156659.png",
+          "duration": 6
+        },
+        {
+          "type": "Number",
+          "text": "Maximum Stacks",
+          "icon": "https://render.guildwars2.com/file/9352ED3244417304995F26CB01AE76BB7E547052/156661.png",
+          "value": 5
         }
       ]
     },

--- a/tests/unit/renderer/relic-facts-equipment.test.js
+++ b/tests/unit/renderer/relic-facts-equipment.test.js
@@ -179,3 +179,43 @@ describe("Relic facts on equipment panel (#125)", () => {
     expect(html).not.toContain("Cooldown: 30s");
   });
 });
+
+describe("Relic of the Thief tooltip completeness (#136)", () => {
+  const relicFacts = require("../../../src/main/gw2Data/relicFacts.json");
+  const thief = relicFacts.relics["100916"];
+
+  test("relicFacts.json contains Relic of the Thief entry", () => {
+    expect(thief).toBeDefined();
+    expect(thief.name).toBe("Relic of the Thief");
+  });
+
+  test("Relic of the Thief has Stack Duration fact", () => {
+    const stackDuration = thief.facts.find(
+      (f) => f.type === "Time" && /stack duration/i.test(f.text)
+    );
+    expect(stackDuration).toBeDefined();
+    expect(stackDuration.duration).toBe(6);
+  });
+
+  test("Relic of the Thief has Maximum Stacks fact", () => {
+    const maxStacks = thief.facts.find(
+      (f) => f.type === "Number" && /maximum stacks/i.test(f.text)
+    );
+    expect(maxStacks).toBeDefined();
+    expect(maxStacks.value).toBe(5);
+  });
+
+  test("tooltip renders stack duration and max stacks for Relic of the Thief", () => {
+    const entity = {
+      name: thief.name,
+      icon: "https://example.com/thief.png",
+      description: "",
+      facts: thief.facts,
+    };
+
+    const html = detailPanel.buildSkillCard(entity, "equip-relic");
+    expect(html).toContain("Damage Increase");
+    expect(html).toContain("Stack Duration");
+    expect(html).toContain("Maximum Stacks");
+  });
+});


### PR DESCRIPTION
## Summary
The Relic of the Thief entry in `relicFacts.json` was missing its Stack Duration (6s) and Maximum Stacks (5) facts. The tooltip only showed "Damage Increase: 1%" without indicating that this is a per-stack value that stacks up to 5 times. Added the missing Time and Number facts to the static data file.

Closes #136