### PR TITLE
feat: add side hover tooltip to relic selector dropdown items (closes #152)

### DIFF
--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -166,8 +166,8 @@ export function bindHoverPreview(node, kind, entityProvider) {
   node.addEventListener("mouseenter", (event) => {
     const entity = readEntity();
     if (!entity) return;
-    // Inside a skill-select dropdown, anchor tooltip to the left of the menu
-    const menu = node.closest(".skill-select-overlay .cselect__menu");
+    // Inside a dropdown menu, anchor tooltip to the left of the menu
+    const menu = node.closest(".skill-select-overlay .cselect__menu") || node.closest(".slot-picker__list");
     if (menu) {
       _anchoredMenu = menu;
       showHoverPreview(kind, entity, 0, 0);

--- a/src/renderer/modules/equipment.js
+++ b/src/renderer/modules/equipment.js
@@ -72,7 +72,7 @@ export function closeSlotPicker() {
   if (_slotPickerCleanup) { _slotPickerCleanup(); _slotPickerCleanup = null; }
 }
 
-export function openSlotPicker(anchorEl, currentValue, onSelect, { items = null, searchPlaceholder = "Search stats…", className = "", tabs = null } = {}) {
+export function openSlotPicker(anchorEl, currentValue, onSelect, { items = null, searchPlaceholder = "Search stats…", className = "", tabs = null, hoverProvider = null } = {}) {
   closeSlotPicker();
 
   const picker = document.createElement("div");
@@ -148,6 +148,9 @@ export function openSlotPicker(anchorEl, currentValue, onSelect, { items = null,
         btn.style.pointerEvents = "none";
       }
       btn.addEventListener("click", () => { if (opt.disabled) return; onSelect(opt.value); closeSlotPicker(); });
+      if (hoverProvider && opt.value) {
+        bindHoverPreview(btn, ...hoverProvider(opt));
+      }
       list.append(btn);
     }
   }
@@ -1640,7 +1643,17 @@ export function renderEquipmentPanel() {
       equip.relic = newVal || "";
       _markEditorChanged();
       renderEquipmentPanel();
-    }, { items: relicItems, searchPlaceholder: "Search relics…" });
+    }, {
+      items: relicItems, searchPlaceholder: "Search relics…",
+      hoverProvider: (opt) => {
+        const rDef = GW2_RELICS_BY_LABEL.get(opt.value);
+        return ["equip-relic", () => {
+          if (!rDef) return null;
+          const catalogRelic = state.upgradeCatalog?.relicByName?.get(rDef.label);
+          return { name: rDef.label, icon: rDef.icon, description: catalogRelic?.description || "", facts: catalogRelic?.facts || [] };
+        }];
+      },
+    });
     if (!_readOnly) {
       wrapper.addEventListener("click", doOpen);
       wrapper.addEventListener("keydown", (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); doOpen(); } });


### PR DESCRIPTION
## Summary
Adds anchored side hover tooltips to the relic selector dropdown on the equipment tab. When hovering over relic options in the dropdown, a tooltip showing the relic's name, icon, description, and facts now appears anchored to the side of the menu — matching the existing behavior of utility skill dropdowns.

- Extended `openSlotPicker` with an optional `hoverProvider` callback for binding hover previews on dropdown items
- Extended `bindHoverPreview` anchored menu detection to include `.slot-picker__list`
- Relic picker passes entity data (name, icon, description, facts) for each option

Closes #152