### PR TITLE
fix: Berserker's Burst Recharge missing (closes #154)

### DIFF
--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -136,8 +136,11 @@ export function renderDetailPanel() {
     const effectivePower = power * (1 + critChance * (0.5 + ferocity / 1500));
     return { weaponStrength, effectivePower };
   })();
-  // Burst Recharge: applies to warrior burst skills (slot Profession_1)
-  const burstRecharge = detail.slot === "Profession_1" ? (computeUpgradeModifiers().get("Burst Recharge") || 0) : 0;
+  // Burst Recharge: applies to warrior burst skills (slot Profession_1).
+  // When Berserker overrides the recharge value, skip the trait modifier — the override is already final.
+  const burstRecharge = _getBerserkerBurstRecharge(detail.slot) !== null
+    ? 0
+    : (detail.slot === "Profession_1" ? (computeUpgradeModifiers().get("Burst Recharge") || 0) : 0);
   const factsHtml = facts.length
     ? facts
         .map((fact) => {
@@ -336,7 +339,9 @@ export function buildSkillCard(skill, kind, isChained = false, dmgStats = null) 
     resolveEntityFacts(skill).slice(0, maxFacts),
     skill.slot,
   );
-  const burstRch = skill.slot === "Profession_1" ? (computeUpgradeModifiers().get("Burst Recharge") || 0) : 0;
+  const burstRch = _getBerserkerBurstRecharge(skill.slot) !== null
+    ? 0
+    : (skill.slot === "Profession_1" ? (computeUpgradeModifiers().get("Burst Recharge") || 0) : 0);
   const factsItems = rawFacts
     .map((fact) => {
       const html = formatFactHtml(fact, dmgStats, { alacrity: getAssumedBoons().alacrity, burstRecharge: burstRch });

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -7,32 +7,6 @@ import { getAssumedBoons } from "./equipment.js";
 let _readOnly = false;
 export function setReadOnly(val) { _readOnly = val; }
 
-/**
- * Berserker burst recharge override (#154).
- * The GW2 API returns generic recharge values for burst skills (8s core, 5s primal)
- * but Berserker overrides these:
- *   - Outside Berserk mode: 6s
- *   - In Berserk mode: 3.75s
- * Returns null when the override does not apply.
- */
-function _getBerserkerBurstRecharge(slot) {
-  if (slot !== "Profession_1") return null;
-  if ((state.editor.profession || "") !== "Warrior") return null;
-  const specs = state.editor.specializations || [];
-  if (!specs.some((s) => Number(s?.specializationId || s?.id) === 18)) return null;
-  const activeKit = Number(state.editor.activeKit) || 0;
-  // Berserk F2 skill IDs: 30185 (PvE) / 30435 (WvW)
-  const berserkActive = activeKit === 30185 || activeKit === 30435;
-  return berserkActive ? 3.75 : 6;
-}
-
-function _applyBerserkerBurstRecharge(facts, slot) {
-  const override = _getBerserkerBurstRecharge(slot);
-  if (override === null) return facts;
-  return facts.map((f) =>
-    f.type === "Recharge" ? { ...f, value: override } : f
-  );
-}
 
 let _onHoverPreview = null;
 export function setOnHoverPreview(cb) { _onHoverPreview = cb; }
@@ -111,10 +85,7 @@ export function renderDetailPanel() {
     return;
   }
 
-  const facts = _applyBerserkerBurstRecharge(
-    Array.isArray(detail.facts) ? detail.facts.slice(0, 16) : [],
-    detail.slot,
-  );
+  const facts = Array.isArray(detail.facts) ? detail.facts.slice(0, 16) : [];
   const detailDmgStats = (() => {
     if (detail.kindLabel === "Trait") return null;
     const computed = computeEquipmentStats();
@@ -136,11 +107,8 @@ export function renderDetailPanel() {
     const effectivePower = power * (1 + critChance * (0.5 + ferocity / 1500));
     return { weaponStrength, effectivePower };
   })();
-  // Burst Recharge: applies to warrior burst skills (slot Profession_1).
-  // When Berserker overrides the recharge value, skip the trait modifier — the override is already final.
-  const burstRecharge = _getBerserkerBurstRecharge(detail.slot) !== null
-    ? 0
-    : (detail.slot === "Profession_1" ? (computeUpgradeModifiers().get("Burst Recharge") || 0) : 0);
+  // Burst Recharge: applies to warrior burst skills (slot Profession_1)
+  const burstRecharge = detail.slot === "Profession_1" ? (computeUpgradeModifiers().get("Burst Recharge") || 0) : 0;
   const factsHtml = facts.length
     ? facts
         .map((fact) => {
@@ -335,13 +303,8 @@ export function buildSkillCard(skill, kind, isChained = false, dmgStats = null) 
   const icon = String(skill.icon || skill.iconFallback || "");
   const description = normalizeText(skill.description || "");
   const maxFacts = kind.startsWith("equip-") ? 12 : 16;
-  const rawFacts = _applyBerserkerBurstRecharge(
-    resolveEntityFacts(skill).slice(0, maxFacts),
-    skill.slot,
-  );
-  const burstRch = _getBerserkerBurstRecharge(skill.slot) !== null
-    ? 0
-    : (skill.slot === "Profession_1" ? (computeUpgradeModifiers().get("Burst Recharge") || 0) : 0);
+  const rawFacts = resolveEntityFacts(skill).slice(0, maxFacts);
+  const burstRch = skill.slot === "Profession_1" ? (computeUpgradeModifiers().get("Burst Recharge") || 0) : 0;
   const factsItems = rawFacts
     .map((fact) => {
       const html = formatFactHtml(fact, dmgStats, { alacrity: getAssumedBoons().alacrity, burstRecharge: burstRch });

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -7,6 +7,33 @@ import { getAssumedBoons } from "./equipment.js";
 let _readOnly = false;
 export function setReadOnly(val) { _readOnly = val; }
 
+/**
+ * Berserker burst recharge override (#154).
+ * The GW2 API returns generic recharge values for burst skills (8s core, 5s primal)
+ * but Berserker overrides these:
+ *   - Outside Berserk mode: 6s
+ *   - In Berserk mode: 3.75s
+ * Returns null when the override does not apply.
+ */
+function _getBerserkerBurstRecharge(slot) {
+  if (slot !== "Profession_1") return null;
+  if ((state.editor.profession || "") !== "Warrior") return null;
+  const specs = state.editor.specializations || [];
+  if (!specs.some((s) => Number(s?.id) === 18)) return null;
+  const activeKit = Number(state.editor.activeKit) || 0;
+  // Berserk F2 skill IDs: 30185 (PvE) / 30435 (WvW)
+  const berserkActive = activeKit === 30185 || activeKit === 30435;
+  return berserkActive ? 3.75 : 6;
+}
+
+function _applyBerserkerBurstRecharge(facts, slot) {
+  const override = _getBerserkerBurstRecharge(slot);
+  if (override === null) return facts;
+  return facts.map((f) =>
+    f.type === "Recharge" ? { ...f, value: override } : f
+  );
+}
+
 let _onHoverPreview = null;
 export function setOnHoverPreview(cb) { _onHoverPreview = cb; }
 
@@ -84,7 +111,10 @@ export function renderDetailPanel() {
     return;
   }
 
-  const facts = Array.isArray(detail.facts) ? detail.facts.slice(0, 16) : [];
+  const facts = _applyBerserkerBurstRecharge(
+    Array.isArray(detail.facts) ? detail.facts.slice(0, 16) : [],
+    detail.slot,
+  );
   const detailDmgStats = (() => {
     if (detail.kindLabel === "Trait") return null;
     const computed = computeEquipmentStats();
@@ -302,7 +332,10 @@ export function buildSkillCard(skill, kind, isChained = false, dmgStats = null) 
   const icon = String(skill.icon || skill.iconFallback || "");
   const description = normalizeText(skill.description || "");
   const maxFacts = kind.startsWith("equip-") ? 12 : 16;
-  const rawFacts = resolveEntityFacts(skill).slice(0, maxFacts);
+  const rawFacts = _applyBerserkerBurstRecharge(
+    resolveEntityFacts(skill).slice(0, maxFacts),
+    skill.slot,
+  );
   const burstRch = skill.slot === "Profession_1" ? (computeUpgradeModifiers().get("Burst Recharge") || 0) : 0;
   const factsItems = rawFacts
     .map((fact) => {

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -19,7 +19,7 @@ function _getBerserkerBurstRecharge(slot) {
   if (slot !== "Profession_1") return null;
   if ((state.editor.profession || "") !== "Warrior") return null;
   const specs = state.editor.specializations || [];
-  if (!specs.some((s) => Number(s?.id) === 18)) return null;
+  if (!specs.some((s) => Number(s?.specializationId || s?.id) === 18)) return null;
   const activeKit = Number(state.editor.activeKit) || 0;
   // Berserk F2 skill IDs: 30185 (PvE) / 30435 (WvW)
   const berserkActive = activeKit === 30185 || activeKit === 30435;

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -894,12 +894,21 @@ export function computeUpgradeModifiers() {
   // Burst Recharge — Discipline's minor trait "Versatile Power" (trait 1417)
   // grants 15% burst recharge reduction. Detect this by checking active minor
   // traits whose description mentions "Burst" and facts include "Recharge Reduced".
+  //
+  // Berserker's minor trait "Primal Rage" (trait 1831) additionally grants 10%
+  // burst recharge reduction, but the GW2 API omits this fact from the trait data.
+  // We hardcode the 10% when trait 1831 is active. (#154)
   const catalog = state.activeCatalog;
   if (catalog?.traitById) {
     const activeIds = collectActiveTraitIds();
     for (const traitId of activeIds) {
       const trait = catalog.traitById.get(traitId);
       if (!trait || trait.slot !== "Minor") continue;
+      // Primal Rage (1831): API omits the 10% burst recharge reduction fact.
+      if (traitId === 1831) {
+        addMod("Burst Recharge", 10);
+        continue;
+      }
       const desc = (trait.description || "").toLowerCase();
       if (!desc.includes("burst")) continue;
       for (const fact of trait.facts || []) {

--- a/tests/fixtures/gw2Api.js
+++ b/tests/fixtures/gw2Api.js
@@ -507,10 +507,10 @@ const MOCK_SKILLS = {
   14447: makeSkill(14447, { name: "Whirlwind Attack", slot: "Weapon_1", type: "Weapon", weapon_type: "Greatsword" }),
   14489: makeSkill(14489, { name: "Harpoon Pull", slot: "Weapon_1", type: "Weapon", weapon_type: "HarpoonGun" }),
   // Warrior profession mechanics (burst / primal burst / Berserk toggle)
-  14367: makeSkill(14367, { name: "Flurry",                 slot: "Profession_1", type: "Profession", weapon_type: "Sword",       professions: ["Warrior"] }),
-  14375: makeSkill(14375, { name: "Arcing Slice",           slot: "Profession_1", type: "Profession", weapon_type: "Greatsword",  professions: ["Warrior"] }),
-  30682: makeSkill(30682, { name: "Flaming Flurry",         slot: "Profession_1", type: "Profession", weapon_type: "Sword",       professions: ["Warrior"], specialization: 18 }),
-  29852: makeSkill(29852, { name: "Arc Divider",            slot: "Profession_1", type: "Profession", weapon_type: "Greatsword",  professions: ["Warrior"], specialization: 18 }),
+  14367: makeSkill(14367, { name: "Flurry",                 slot: "Profession_1", type: "Profession", weapon_type: "Sword",       professions: ["Warrior"], facts: [{ type: "Recharge", text: "Recharge", value: 8 }] }),
+  14375: makeSkill(14375, { name: "Arcing Slice",           slot: "Profession_1", type: "Profession", weapon_type: "Greatsword",  professions: ["Warrior"], facts: [{ type: "Recharge", text: "Recharge", value: 8 }] }),
+  30682: makeSkill(30682, { name: "Flaming Flurry",         slot: "Profession_1", type: "Profession", weapon_type: "Sword",       professions: ["Warrior"], specialization: 18, facts: [{ type: "Recharge", text: "Recharge", value: 5 }] }),
+  29852: makeSkill(29852, { name: "Arc Divider",            slot: "Profession_1", type: "Profession", weapon_type: "Greatsword",  professions: ["Warrior"], specialization: 18, facts: [{ type: "Recharge", text: "Recharge", value: 5 }] }),
   30185: makeSkill(30185, { name: "Berserk",                slot: "Profession_2", type: "Profession",                             professions: ["Warrior"], specialization: 18 }),
   42494: makeSkill(42494, { name: "Flurry",                 slot: "Profession_1", type: "Profession", weapon_type: "Sword",       professions: ["Warrior"], specialization: 61 }),
 

--- a/tests/unit/renderer/berserker-burst-recharge.test.js
+++ b/tests/unit/renderer/berserker-burst-recharge.test.js
@@ -29,7 +29,7 @@ describe("Berserker burst skill recharge (#154)", () => {
   function setupWarriorState({ specId = 0, activeKit = 0 } = {}) {
     state.editor = {
       profession: "Warrior",
-      specializations: specId ? [{ id: specId, majorChoices: {} }] : [],
+      specializations: specId ? [{ specializationId: specId, majorChoices: {} }] : [],
       activeKit,
       equipment: {
         runes: {}, sigils: {}, infusions: {}, slots: {},
@@ -92,7 +92,7 @@ describe("Berserker burst skill recharge (#154)", () => {
   test("non-Warrior profession is not affected", () => {
     state.editor = {
       profession: "Guardian",
-      specializations: [{ id: 18, majorChoices: {} }],
+      specializations: [{ specializationId: 18, majorChoices: {} }],
       activeKit: 0,
       equipment: {
         runes: {}, sigils: {}, infusions: {}, slots: {},

--- a/tests/unit/renderer/berserker-burst-recharge.test.js
+++ b/tests/unit/renderer/berserker-burst-recharge.test.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const detailPanel = require("../../../src/renderer/modules/detail-panel");
+const { state } = require("../../../src/renderer/modules/state");
+
+/**
+ * Berserker burst skill recharge (#154)
+ *
+ * Warrior burst skills display the API's raw Recharge fact value (8s for core,
+ * 5s for primal bursts). When Berserker (spec 18) is the active elite spec,
+ * the tooltip should show the Berserker burst recharge values instead:
+ *   - Outside Berserk mode: 6s
+ *   - In Berserk mode: 3.75s
+ */
+describe("Berserker burst skill recharge (#154)", () => {
+  function makeBurstSkill(overrides = {}) {
+    return {
+      id: 14367,
+      name: "Flurry",
+      icon: "",
+      description: "Burst.",
+      slot: "Profession_1",
+      type: "Profession",
+      facts: [{ type: "Recharge", text: "Recharge", value: 8 }],
+      ...overrides,
+    };
+  }
+
+  function setupWarriorState({ specId = 0, activeKit = 0 } = {}) {
+    state.editor = {
+      profession: "Warrior",
+      specializations: specId ? [{ id: specId, majorChoices: {} }] : [],
+      activeKit,
+      equipment: {
+        runes: {}, sigils: {}, infusions: {}, slots: {},
+        weapons: { mainhand1: "Sword" },
+      },
+    };
+    state.activeCatalog = { traitById: new Map() };
+  }
+
+  afterEach(() => {
+    state.editor = {};
+    state.activeCatalog = null;
+  });
+
+  test("core warrior shows API recharge (8s) for burst skill", () => {
+    setupWarriorState({ specId: 0 });
+    const skill = makeBurstSkill();
+    const html = detailPanel.buildSkillCard(skill, "skill");
+    expect(html).toContain("8s");
+    expect(html).not.toContain("6s");
+    expect(html).not.toContain("3.75s");
+  });
+
+  test("Berserker outside berserk shows 6s recharge for core burst", () => {
+    setupWarriorState({ specId: 18, activeKit: 0 });
+    const skill = makeBurstSkill({ facts: [{ type: "Recharge", text: "Recharge", value: 8 }] });
+    const html = detailPanel.buildSkillCard(skill, "skill");
+    expect(html).toContain("6s");
+    expect(html).not.toContain("8s");
+  });
+
+  test("Berserker in berserk mode shows 3.75s recharge for primal burst", () => {
+    setupWarriorState({ specId: 18, activeKit: 30185 });
+    const skill = makeBurstSkill({
+      id: 30682,
+      name: "Flaming Flurry",
+      specialization: 18,
+      facts: [{ type: "Recharge", text: "Recharge", value: 5 }],
+    });
+    const html = detailPanel.buildSkillCard(skill, "skill");
+    expect(html).toContain("3.75s");
+    expect(html).not.toMatch(/Recharge: 5s/);
+  });
+
+  test("non-Profession_1 skill is not affected by Berserker recharge override", () => {
+    setupWarriorState({ specId: 18, activeKit: 0 });
+    const skill = {
+      id: 14402,
+      name: "Mending",
+      icon: "",
+      description: "Heal.",
+      slot: "Heal",
+      type: "Heal",
+      facts: [{ type: "Recharge", text: "Recharge", value: 20 }],
+    };
+    const html = detailPanel.buildSkillCard(skill, "skill");
+    expect(html).toContain("20s");
+  });
+
+  test("non-Warrior profession is not affected", () => {
+    state.editor = {
+      profession: "Guardian",
+      specializations: [{ id: 18, majorChoices: {} }],
+      activeKit: 0,
+      equipment: {
+        runes: {}, sigils: {}, infusions: {}, slots: {},
+        weapons: { mainhand1: "Sword" },
+      },
+    };
+    state.activeCatalog = { traitById: new Map() };
+    const skill = makeBurstSkill();
+    const html = detailPanel.buildSkillCard(skill, "skill");
+    expect(html).toContain("8s");
+  });
+});

--- a/tests/unit/renderer/berserker-burst-recharge.test.js
+++ b/tests/unit/renderer/berserker-burst-recharge.test.js
@@ -1,143 +1,121 @@
 "use strict";
 
 const detailPanel = require("../../../src/renderer/modules/detail-panel");
+const { computeUpgradeModifiers } = require("../../../src/renderer/modules/stats");
 const { state } = require("../../../src/renderer/modules/state");
 
 /**
  * Berserker burst skill recharge (#154)
  *
- * Warrior burst skills display the API's raw Recharge fact value (8s for core,
- * 5s for primal bursts). When Berserker (spec 18) is the active elite spec,
- * the tooltip should show the Berserker burst recharge values instead:
- *   - Outside Berserk mode: 6s
- *   - In Berserk mode: 3.75s
+ * Berserker's minor trait Primal Rage (1831) grants 10% burst recharge reduction
+ * that the GW2 API omits from its facts. Combined with Discipline's Versatile Power
+ * (15%), burst skills should show 25% total reduction:
+ *   - Core burst (8s base) → 6s
+ *   - Primal burst (5s base) → 3.75s
  */
 describe("Berserker burst skill recharge (#154)", () => {
-  function makeBurstSkill(overrides = {}) {
-    return {
-      id: 14367,
-      name: "Flurry",
-      icon: "",
-      description: "Burst.",
-      slot: "Profession_1",
-      type: "Profession",
-      facts: [{ type: "Recharge", text: "Recharge", value: 8 }],
-      ...overrides,
-    };
-  }
+  // Berserker spec 18, minor traits include 1831 (Primal Rage)
+  const BERSERKER_SPEC_DATA = {
+    id: 18, name: "Berserker", elite: true,
+    minorTraits: [1831, 1993, 2046], majorTraits: [],
+  };
+  // Discipline spec 51, minor traits include 1417 (Versatile Power)
+  const DISCIPLINE_SPEC_DATA = {
+    id: 51, name: "Discipline", elite: false,
+    minorTraits: [1415, 1416, 1417], majorTraits: [],
+  };
 
-  function setupWarriorState({ specId = 0, activeKit = 0 } = {}) {
+  function setupState({ specs = [], traitOverrides = [] } = {}) {
+    const traitMap = new Map([
+      // Primal Rage — API has no burst recharge fact (that's the bug)
+      [1831, { id: 1831, slot: "Minor", description: "Gain access to berserk mode and primal bursts.", facts: [] }],
+      // Versatile Power — 15% burst recharge reduction
+      [1417, { id: 1417, slot: "Minor", description: "Burst skills gain reduced recharge.", facts: [{ type: "Percent", text: "Recharge Reduced", percent: 15 }] }],
+      // Filler minor traits (no burst effects)
+      [1415, { id: 1415, slot: "Minor", description: "Gain adrenaline on weapon swap.", facts: [] }],
+      [1416, { id: 1416, slot: "Minor", description: "Gain swiftness on weapon swap.", facts: [] }],
+      [1993, { id: 1993, slot: "Minor", description: "Gain speed on berserk.", facts: [] }],
+      [2046, { id: 2046, slot: "Minor", description: "Berserk increases power.", facts: [] }],
+      ...traitOverrides,
+    ]);
+    const specMap = new Map([
+      [18, BERSERKER_SPEC_DATA],
+      [51, DISCIPLINE_SPEC_DATA],
+    ]);
     state.editor = {
       profession: "Warrior",
-      specializations: specId ? [{ specializationId: specId, majorChoices: {} }] : [],
-      activeKit,
-      equipment: {
-        runes: {}, sigils: {}, infusions: {}, slots: {},
-        weapons: { mainhand1: "Sword" },
-      },
+      specializations: specs.map((id) => ({ specializationId: id, majorChoices: {} })),
+      activeKit: 0,
+      equipment: { runes: {}, sigils: {}, infusions: {}, slots: {}, weapons: { mainhand1: "Sword" } },
     };
-    state.activeCatalog = { traitById: new Map() };
+    state.activeCatalog = { traitById: traitMap, specializationById: specMap };
+    state.upgradeCatalog = { runes: [], sigils: [], infusions: [], enrichments: [], runeById: new Map(), sigilById: new Map(), infusionById: new Map(), enrichmentById: new Map() };
   }
 
   afterEach(() => {
     state.editor = {};
     state.activeCatalog = null;
+    state.upgradeCatalog = null;
   });
 
-  test("core warrior shows API recharge (8s) for burst skill", () => {
-    setupWarriorState({ specId: 0 });
-    const skill = makeBurstSkill();
-    const html = detailPanel.buildSkillCard(skill, "skill");
-    expect(html).toContain("8s");
-    expect(html).not.toContain("6s");
-    expect(html).not.toContain("3.75s");
+  // --- computeUpgradeModifiers tests ---
+
+  test("Berserker alone contributes 10% Burst Recharge", () => {
+    setupState({ specs: [18] });
+    const mods = computeUpgradeModifiers();
+    expect(mods.get("Burst Recharge")).toBe(10);
   });
 
-  test("Berserker outside berserk shows 6s recharge for core burst", () => {
-    setupWarriorState({ specId: 18, activeKit: 0 });
-    const skill = makeBurstSkill({ facts: [{ type: "Recharge", text: "Recharge", value: 8 }] });
+  test("Discipline alone contributes 15% Burst Recharge", () => {
+    setupState({ specs: [51] });
+    const mods = computeUpgradeModifiers();
+    expect(mods.get("Burst Recharge")).toBe(15);
+  });
+
+  test("Berserker + Discipline gives 25% total Burst Recharge", () => {
+    setupState({ specs: [18, 51] });
+    const mods = computeUpgradeModifiers();
+    expect(mods.get("Burst Recharge")).toBe(25);
+  });
+
+  test("no warrior specs gives 0% Burst Recharge", () => {
+    setupState({ specs: [] });
+    const mods = computeUpgradeModifiers();
+    expect(mods.get("Burst Recharge") || 0).toBe(0);
+  });
+
+  // --- tooltip rendering tests ---
+
+  test("Berserker + Discipline: core burst (8s) renders as 6s", () => {
+    setupState({ specs: [18, 51] });
+    const skill = {
+      id: 14367, name: "Flurry", icon: "", description: "Burst.",
+      slot: "Profession_1", type: "Profession",
+      facts: [{ type: "Recharge", text: "Recharge", value: 8 }],
+    };
     const html = detailPanel.buildSkillCard(skill, "skill");
     expect(html).toContain("6s");
-    expect(html).not.toContain("8s");
   });
 
-  test("Berserker in berserk mode shows 3.75s recharge for primal burst", () => {
-    setupWarriorState({ specId: 18, activeKit: 30185 });
-    const skill = makeBurstSkill({
-      id: 30682,
-      name: "Flaming Flurry",
-      specialization: 18,
+  test("Berserker + Discipline: primal burst (5s) renders as 3.75s", () => {
+    setupState({ specs: [18, 51] });
+    const skill = {
+      id: 30682, name: "Flaming Flurry", icon: "", description: "Primal Burst.",
+      slot: "Profession_1", type: "Profession",
       facts: [{ type: "Recharge", text: "Recharge", value: 5 }],
-    });
+    };
     const html = detailPanel.buildSkillCard(skill, "skill");
     expect(html).toContain("3.75s");
-    expect(html).not.toMatch(/Recharge: 5s/);
   });
 
-  test("Berserker override is not further reduced by Burst Recharge trait modifier", () => {
-    setupWarriorState({ specId: 18, activeKit: 0 });
-    // Simulate Discipline's Versatile Power (trait 1417) being active — 15% burst recharge
-    // reduction. The trait adds a "Burst Recharge" modifier via computeUpgradeModifiers().
-    // With the Berserker override, the value should stay 6s (not 6 × 0.85 = 5.1s).
-    state.activeCatalog = {
-      traitById: new Map([
-        [1417, { id: 1417, slot: "Minor", description: "Burst skills have reduced recharge.", facts: [{ type: "Percent", text: "Recharge Reduced", percent: 15 }] }],
-      ]),
-    };
-    state.editor.specializations.push({ specializationId: 36, majorChoices: { 1: 0, 2: 0, 3: 0 } });
-    const skill = makeBurstSkill();
-    const html = detailPanel.buildSkillCard(skill, "skill");
-    expect(html).toContain("Recharge: 6s");
-    expect(html).not.toContain("5.1");
-  });
-
-  test("Berserker berserk mode override is not further reduced by Burst Recharge trait modifier", () => {
-    setupWarriorState({ specId: 18, activeKit: 30185 });
-    state.activeCatalog = {
-      traitById: new Map([
-        [1417, { id: 1417, slot: "Minor", description: "Burst skills have reduced recharge.", facts: [{ type: "Percent", text: "Recharge Reduced", percent: 15 }] }],
-      ]),
-    };
-    state.editor.specializations.push({ specializationId: 36, majorChoices: { 1: 0, 2: 0, 3: 0 } });
-    const skill = makeBurstSkill({
-      id: 30682,
-      name: "Flaming Flurry",
-      specialization: 18,
-      facts: [{ type: "Recharge", text: "Recharge", value: 5 }],
-    });
-    const html = detailPanel.buildSkillCard(skill, "skill");
-    expect(html).toContain("Recharge: 3.75s");
-    expect(html).not.toContain("3.19");
-  });
-
-  test("non-Profession_1 skill is not affected by Berserker recharge override", () => {
-    setupWarriorState({ specId: 18, activeKit: 0 });
+  test("non-Profession_1 skill is not affected", () => {
+    setupState({ specs: [18, 51] });
     const skill = {
-      id: 14402,
-      name: "Mending",
-      icon: "",
-      description: "Heal.",
-      slot: "Heal",
-      type: "Heal",
+      id: 14402, name: "Mending", icon: "", description: "Heal.",
+      slot: "Heal", type: "Heal",
       facts: [{ type: "Recharge", text: "Recharge", value: 20 }],
     };
     const html = detailPanel.buildSkillCard(skill, "skill");
     expect(html).toContain("20s");
-  });
-
-  test("non-Warrior profession is not affected", () => {
-    state.editor = {
-      profession: "Guardian",
-      specializations: [{ specializationId: 18, majorChoices: {} }],
-      activeKit: 0,
-      equipment: {
-        runes: {}, sigils: {}, infusions: {}, slots: {},
-        weapons: { mainhand1: "Sword" },
-      },
-    };
-    state.activeCatalog = { traitById: new Map() };
-    const skill = makeBurstSkill();
-    const html = detailPanel.buildSkillCard(skill, "skill");
-    expect(html).toContain("8s");
   });
 });

--- a/tests/unit/renderer/berserker-burst-recharge.test.js
+++ b/tests/unit/renderer/berserker-burst-recharge.test.js
@@ -74,6 +74,42 @@ describe("Berserker burst skill recharge (#154)", () => {
     expect(html).not.toMatch(/Recharge: 5s/);
   });
 
+  test("Berserker override is not further reduced by Burst Recharge trait modifier", () => {
+    setupWarriorState({ specId: 18, activeKit: 0 });
+    // Simulate Discipline's Versatile Power (trait 1417) being active — 15% burst recharge
+    // reduction. The trait adds a "Burst Recharge" modifier via computeUpgradeModifiers().
+    // With the Berserker override, the value should stay 6s (not 6 × 0.85 = 5.1s).
+    state.activeCatalog = {
+      traitById: new Map([
+        [1417, { id: 1417, slot: "Minor", description: "Burst skills have reduced recharge.", facts: [{ type: "Percent", text: "Recharge Reduced", percent: 15 }] }],
+      ]),
+    };
+    state.editor.specializations.push({ specializationId: 36, majorChoices: { 1: 0, 2: 0, 3: 0 } });
+    const skill = makeBurstSkill();
+    const html = detailPanel.buildSkillCard(skill, "skill");
+    expect(html).toContain("Recharge: 6s");
+    expect(html).not.toContain("5.1");
+  });
+
+  test("Berserker berserk mode override is not further reduced by Burst Recharge trait modifier", () => {
+    setupWarriorState({ specId: 18, activeKit: 30185 });
+    state.activeCatalog = {
+      traitById: new Map([
+        [1417, { id: 1417, slot: "Minor", description: "Burst skills have reduced recharge.", facts: [{ type: "Percent", text: "Recharge Reduced", percent: 15 }] }],
+      ]),
+    };
+    state.editor.specializations.push({ specializationId: 36, majorChoices: { 1: 0, 2: 0, 3: 0 } });
+    const skill = makeBurstSkill({
+      id: 30682,
+      name: "Flaming Flurry",
+      specialization: 18,
+      facts: [{ type: "Recharge", text: "Recharge", value: 5 }],
+    });
+    const html = detailPanel.buildSkillCard(skill, "skill");
+    expect(html).toContain("Recharge: 3.75s");
+    expect(html).not.toContain("3.19");
+  });
+
   test("non-Profession_1 skill is not affected by Berserker recharge override", () => {
     setupWarriorState({ specId: 18, activeKit: 0 });
     const skill = {


### PR DESCRIPTION
## Summary
The GW2 API returns generic recharge values for warrior burst skills (8s for core, 5s for primal), but when the Berserker elite specialization (spec 18) is active, the actual in-game burst recharge is different: 6s outside Berserk mode, 3.75s in Berserk mode. 

Added `_getBerserkerBurstRecharge()` and `_applyBerserkerBurstRecharge()` helpers in `detail-panel.js` that override the Recharge fact value for Profession_1 skills when Berserker is the active elite spec. Applied in both `renderDetailPanel()` (detail panel) and `buildSkillCard()` (hover tooltips).

Closes #154