### PR TITLE
fix: 2h weapons use correct stat weights (closes #150)

### DIFF
--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -77,6 +77,12 @@ const SLOT_WEIGHTS = {
   accessory2: { p: 110, s: 74,  p4: 92,  s4: 49, c: 50 },
 };
 
+// Two-handed weapon stat weights (attribute_adjustment 716.8, double the 1h value).
+const TWO_HAND_WEIGHTS = { p: 251, s: 179, p4: 215, s4: 118, c: 118 };
+const TWO_HAND_WEAPON_IDS = new Set([
+  "greatsword", "hammer", "longbow", "rifle", "shortbow", "staff", "spear",
+]);
+
 const PROFESSION_BASE_HP = {
   Warrior: 19212, Necromancer: 19212, Revenant: 15922,
   Engineer: 15922, Ranger: 15922, Mesmer: 15922,
@@ -103,11 +109,16 @@ function computePublishStats(equipment, upgradeCatalog, profession, gameMode) {
   };
 
   // Equipment slot contributions
+  const weapons = equipment.weapons || {};
   for (const [slotKey, comboLabel] of Object.entries(slots)) {
     if (!comboLabel) continue;
     const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
-    const w = SLOT_WEIGHTS[slotKey];
+    let w = SLOT_WEIGHTS[slotKey];
     if (!combo || !w) continue;
+    // Use 2h weights when a two-handed weapon is equipped in a mainhand slot
+    if (slotKey.startsWith("mainhand") && TWO_HAND_WEAPON_IDS.has(weapons[slotKey])) {
+      w = TWO_HAND_WEIGHTS;
+    }
     const stats = _getEffectiveStats(comboLabel, combo, gm);
     const n = stats.length;
     if (n <= 3) {
@@ -272,11 +283,15 @@ function estimateRole(build) {
     Ferocity: 0, ConditionDamage: 0, Expertise: 0, Concentration: 0, HealingPower: 0,
   };
 
+  const weapons = build?.equipment?.weapons || {};
   for (const [slotKey, comboLabel] of Object.entries(slots)) {
     if (!comboLabel) continue;
     const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
-    const w = SLOT_WEIGHTS[slotKey];
+    let w = SLOT_WEIGHTS[slotKey];
     if (!combo || !w) continue;
+    if (slotKey.startsWith("mainhand") && TWO_HAND_WEAPON_IDS.has(weapons[slotKey])) {
+      w = TWO_HAND_WEIGHTS;
+    }
     const n = combo.stats.length;
     if (n <= 3) {
       totals[combo.stats[0]] += w.p;

--- a/src/renderer/modules/constants.js
+++ b/src/renderer/modules/constants.js
@@ -107,6 +107,9 @@ export const SLOT_WEIGHTS = {
   aquatic2:   { p: 251, s: 179, p4: 215, s4: 118, c: 118 },
 };
 
+// Two-handed land weapon stat weights (same as aquatic — attribute_adjustment 716.8).
+export const TWO_HAND_WEIGHTS = { p: 251, s: 179, p4: 215, s4: 118, c: 118 };
+
 export const EQUIP_ARMOR_SLOTS = [
   { key: "head",      label: "Head",      icon: "Head_slot.png" },
   { key: "shoulders", label: "Shoulders", icon: "Shoulder_slot.png" },

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -1,8 +1,9 @@
 // Equipment stat computation — pure logic over state + constants, no DOM deps.
 import { state } from "./state.js";
 import {
-  STAT_COMBOS_BY_LABEL, SLOT_WEIGHTS, LAND_ONLY_SLOTS, AQUATIC_SLOTS,
+  STAT_COMBOS_BY_LABEL, SLOT_WEIGHTS, TWO_HAND_WEIGHTS, LAND_ONLY_SLOTS, AQUATIC_SLOTS,
   MIGHT_POWER_PER_STACK, MIGHT_CONDI_PER_STACK, STACKING_SIGIL_DEFS, getEffectiveStats,
+  GW2_WEAPONS_BY_ID,
 } from "./constants.js";
 
 /**
@@ -203,8 +204,12 @@ function getExcludedSlots() {
 
 export function computeSlotStats(comboLabel, slotKey) {
   const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
-  const w = SLOT_WEIGHTS[slotKey];
+  let w = SLOT_WEIGHTS[slotKey];
   if (!combo || !w) return [];
+  const weapons = state.editor.equipment?.weapons || {};
+  if (slotKey.startsWith("mainhand") && GW2_WEAPONS_BY_ID.get(weapons[slotKey])?.hand === "two") {
+    w = TWO_HAND_WEIGHTS;
+  }
   const gameMode = state.editor?.gameMode || "pve";
   const stats = getEffectiveStats(combo, gameMode);
   const n = stats.length;
@@ -233,11 +238,15 @@ export function computeEquipmentStats(assumedBoons = null, sigilStacks = null) {
   const isUnderwater = Boolean(state.editor.underwaterMode);
   const EXCLUDED_SLOTS = getExcludedSlots();
   const gameMode = state.editor?.gameMode || "pve";
+  const weapons = state.editor.equipment?.weapons || {};
   for (const [slotKey, comboLabel] of Object.entries(slots)) {
     if (!comboLabel || EXCLUDED_SLOTS.has(slotKey)) continue;
     const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
-    const w = SLOT_WEIGHTS[slotKey];
+    let w = SLOT_WEIGHTS[slotKey];
     if (!combo || !w) continue;
+    if (slotKey.startsWith("mainhand") && GW2_WEAPONS_BY_ID.get(weapons[slotKey])?.hand === "two") {
+      w = TWO_HAND_WEIGHTS;
+    }
     const stats = getEffectiveStats(combo, gameMode);
     const n = stats.length;
     if (n <= 3) {
@@ -573,11 +582,15 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
   };
 
   // Equipment slots
+  const weapons = state.editor.equipment?.weapons || {};
   for (const [slotKey, comboLabel] of Object.entries(slots)) {
     if (!comboLabel || EXCLUDED_SLOTS.has(slotKey)) continue;
     const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
-    const w = SLOT_WEIGHTS[slotKey];
+    let w = SLOT_WEIGHTS[slotKey];
     if (!combo || !w) continue;
+    if (slotKey.startsWith("mainhand") && GW2_WEAPONS_BY_ID.get(weapons[slotKey])?.hand === "two") {
+      w = TWO_HAND_WEIGHTS;
+    }
     const n = combo.stats.length;
     let val = 0;
     if (n <= 3) {

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -455,11 +455,15 @@ export function computeBuildConcentration(build, upgradeCatalog) {
 
   // Stat combo slots — no catalog needed
   const EXCLUDED = AQUATIC_SLOTS; // always land mode
+  const weapons = equipment.weapons || {};
   for (const [slotKey, comboLabel] of Object.entries(slots)) {
     if (!comboLabel || EXCLUDED.has(slotKey)) continue;
     const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
-    const w = SLOT_WEIGHTS[slotKey];
+    let w = SLOT_WEIGHTS[slotKey];
     if (!combo || !w) continue;
+    if (slotKey.startsWith("mainhand") && GW2_WEAPONS_BY_ID.get(weapons[slotKey])?.hand === "two") {
+      w = TWO_HAND_WEIGHTS;
+    }
     const n = combo.stats.length;
     if (n <= 3) {
       if (combo.stats[0] === "Concentration") concentration += w.p;

--- a/tests/unit/statsCompute.test.js
+++ b/tests/unit/statsCompute.test.js
@@ -252,6 +252,59 @@ describe("computePublishStats", () => {
     expect(result.stats.HealingPower).toBe(101);
   });
 
+  // ── Two-handed weapon stats (issue #150) ─────────────────────────────
+
+  test("2h mainhand weapon uses higher stat weights than 1h (issue #150)", () => {
+    // A greatsword (2h) in mainhand1 should give p:251, not p:125
+    const equipment = {
+      slots: { mainhand1: "Berserker's" },
+      weapons: { mainhand1: "greatsword" },
+      runes: {}, infusions: {},
+    };
+    const result = computePublishStats(equipment, null, "Warrior");
+    // 2h Berserker's mainhand: Power major=251, Precision minor=179, Ferocity minor=179
+    expect(result.stats.Power).toBe(1000 + 251);
+    expect(result.stats.Precision).toBe(1000 + 179);
+    expect(result.stats.Ferocity).toBe(179);
+  });
+
+  test("1h mainhand weapon keeps original stat weights (issue #150)", () => {
+    const equipment = {
+      slots: { mainhand1: "Berserker's" },
+      weapons: { mainhand1: "sword" },
+      runes: {}, infusions: {},
+    };
+    const result = computePublishStats(equipment, null, "Warrior");
+    // 1h Berserker's mainhand: Power major=125, Precision minor=90, Ferocity minor=90
+    expect(result.stats.Power).toBe(1000 + 125);
+    expect(result.stats.Precision).toBe(1000 + 90);
+    expect(result.stats.Ferocity).toBe(90);
+  });
+
+  test("2h weapon with 4-stat combo uses correct 2h weights (issue #150)", () => {
+    const equipment = {
+      slots: { mainhand1: "Viper's" },
+      weapons: { mainhand1: "staff" },
+      runes: {}, infusions: {},
+    };
+    const result = computePublishStats(equipment, null, "Necromancer");
+    // 2h Viper's: Power + CondDmg major (p4=215), Precision + Expertise minor (s4=118)
+    expect(result.stats.Power).toBe(1000 + 215);
+    expect(result.stats.ConditionDamage).toBe(215);
+    expect(result.stats.Precision).toBe(1000 + 118);
+    expect(result.stats.Expertise).toBe(118);
+  });
+
+  test("no weapons object falls back to 1h weights (backwards compat, issue #150)", () => {
+    // Old builds without weapons data should still work (use 1h weights)
+    const equipment = {
+      slots: { mainhand1: "Berserker's" },
+      runes: {}, infusions: {},
+    };
+    const result = computePublishStats(equipment, null, "Warrior");
+    expect(result.stats.Power).toBe(1000 + 125);
+  });
+
   test("food with 'to All Attributes' adds to every stat", () => {
     const equipment = { slots: {}, runes: {}, infusions: {}, food: "91713", utility: "" };
     const upgradeCatalog = {


### PR DESCRIPTION
## Summary

Two-handed weapons (greatsword, hammer, longbow, rifle, shortbow, staff, spear) were using the same stat weights as one-handed weapons (attribute_adjustment 358.4 → p:125, s:90). They now correctly use doubled weights (attribute_adjustment 716.8 → p:251, s:179), matching the values already used for aquatic weapons.

**Changes:**
- Added `TWO_HAND_WEIGHTS` constant and `TWO_HAND_WEAPON_IDS` set to `statsCompute.js`
- Added `TWO_HAND_WEIGHTS` export to renderer `constants.js`
- Updated stat computation in 3 renderer functions (`computeSlotStats`, `computeEquipmentStats`, stat breakdown tooltip) and 2 main-process functions (`computePublishStats`, `estimateRole`) to use 2h weights when a two-handed weapon is detected in a mainhand slot
- Backwards compatible: builds without `weapons` data fall back to 1h weights

Closes #150

## Test plan
- [x] Added 4 new unit tests (2h Berserker's, 1h Berserker's, 2h Viper's 4-stat, no-weapons fallback)
- [x] All 2843 existing tests pass
- [ ] Manual: equip a greatsword with Berserker's stats → Power should show +251 (not +125)
- [ ] Manual: equip a sword with Berserker's stats → Power should still show +125
- [ ] Manual: verify published build stat totals match in-editor stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)