### PR TITLE
fix: Signet Passive buffs not effecting stat totals (closes #155)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "audit:wiki:skills": "node tests/wiki-audit/run-audit.js --type skills",
     "audit:wiki:traits": "node tests/wiki-audit/run-audit.js --type traits",
     "audit:wiki:relics": "node tests/wiki-audit/run-audit.js --type relics",
+    "audit:wiki:signets": "node tests/wiki-audit/run-audit.js --type signets",
     "test:e2e": "npx playwright test --config tests/e2e/playwright.config.js",
     "test:e2e:headed": "npx playwright test --config tests/e2e/playwright.config.js --headed",
     "test:e2e:debug": "PWDEBUG=1 npx playwright test --config tests/e2e/playwright.config.js",

--- a/src/main/gw2Data/signetPassives.json
+++ b/src/main/gw2Data/signetPassives.json
@@ -1,82 +1,265 @@
 {
   "updatedAt": "2026-04-06T00:00:00.000Z",
   "signets": {
+    "5503": {
+      "name": "Signet of Restoration",
+      "passive": "heal per spell cast",
+      "facts": []
+    },
+    "5542": {
+      "name": "Signet of Fire",
+      "passive": "+180 Precision",
+      "facts": [
+        { "type": "Number", "text": "Signet of Fire", "value": 180 }
+      ]
+    },
+    "5570": {
+      "name": "Signet of Water",
+      "passive": "-20% condition duration",
+      "facts": [
+        { "type": "Number", "text": "Signet of Water", "value": -20 }
+      ]
+    },
+    "5571": {
+      "name": "Signet of Earth",
+      "passive": "-10% incoming strike damage",
+      "facts": [
+        { "type": "Number", "text": "Signet of Earth", "value": -10 }
+      ]
+    },
+    "5572": {
+      "name": "Signet of Air",
+      "passive": "25% movement speed",
+      "facts": []
+    },
     "9093": {
       "name": "Bane Signet",
+      "passive": "+180 Power",
       "facts": [
-        { "type": "Number", "text": "Power", "value": 180 }
+        { "type": "Number", "text": "Bane Signet", "value": 180 }
+      ]
+    },
+    "9150": {
+      "name": "Signet of Judgment",
+      "passive": "-10% incoming damage, -10% incoming condition damage",
+      "facts": [
+        { "type": "Number", "text": "Signet of Judgment", "value": -10 }
       ]
     },
     "9151": {
       "name": "Signet of Wrath",
+      "passive": "+180 Condition Damage",
       "facts": [
-        { "type": "Number", "text": "Condition Damage", "value": 180 }
+        { "type": "Number", "text": "Signet of Wrath", "value": 180 }
       ]
+    },
+    "9158": {
+      "name": "Signet of Resolve",
+      "passive": "condition removal every few seconds",
+      "facts": []
     },
     "9163": {
       "name": "Signet of Mercy",
+      "passive": "+180 Concentration",
       "facts": [
-        { "type": "Number", "text": "Concentration", "value": 180 }
-      ]
-    },
-    "14404": {
-      "name": "Signet of Might",
-      "facts": [
-        { "type": "Number", "text": "Power", "value": 180 }
-      ]
-    },
-    "14410": {
-      "name": "Signet of Fury",
-      "facts": [
-        { "type": "Number", "text": "Precision", "value": 180 }
-      ]
-    },
-    "12500": {
-      "name": "Signet of Stone",
-      "facts": [
-        { "type": "Number", "text": "Toughness", "value": 180 }
-      ]
-    },
-    "12491": {
-      "name": "Signet of the Wild",
-      "facts": [
-        { "type": "Number", "text": "Ferocity", "value": 180 }
-      ]
-    },
-    "13046": {
-      "name": "Assassin's Signet",
-      "facts": [
-        { "type": "Number", "text": "Power", "value": 180 }
-      ]
-    },
-    "13062": {
-      "name": "Signet of Agility",
-      "facts": [
-        { "type": "Number", "text": "Precision", "value": 180 }
-      ]
-    },
-    "5542": {
-      "name": "Signet of Fire",
-      "facts": [
-        { "type": "Number", "text": "Precision", "value": 180 }
+        { "type": "Number", "text": "Signet of Mercy", "value": 180 }
       ]
     },
     "10232": {
       "name": "Signet of Domination",
+      "passive": "+180 Condition Damage",
       "facts": [
-        { "type": "Number", "text": "Condition Damage", "value": 180 }
+        { "type": "Number", "text": "Signet of Domination", "value": 180 }
       ]
     },
     "10234": {
       "name": "Signet of Midnight",
+      "passive": "+180 Expertise",
       "facts": [
-        { "type": "Number", "text": "Expertise", "value": 180 }
+        { "type": "Number", "text": "Signet of Midnight", "value": 180 }
       ]
+    },
+    "10236": {
+      "name": "Signet of Inspiration",
+      "passive": "random boon every 10 seconds",
+      "facts": []
+    },
+    "10247": {
+      "name": "Signet of Illusions",
+      "passive": "creates clone every few seconds",
+      "facts": []
+    },
+    "10562": {
+      "name": "Plague Signet",
+      "passive": "-10% incoming condition damage",
+      "facts": [
+        { "type": "Number", "text": "Plague Signet", "value": -10 }
+      ]
+    },
+    "10611": {
+      "name": "Signet of Undeath",
+      "passive": "life force generation",
+      "facts": []
+    },
+    "10612": {
+      "name": "Signet of the Locust",
+      "passive": "25% movement speed",
+      "facts": []
     },
     "10622": {
       "name": "Signet of Spite",
+      "passive": "+180 Power",
       "facts": [
-        { "type": "Number", "text": "Power", "value": 180 }
+        { "type": "Number", "text": "Signet of Spite", "value": 180 }
+      ]
+    },
+    "12491": {
+      "name": "Signet of the Wild",
+      "passive": "+180 Ferocity",
+      "facts": [
+        { "type": "Number", "text": "Signet of the Wild", "value": 180 }
+      ]
+    },
+    "12500": {
+      "name": "Signet of Stone",
+      "passive": "+180 Toughness",
+      "facts": [
+        { "type": "Number", "text": "Signet of Stone", "value": 180 }
+      ]
+    },
+    "12502": {
+      "name": "Signet of Renewal",
+      "passive": "heal per second",
+      "facts": []
+    },
+    "12542": {
+      "name": "Signet of the Hunt",
+      "passive": "25% movement speed",
+      "facts": []
+    },
+    "13046": {
+      "name": "Assassin's Signet",
+      "passive": "+180 Power",
+      "facts": [
+        { "type": "Number", "text": "Assassin's Signet", "value": 180 }
+      ]
+    },
+    "13050": {
+      "name": "Signet of Malice",
+      "passive": "heal on hit",
+      "facts": []
+    },
+    "13060": {
+      "name": "Signet of Shadows",
+      "passive": "25% movement speed",
+      "facts": []
+    },
+    "13062": {
+      "name": "Signet of Agility",
+      "passive": "+180 Precision",
+      "facts": [
+        { "type": "Number", "text": "Signet of Agility", "value": 180 }
+      ]
+    },
+    "13064": {
+      "name": "Infiltrator's Signet",
+      "passive": "initiative every 10 seconds",
+      "facts": []
+    },
+    "14355": {
+      "name": "Signet of Rage",
+      "passive": "adrenaline generation",
+      "facts": []
+    },
+    "14389": {
+      "name": "Healing Signet",
+      "passive": "heal per second",
+      "facts": []
+    },
+    "14404": {
+      "name": "Signet of Might",
+      "passive": "+180 Power",
+      "facts": [
+        { "type": "Number", "text": "Signet of Might", "value": 180 }
+      ]
+    },
+    "14410": {
+      "name": "Signet of Fury",
+      "passive": "+180 Precision",
+      "facts": [
+        { "type": "Number", "text": "Signet of Fury", "value": 180 }
+      ]
+    },
+    "14413": {
+      "name": "Dolyak Signet",
+      "passive": "-10% incoming damage",
+      "facts": [
+        { "type": "Number", "text": "Dolyak Signet", "value": -10 }
+      ]
+    },
+    "14479": {
+      "name": "Signet of Stamina",
+      "passive": "faster endurance regeneration",
+      "facts": []
+    },
+    "21750": {
+      "name": "Signet of the Ether",
+      "passive": "heal on illusion summon",
+      "facts": []
+    },
+    "21762": {
+      "name": "Signet of Vampirism",
+      "passive": "health steal",
+      "facts": []
+    },
+    "29519": {
+      "name": "Signet of Humility",
+      "passive": "-20% stun/daze/fear/taunt duration",
+      "facts": [
+        { "type": "Number", "text": "Signet of Humility", "value": -20 }
+      ]
+    },
+    "30461": {
+      "name": "Signet of Courage",
+      "passive": "periodic heal to allies",
+      "facts": []
+    },
+    "63049": {
+      "name": "Rectifier Signet",
+      "passive": "heal per second",
+      "facts": []
+    },
+    "63095": {
+      "name": "Overclock Signet",
+      "passive": "-20% signet recharge",
+      "facts": [
+        { "type": "Number", "text": "Overclock Signet", "value": -20 }
+      ]
+    },
+    "63111": {
+      "name": "Shift Signet",
+      "passive": "movement speed increase",
+      "facts": []
+    },
+    "63113": {
+      "name": "Superconducting Signet",
+      "passive": "+10% condition damage dealt",
+      "facts": [
+        { "type": "Number", "text": "Superconducting Signet", "value": 10 }
+      ]
+    },
+    "63253": {
+      "name": "Force Signet",
+      "passive": "+15% strike damage dealt",
+      "facts": [
+        { "type": "Number", "text": "Force Signet", "value": 15 }
+      ]
+    },
+    "63262": {
+      "name": "Barrier Signet",
+      "passive": "-10% incoming damage, -10% incoming condition damage",
+      "facts": [
+        { "type": "Number", "text": "Barrier Signet", "value": -10 }
       ]
     }
   }

--- a/src/main/gw2Data/signetPassives.json
+++ b/src/main/gw2Data/signetPassives.json
@@ -4,7 +4,9 @@
     "5503": {
       "name": "Signet of Restoration",
       "passive": "heal per spell cast",
-      "facts": []
+      "facts": [
+        { "type": "Number", "text": "Healing per Cast", "value": 171 }
+      ]
     },
     "5542": {
       "name": "Signet of Fire",
@@ -30,7 +32,9 @@
     "5572": {
       "name": "Signet of Air",
       "passive": "25% movement speed",
-      "facts": []
+      "facts": [
+        { "type": "Number", "text": "Signet of Air", "value": 25 }
+      ]
     },
     "9093": {
       "name": "Bane Signet",
@@ -55,12 +59,15 @@
     },
     "9158": {
       "name": "Signet of Resolve",
-      "passive": "condition removal every few seconds",
-      "facts": []
+      "passive": "condition removal every 5s",
+      "facts": [
+        { "type": "Number", "text": "Passive Conditions Removed", "value": 1 },
+        { "type": "Number", "text": "Interval", "value": 5 }
+      ]
     },
     "9163": {
       "name": "Signet of Mercy",
-      "passive": "+180 Concentration",
+      "passive": "+180 Concentration (120 in WvW)",
       "facts": [
         { "type": "Number", "text": "Signet of Mercy", "value": 180 }
       ]
@@ -86,8 +93,10 @@
     },
     "10247": {
       "name": "Signet of Illusions",
-      "passive": "creates clone every few seconds",
-      "facts": []
+      "passive": "creates clone every 10 seconds",
+      "facts": [
+        { "type": "Number", "text": "Interval", "value": 10 }
+      ]
     },
     "10562": {
       "name": "Plague Signet",
@@ -98,13 +107,17 @@
     },
     "10611": {
       "name": "Signet of Undeath",
-      "passive": "life force generation",
-      "facts": []
+      "passive": "4% life force per 3 seconds",
+      "facts": [
+        { "type": "Percent", "text": "Life Force per 3 Seconds", "percent": 4 }
+      ]
     },
     "10612": {
       "name": "Signet of the Locust",
       "passive": "25% movement speed",
-      "facts": []
+      "facts": [
+        { "type": "Number", "text": "Signet of the Locust", "value": 25 }
+      ]
     },
     "10622": {
       "name": "Signet of Spite",
@@ -129,13 +142,17 @@
     },
     "12502": {
       "name": "Signet of Renewal",
-      "passive": "heal per second",
-      "facts": []
+      "passive": "heal per second (you and pet)",
+      "facts": [
+        { "type": "Number", "text": "Signet of Renewal", "value": 62 }
+      ]
     },
     "12542": {
       "name": "Signet of the Hunt",
       "passive": "25% movement speed",
-      "facts": []
+      "facts": [
+        { "type": "Number", "text": "Signet of the Hunt", "value": 25 }
+      ]
     },
     "13046": {
       "name": "Assassin's Signet",
@@ -168,13 +185,17 @@
     },
     "14355": {
       "name": "Signet of Rage",
-      "passive": "adrenaline generation",
-      "facts": []
+      "passive": "adrenaline every 3 seconds",
+      "facts": [
+        { "type": "Number", "text": "Interval", "value": 3 }
+      ]
     },
     "14389": {
       "name": "Healing Signet",
-      "passive": "heal per second",
-      "facts": []
+      "passive": "344 heal per second",
+      "facts": [
+        { "type": "Number", "text": "Healing Signet", "value": 344 }
+      ]
     },
     "14404": {
       "name": "Signet of Might",
@@ -199,13 +220,17 @@
     },
     "14479": {
       "name": "Signet of Stamina",
-      "passive": "faster endurance regeneration",
-      "facts": []
+      "passive": "50% endurance regeneration",
+      "facts": [
+        { "type": "Percent", "text": "Signet of Stamina", "percent": 50 }
+      ]
     },
     "21750": {
       "name": "Signet of the Ether",
       "passive": "heal on illusion summon",
-      "facts": []
+      "facts": [
+        { "type": "Number", "text": "Heal on Illusion Summon", "value": 297 }
+      ]
     },
     "21762": {
       "name": "Signet of Vampirism",
@@ -222,12 +247,17 @@
     "30461": {
       "name": "Signet of Courage",
       "passive": "periodic heal to allies",
-      "facts": []
+      "facts": [
+        { "type": "Number", "text": "Passive Heal", "value": 202 },
+        { "type": "Number", "text": "Passive Radius", "value": 300 }
+      ]
     },
     "63049": {
       "name": "Rectifier Signet",
-      "passive": "heal per second",
-      "facts": []
+      "passive": "230 heal per second",
+      "facts": [
+        { "type": "Number", "text": "Heal Pulse", "value": 230 }
+      ]
     },
     "63095": {
       "name": "Overclock Signet",
@@ -238,8 +268,10 @@
     },
     "63111": {
       "name": "Shift Signet",
-      "passive": "movement speed increase",
-      "facts": []
+      "passive": "25% movement speed",
+      "facts": [
+        { "type": "Percent", "text": "Movement Speed Increase", "percent": 25 }
+      ]
     },
     "63113": {
       "name": "Superconducting Signet",
@@ -250,7 +282,7 @@
     },
     "63253": {
       "name": "Force Signet",
-      "passive": "+15% strike damage dealt",
+      "passive": "+15% strike damage dealt (10% WvW)",
       "facts": [
         { "type": "Number", "text": "Force Signet", "value": 15 }
       ]

--- a/src/main/gw2Data/signetPassives.json
+++ b/src/main/gw2Data/signetPassives.json
@@ -1,0 +1,83 @@
+{
+  "updatedAt": "2026-04-06T00:00:00.000Z",
+  "signets": {
+    "9093": {
+      "name": "Bane Signet",
+      "facts": [
+        { "type": "Number", "text": "Power", "value": 180 }
+      ]
+    },
+    "9151": {
+      "name": "Signet of Wrath",
+      "facts": [
+        { "type": "Number", "text": "Condition Damage", "value": 180 }
+      ]
+    },
+    "9163": {
+      "name": "Signet of Mercy",
+      "facts": [
+        { "type": "Number", "text": "Concentration", "value": 180 }
+      ]
+    },
+    "14404": {
+      "name": "Signet of Might",
+      "facts": [
+        { "type": "Number", "text": "Power", "value": 180 }
+      ]
+    },
+    "14410": {
+      "name": "Signet of Fury",
+      "facts": [
+        { "type": "Number", "text": "Precision", "value": 180 }
+      ]
+    },
+    "12500": {
+      "name": "Signet of Stone",
+      "facts": [
+        { "type": "Number", "text": "Toughness", "value": 180 }
+      ]
+    },
+    "12491": {
+      "name": "Signet of the Wild",
+      "facts": [
+        { "type": "Number", "text": "Ferocity", "value": 180 }
+      ]
+    },
+    "13046": {
+      "name": "Assassin's Signet",
+      "facts": [
+        { "type": "Number", "text": "Power", "value": 180 }
+      ]
+    },
+    "13062": {
+      "name": "Signet of Agility",
+      "facts": [
+        { "type": "Number", "text": "Precision", "value": 180 }
+      ]
+    },
+    "5542": {
+      "name": "Signet of Fire",
+      "facts": [
+        { "type": "Number", "text": "Precision", "value": 180 }
+      ]
+    },
+    "10232": {
+      "name": "Signet of Domination",
+      "facts": [
+        { "type": "Number", "text": "Condition Damage", "value": 180 }
+      ]
+    },
+    "10234": {
+      "name": "Signet of Midnight",
+      "facts": [
+        { "type": "Number", "text": "Expertise", "value": 180 }
+      ]
+    },
+    "10622": {
+      "name": "Signet of Spite",
+      "facts": [
+        { "type": "Number", "text": "Power", "value": 180 }
+      ]
+    }
+  }
+}

--- a/src/renderer/modules/constants.js
+++ b/src/renderer/modules/constants.js
@@ -569,6 +569,32 @@ export const STACKING_SIGIL_DEFS = [
 ];
 export const STACKING_SIGIL_IDS = new Set(STACKING_SIGIL_DEFS.map((d) => d.id));
 
+// Signet passive attribute buffs — the GW2 API does not expose these values,
+// so they are maintained as a static map.  Key = skill ID, value = { stat, value }.
+// Source: https://wiki.guildwars2.com/wiki/Signet (PvE values, all 180 as of 2025-06).
+export const SIGNET_PASSIVE_BUFFS = new Map([
+  // Guardian
+  [9093,  { stat: "Power",          value: 180 }], // Bane Signet
+  [9151,  { stat: "ConditionDamage", value: 180 }], // Signet of Wrath
+  [9163,  { stat: "Concentration",  value: 180 }], // Signet of Mercy
+  // Warrior
+  [14404, { stat: "Power",          value: 180 }], // Signet of Might
+  [14410, { stat: "Precision",      value: 180 }], // Signet of Fury
+  // Ranger
+  [12500, { stat: "Toughness",      value: 180 }], // Signet of Stone
+  [12491, { stat: "Ferocity",       value: 180 }], // Signet of the Wild
+  // Thief
+  [13046, { stat: "Power",          value: 180 }], // Assassin's Signet
+  [13062, { stat: "Precision",      value: 180 }], // Signet of Agility
+  // Elementalist
+  [5542,  { stat: "Precision",      value: 180 }], // Signet of Fire
+  // Mesmer
+  [10232, { stat: "ConditionDamage", value: 180 }], // Signet of Domination
+  [10234, { stat: "Expertise",      value: 180 }], // Signet of Midnight
+  // Necromancer
+  [10622, { stat: "Power",          value: 180 }], // Signet of Spite
+]);
+
 export const BOON_NAMES = new Set([
   "Aegis", "Alacrity", "Fury", "Might", "Protection", "Quickness",
   "Regeneration", "Resistance", "Resolution", "Stability", "Swiftness", "Vigor",

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -3,7 +3,7 @@ import { state } from "./state.js";
 import {
   STAT_COMBOS_BY_LABEL, SLOT_WEIGHTS, TWO_HAND_WEIGHTS, LAND_ONLY_SLOTS, AQUATIC_SLOTS,
   MIGHT_POWER_PER_STACK, MIGHT_CONDI_PER_STACK, STACKING_SIGIL_DEFS, getEffectiveStats,
-  GW2_WEAPONS_BY_ID,
+  GW2_WEAPONS_BY_ID, SIGNET_PASSIVE_BUFFS,
 } from "./constants.js";
 
 /**
@@ -429,6 +429,23 @@ export function computeEquipmentStats(assumedBoons = null, sigilStacks = null) {
         totals[def.stat] = (totals[def.stat] || 0) + stacks * def.perStack;
       }
       // modifier-only sigils (e.g. Benevolence) don't affect flat attributes
+    }
+  }
+
+  // Signet passive attribute buff contributions
+  const skillSource = isUnderwater ? state.editor.underwaterSkills : state.editor.skills;
+  if (skillSource && state.activeCatalog?.skillById) {
+    const ids = [
+      skillSource.healId,
+      ...(skillSource.utilityIds || []),
+      skillSource.eliteId,
+    ];
+    for (const id of ids) {
+      if (!id) continue;
+      const buff = SIGNET_PASSIVE_BUFFS.get(Number(id));
+      if (buff && totals[buff.stat] !== undefined) {
+        totals[buff.stat] += buff.value;
+      }
     }
   }
 

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -714,3 +714,144 @@ describe("FURY_CRIT_CHANCE constants", () => {
     expect(FURY_CRIT_CHANCE_WVW).toBeLessThan(FURY_CRIT_CHANCE);
   });
 });
+
+// ---------------------------------------------------------------------------
+// computeEquipmentStats — signet passive buff contributions (issue #155)
+// ---------------------------------------------------------------------------
+
+describe("computeEquipmentStats — signet passive buffs", () => {
+  // Signet of Might (14404) grants +180 Power passively
+  const mockCatalog = {
+    skillById: new Map([
+      [14404, { id: 14404, name: "Signet of Might", categories: ["Signet"], facts: [] }],
+      [14410, { id: 14410, name: "Signet of Fury", categories: ["Signet"], facts: [] }],
+      [9093, { id: 9093, name: "Bane Signet", categories: ["Signet"], facts: [] }],
+      [12491, { id: 12491, name: "Signet of the Wild", categories: ["Signet"], facts: [] }],
+      [10622, { id: 10622, name: "Signet of Spite", categories: ["Signet"], facts: [] }],
+      [10232, { id: 10232, name: "Signet of Domination", categories: ["Signet"], facts: [] }],
+      [10234, { id: 10234, name: "Signet of Midnight", categories: ["Signet"], facts: [] }],
+      [5542, { id: 5542, name: "Signet of Fire", categories: ["Signet"], facts: [] }],
+      [13046, { id: 13046, name: "Assassin's Signet", categories: ["Signet"], facts: [] }],
+      [13062, { id: 13062, name: "Signet of Agility", categories: ["Signet"], facts: [] }],
+      [12500, { id: 12500, name: "Signet of Stone", categories: ["Signet"], facts: [] }],
+      [9151, { id: 9151, name: "Signet of Wrath", categories: ["Signet"], facts: [] }],
+      [9163, { id: 9163, name: "Signet of Mercy", categories: ["Signet"], facts: [] }],
+      // Non-signet utility for negative test
+      [14354, { id: 14354, name: "Bull's Charge", categories: [], facts: [] }],
+    ]),
+    traitById: new Map(),
+    specializationById: new Map(),
+  };
+
+  beforeEach(() => {
+    state.activeCatalog = mockCatalog;
+  });
+  afterEach(() => {
+    state.activeCatalog = null;
+  });
+
+  test("Signet of Might in utility slot adds +180 Power", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [14404, 0, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000 + 180);
+  });
+
+  test("Signet of Fury in utility slot adds +180 Precision", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [14410, 0, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.Precision).toBe(1000 + 180);
+  });
+
+  test("multiple signets stack their passive buffs", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [14404, 14410, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000 + 180);
+    expect(result.Precision).toBe(1000 + 180);
+  });
+
+  test("signet passive buffs stack with equipment stats", () => {
+    state.editor = makeEditor({ chest: "Berserker's" });
+    state.editor.skills = { healId: 0, utilityIds: [14404, 0, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000 + 141 + 180);
+  });
+
+  test("non-signet utility skill does not add passive stats", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [14354, 0, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000);
+  });
+
+  test("empty skill slots add nothing", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000);
+  });
+
+  test("heal and elite signets also contribute passive buffs", () => {
+    state.editor = makeEditor({});
+    // Use Bane Signet as heal slot (for test purposes) and Signet of Spite as elite
+    state.editor.skills = { healId: 9093, utilityIds: [0, 0, 0], eliteId: 10622 };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000 + 180 + 180);
+  });
+
+  test("Signet of the Wild adds +180 Ferocity", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [12491, 0, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.Ferocity).toBe(180);
+  });
+
+  test("Signet of Domination adds +180 ConditionDamage", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [10232, 0, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.ConditionDamage).toBe(180);
+  });
+
+  test("Signet of Midnight adds +180 Expertise", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [10234, 0, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.Expertise).toBe(180);
+  });
+
+  test("Signet of Stone adds +180 Toughness", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [12500, 0, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.Toughness).toBe(1000 + 180);
+  });
+
+  test("Signet of Mercy adds +180 Concentration", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [9163, 0, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.Concentration).toBe(180);
+  });
+
+  test("underwater mode uses underwaterSkills for signet passives", () => {
+    state.editor = {
+      ...makeEditor({}),
+      underwaterMode: true,
+      underwaterSkills: { healId: 0, utilityIds: [14404, 0, 0], eliteId: 0 },
+      skills: { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 },
+    };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000 + 180);
+  });
+
+  test("missing activeCatalog does not throw", () => {
+    state.activeCatalog = null;
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [14404, 0, 0], eliteId: 0 };
+    const result = computeEquipmentStats();
+    expect(result.Power).toBe(1000);
+  });
+});

--- a/tests/wiki-audit/crawl-signet.js
+++ b/tests/wiki-audit/crawl-signet.js
@@ -1,0 +1,106 @@
+"use strict";
+
+/**
+ * crawl-signet.js — Extract signet passive attribute facts from wiki pages.
+ *
+ * Signet passives are rendered in the blockquote as a self-named buff row:
+ *   [icon] Signet of Might: 180 Power
+ *
+ * This crawler navigates to the skill page and extracts just the passive
+ * attribute fact (the row whose link text matches the skill name), ignoring
+ * active-skill facts like Recharge, Might stacks, etc.
+ */
+
+const { WIKI_BASE } = require("./crawl");
+
+const PAGE_TIMEOUT = 10_000;
+const RETRY_DELAY = 2_000;
+
+const SELECTORS = {
+  factRow: "blockquote dl > dd",
+  noArticle: ".mw-newarticletext",
+};
+
+/**
+ * Browser-context function: extract the self-named passive buff fact row.
+ * Returns an array of { name, valueText, titleAttr } (0 or 1 entries).
+ */
+function _extractPassiveFactBrowser(dds, skillName) {
+  const results = [];
+  const target = skillName.toLowerCase();
+
+  for (const dd of dds) {
+    // Skip hidden rows (gamemode toggling)
+    const style = window.getComputedStyle(dd);
+    if (style.display === "none") continue;
+
+    const links = dd.querySelectorAll("a[title]");
+    let name = "";
+    let titleAttr = "";
+    for (const a of links) {
+      const text = (a.textContent || "").trim();
+      if (text) { name = text; titleAttr = a.getAttribute("title") || ""; break; }
+    }
+    if (!name) continue;
+
+    // The passive buff row links to the effect page, e.g. "Signet of Might"
+    // or "Signet of Might (effect)". Match by checking if the name or title
+    // contains the skill name.
+    const nameLower = name.toLowerCase();
+    const titleLower = titleAttr.toLowerCase();
+    if (nameLower !== target && !titleLower.includes(target)) continue;
+
+    const fullText = (dd.textContent || "").trim();
+    const nameIdx = fullText.indexOf(name);
+    let valueText = "";
+    if (nameIdx >= 0) {
+      valueText = fullText.slice(nameIdx + name.length).replace(/^\s*[:;]\s*/, "").trim();
+    }
+
+    // The passive fact value looks like "180 Power" — a number followed by a stat name.
+    // Skip rows that don't have a numeric value (e.g. pure text descriptions).
+    if (/^\d/.test(valueText)) {
+      results.push({ name, valueText, titleAttr });
+    }
+  }
+  return results;
+}
+
+async function _crawlSignetOnce(page, entity) {
+  const pageName = entity.name.replace(/ /g, "_");
+  const url = WIKI_BASE + encodeURI(pageName);
+
+  try {
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: PAGE_TIMEOUT });
+  } catch (err) {
+    return { facts: [], error: `Navigation failed: ${err.message}`, wiki_url: url };
+  }
+
+  const missing = await page.$(SELECTORS.noArticle);
+  if (missing) {
+    return { facts: [], error: "Wiki page not found", wiki_url: url };
+  }
+
+  const finalUrl = page.url();
+
+  try {
+    const facts = await page.$$eval(
+      SELECTORS.factRow,
+      _extractPassiveFactBrowser,
+      entity.name,
+    );
+    return { facts, error: null, wiki_url: finalUrl };
+  } catch (err) {
+    return { facts: [], error: err.message, wiki_url: finalUrl };
+  }
+}
+
+async function crawlEntity(page, entity, _entityType) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const result = await _crawlSignetOnce(page, entity);
+    if (!result.error || attempt === 1) return result;
+    await new Promise((r) => setTimeout(r, RETRY_DELAY));
+  }
+}
+
+module.exports = { crawlEntity };

--- a/tests/wiki-audit/run-audit.js
+++ b/tests/wiki-audit/run-audit.js
@@ -15,6 +15,7 @@ const path = require("path");
 const fs = require("fs/promises");
 const { crawlEntity } = require("./crawl");
 const { crawlEntity: crawlRelic } = require("./crawl-relic");
+const { crawlEntity: crawlSignet } = require("./crawl-signet");
 const { compareEntity, compareRelicFacts } = require("./compare");
 const { parseFactText } = require("./parse-facts");
 const { IncrementalReport, writeReport } = require("./report");
@@ -36,7 +37,7 @@ function parseArgs() {
   }
   const typeArg = args.find(a => a.startsWith("--type"));
   const typeVal = typeArg ? (typeArg.includes("=") ? typeArg.split("=")[1] : args[args.indexOf(typeArg) + 1]) : null;
-  const VALID_TYPES = new Set(["skills", "traits", "relics"]);
+  const VALID_TYPES = new Set(["skills", "traits", "relics", "signets"]);
   if (typeVal && !VALID_TYPES.has(typeVal)) {
     console.error(`Invalid --type: ${typeVal}. Must be one of: skills, traits, relics`);
     process.exit(1);
@@ -72,9 +73,9 @@ async function fetchByIds(endpoint, ids) {
  * Each worker gets its own browser context + page, pulls entities
  * from a shared queue, and pushes results to shared arrays.
  */
-async function crawlWithWorkers(browser, entities, splitsIndex, relicFactsData, workerCount, incremental, display) {
+async function crawlWithWorkers(browser, entities, splitsIndex, relicFactsData, signetPassivesData, workerCount, incremental, display) {
   const summary = {
-    skills_checked: 0, traits_checked: 0, relics_checked: 0, total_checked: 0,
+    skills_checked: 0, traits_checked: 0, relics_checked: 0, signets_checked: 0, total_checked: 0,
     matches: 0, mismatches: 0, missing_from_splits: 0,
     missing_from_wiki: 0, no_split: 0, errors: 0,
   };
@@ -102,12 +103,15 @@ async function crawlWithWorkers(browser, entities, splitsIndex, relicFactsData, 
       // Crawl
       const crawlResult = entityType === "relic"
         ? await crawlRelic(page, entity, entityType)
+        : entityType === "signet"
+        ? await crawlSignet(page, entity, entityType)
         : await crawlEntity(page, entity, entityType);
 
       // Process result (synchronized via single-threaded JS)
       if (entityType === "skill") summary.skills_checked++;
       else if (entityType === "trait") summary.traits_checked++;
       else if (entityType === "relic") summary.relics_checked++;
+      else if (entityType === "signet") summary.signets_checked++;
       summary.total_checked++;
 
       if (crawlResult.error) {
@@ -122,6 +126,48 @@ async function crawlWithWorkers(browser, entities, splitsIndex, relicFactsData, 
         display.addRecent("!", "\x1b[90m", "ERROR", `${entity.name} — ${crawlResult.error.slice(0, 50)}`);
       } else if (entityType === "relic") {
         const storedEntry = relicFactsData.relics[String(entity.id)];
+        const wikiFacts = crawlResult.facts
+          .map((f) => parseFactText(f.name, f.valueText, f.titleAttr))
+          .filter(Boolean);
+        const cmp = compareRelicFacts(wikiFacts, storedEntry?.facts || null);
+
+        switch (cmp.category) {
+          case "match": summary.matches++; break;
+          case "mismatch": summary.mismatches++; break;
+          case "missing_from_splits": summary.missing_from_splits++; break;
+          case "no_split": summary.no_split++; break;
+        }
+
+        display.addCompleted(cmp.category === "match" ? "matches"
+          : cmp.category === "no_split" ? "no_split"
+          : cmp.category === "mismatch" ? "mismatches"
+          : cmp.category === "missing_from_splits" ? "missing_from_splits"
+          : "errors");
+
+        if (cmp.category !== "match" && cmp.category !== "no_split") {
+          const record = {
+            entity_type: entityType,
+            id: entity.id,
+            name: entity.name,
+            wiki_url: crawlResult.wiki_url || `https://wiki.guildwars2.com/wiki/${entity.name.replace(/ /g, "_")}`,
+            category: cmp.category,
+            wiki_wvw_facts: wikiFacts,
+            splits_wvw_facts: storedEntry?.facts || [],
+          };
+          if (cmp.fact_diffs.length) record.fact_diffs = cmp.fact_diffs;
+          if (cmp.wiki_only_facts.length) record.wiki_only_facts = cmp.wiki_only_facts;
+          if (cmp.splits_only_facts.length) record.splits_only_facts = cmp.splits_only_facts;
+          discrepancies.push(record);
+          incremental.writeDiscrepancy(record);
+          const tag = `${entity.name} (${entityType} #${entity.id})`;
+          if (cmp.category === "mismatch") {
+            display.addRecent("\u2717", "\x1b[31m", "MISMATCH", tag);
+          } else if (cmp.category === "missing_from_splits") {
+            display.addRecent("\u25cc", "\x1b[33m", "MISSING(S)", tag);
+          }
+        }
+      } else if (entityType === "signet") {
+        const storedEntry = signetPassivesData.signets[String(entity.id)];
         const wikiFacts = crawlResult.facts
           .map((f) => parseFactText(f.name, f.valueText, f.titleAttr))
           .filter(Boolean);
@@ -274,6 +320,17 @@ async function main() {
     console.log(`${relicEntities.length} relics`);
   }
 
+  let signetEntities = [];
+  if (!typeVal || typeVal === "signets") {
+    const signetPassivesData = require("../../src/main/gw2Data/signetPassives.json");
+    signetEntities = Object.entries(signetPassivesData.signets).map(([id, data]) => ({
+      id: parseInt(id, 10),
+      name: data.name,
+      type: "signet",
+    }));
+    console.log(`${signetEntities.length} signet passives`);
+  }
+
   // 2. Load splits.json
   const splitsRaw = JSON.parse(await fs.readFile(SPLITS_PATH, "utf-8"));
   const splitsIndex = {
@@ -287,8 +344,11 @@ async function main() {
   // 2b. Load relicFacts.json
   const relicFactsData = require("../../src/main/gw2Data/relicFacts.json");
 
+  // 2c. Load signetPassives.json
+  const signetPassivesData = require("../../src/main/gw2Data/signetPassives.json");
+
   // 3. Build entity list with skip/limit
-  const allEntities = [...skillEntities, ...traitEntities, ...relicEntities];
+  const allEntities = [...skillEntities, ...traitEntities, ...relicEntities, ...signetEntities];
   const entities = allEntities.slice(skip, skip + limit);
   console.log(`Crawling ${entities.length} entities (skip=${skip}, limit=${limit === Infinity ? "all" : limit}, workers=${workers})\n`);
 
@@ -301,7 +361,7 @@ async function main() {
   display.start();
 
   // 5. Crawl and compare with worker pool
-  const { summary, discrepancies, errors } = await crawlWithWorkers(browser, entities, splitsIndex, relicFactsData, workers, incremental, display);
+  const { summary, discrepancies, errors } = await crawlWithWorkers(browser, entities, splitsIndex, relicFactsData, signetPassivesData, workers, incremental, display);
 
   display.stop();
   console.log("");
@@ -323,7 +383,7 @@ async function main() {
   // 8. Print summary
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   console.log("── Summary ──");
-  console.log(`  Checked:             ${summary.total_checked}`);
+  console.log(`  Checked:             ${summary.total_checked} (${summary.skills_checked} skills, ${summary.traits_checked} traits, ${summary.relics_checked} relics, ${summary.signets_checked} signets)`);
   console.log(`  Matches:             ${summary.matches}`);
   console.log(`  Mismatches:          ${summary.mismatches}`);
   console.log(`  Missing from splits: ${summary.missing_from_splits}`);


### PR DESCRIPTION
## Summary
Signet passive attribute buffs (e.g. Signet of Might's +180 Power) were not being included in the stat calculation pipeline. The GW2 API does not expose these passive stat values in skill facts, so a static `SIGNET_PASSIVE_BUFFS` map was added to `constants.js` covering all 13 signets across all professions that grant flat attribute bonuses. The stat computation in `computeEquipmentStats()` now reads equipped skills (heal, utility, elite) and applies any matching signet passive buffs before trait conversions.

Covers: Guardian (Bane Signet, Signet of Wrath, Signet of Mercy), Warrior (Signet of Might, Signet of Fury), Ranger (Signet of Stone, Signet of the Wild), Thief (Assassin's Signet, Signet of Agility), Elementalist (Signet of Fire), Mesmer (Signet of Domination, Signet of Midnight), Necromancer (Signet of Spite).

Closes #155