### PR TITLE
fix: Published Build window scaling issue in web browser (closes #148)

### DIFF
--- a/src/site/render-build.js
+++ b/src/site/render-build.js
@@ -1,6 +1,6 @@
 import { state } from "@renderer/modules/state.js";
 import { initSkills, renderSkills } from "@renderer/modules/skills.js";
-import { initSpecializations, renderSpecializations } from "@renderer/modules/specializations.js";
+import { initSpecializations, renderSpecializations, drawSpecConnector } from "@renderer/modules/specializations.js";
 import { initEquipment, initEquipmentCallbacks, renderEquipmentPanel } from "@renderer/modules/equipment.js";
 import { initDetailPanel, bindHoverPreview, setOnHoverPreview } from "@renderer/modules/detail-panel.js";
 import { initReferencePanel, updateReferencePanel } from "./render-reference.js";
@@ -445,6 +445,15 @@ export function renderBuildPage(container, build) {
 
   allTabs.forEach((tab, i) => {
     tab.addEventListener("click", () => activateTab(i));
+  });
+
+  // Redraw spec connectors on window resize so SVG lines stay aligned (#148)
+  let resizeRaf = 0;
+  window.addEventListener("resize", () => {
+    cancelAnimationFrame(resizeRaf);
+    resizeRaf = requestAnimationFrame(() => {
+      specializationsHost.querySelectorAll(".spec-card__body").forEach((body) => drawSpecConnector(body));
+    });
   });
 
   // Mobile enhancements

--- a/tests/unit/renderer/spec-connector-resize.test.js
+++ b/tests/unit/renderer/spec-connector-resize.test.js
@@ -1,0 +1,34 @@
+"use strict";
+
+/**
+ * Verifies that spec connector lines are redrawn on window resize.
+ * Bug: #148 — Published Build window scaling issue in web browser.
+ *
+ * The SVG connector coordinates are computed from getBoundingClientRect at draw
+ * time. Without a resize handler the lines become misaligned when the browser
+ * window changes size.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+describe("spec connector resize handling", () => {
+  test("render-build.js imports drawSpecConnector", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "../../../src/site/render-build.js"),
+      "utf8"
+    );
+    expect(src).toMatch(/drawSpecConnector/);
+  });
+
+  test("render-build.js registers a window resize listener that redraws connectors", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "../../../src/site/render-build.js"),
+      "utf8"
+    );
+    // Must add a resize event listener
+    expect(src).toMatch(/addEventListener\s*\(\s*["']resize["']/);
+    // The resize handler must reference drawSpecConnector or spec-card__body
+    expect(src).toMatch(/resize[\s\S]{0,300}(drawSpecConnector|spec-card__body)/);
+  });
+});


### PR DESCRIPTION
## Summary

The SVG trait connector lines in the published web view were drawn once using `getBoundingClientRect()` pixel coordinates but never redrawn when the browser window was resized. This caused the SVG to stretch via CSS `inset: 0` while the trait nodes reflowed to new positions, making the lines misaligned.

Adds a debounced `window.resize` listener in `render-build.js` that redraws all spec connectors via `requestAnimationFrame`, matching the existing pattern used for tab-visibility redraws in the Electron app.

Closes #148