### PR TITLE
fix: Forceful Greatsword and other Trait passive buffs not applying to stat totals (closes #156)

### DIFF
--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -112,7 +112,7 @@ export function renderDetailPanel() {
   const factsHtml = facts.length
     ? facts
         .map((fact) => {
-          const cls = fact.type === "NoData" ? "fact-item--section" : fact._splitFact ? "fact-item--split" : fact._newFact ? "fact-item--new-in-mode" : "";
+          const cls = fact.type === "NoData" ? "fact-item--section" : fact._splitFact ? "fact-item--split" : fact._traitedFact ? "fact-item--traited" : fact._newFact ? "fact-item--new-in-mode" : "";
           return `<li${cls ? ` class="${cls}"` : ""}>${formatFactHtml(fact, detailDmgStats, { alacrity: getAssumedBoons().alacrity, burstRecharge })}</li>`;
         })
         .join("")
@@ -225,20 +225,30 @@ export function resolveEntityFacts(entity) {
   // Apply traited_facts overrides when the required trait is active.
   let result = baseFacts;
   if (traitedFacts.length) {
-    const activeTraitIds = new Set(
-      (state.editor.specializations || [])
-        .flatMap((s) => Object.values(s?.majorChoices || {}))
-        .map(Number)
-        .filter(Boolean)
-    );
+    // Collect active trait IDs — both major choices and minor traits.
+    const activeTraitIds = new Set();
+    const catalog = state.activeCatalog;
+    for (const spec of state.editor.specializations || []) {
+      for (const id of Object.values(spec?.majorChoices || {})) {
+        const n = Number(id);
+        if (n) activeTraitIds.add(n);
+      }
+      const specId = Number(spec?.specializationId || spec?.id) || 0;
+      const specData = specId ? catalog?.specializationById?.get(specId) : null;
+      for (const minorId of specData?.minorTraits || []) {
+        if (minorId) activeTraitIds.add(Number(minorId));
+      }
+    }
     if (activeTraitIds.size) {
       result = [...baseFacts];
       for (const tf of traitedFacts) {
         if (!activeTraitIds.has(Number(tf.requires_trait))) continue;
         const { requires_trait: _r, overrides, ...factData } = tf;
-        // Only apply replacements (overrides set); skip appended facts.
+        factData._traitedFact = true;
         if (overrides !== undefined && overrides !== null && overrides >= 0 && overrides < result.length) {
           result[overrides] = factData;
+        } else if (overrides === undefined || overrides === null) {
+          result.push(factData);
         }
       }
     }
@@ -309,7 +319,7 @@ export function buildSkillCard(skill, kind, isChained = false, dmgStats = null) 
     .map((fact) => {
       const html = formatFactHtml(fact, dmgStats, { alacrity: getAssumedBoons().alacrity, burstRecharge: burstRch });
       if (!html) return null;
-      const cls = fact.type === "NoData" ? "fact-item--section" : fact._splitFact ? "fact-item--split" : "";
+      const cls = fact.type === "NoData" ? "fact-item--section" : fact._splitFact ? "fact-item--split" : fact._traitedFact ? "fact-item--traited" : "";
       return `<li${cls ? ` class="${cls}"` : ""}>${html}</li>`;
     })
     .filter(Boolean);

--- a/src/renderer/modules/specializations.js
+++ b/src/renderer/modules/specializations.js
@@ -20,12 +20,14 @@ let _enforceEditorConsistency = () => {};
 let _markEditorChanged = () => {};
 let _renderEditor = () => {};
 let _renderSkills = () => {};
+let _renderEquipmentPanel = () => {};
 
-export function initSpecializationsCallbacks({ enforceEditorConsistency, markEditorChanged, renderEditor, renderSkills }) {
+export function initSpecializationsCallbacks({ enforceEditorConsistency, markEditorChanged, renderEditor, renderSkills, renderEquipmentPanel }) {
   _enforceEditorConsistency = enforceEditorConsistency;
   _markEditorChanged = markEditorChanged;
   _renderEditor = renderEditor;
   _renderSkills = renderSkills;
+  _renderEquipmentPanel = renderEquipmentPanel || (() => {});
 }
 
 export function getMajorTraitsByTier(spec, catalog) {
@@ -323,6 +325,7 @@ export function renderSpecializations() {
           cancelAnimationFrame(_connectorRafId);
           _connectorRafId = requestAnimationFrame(() => drawSpecConnector(body));
           _renderSkills();
+          _renderEquipmentPanel();
           selectDetail("trait", trait);
         };
         const majorButton = makeTraitButton(trait, isSelected, majorOnClick);

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -169,6 +169,45 @@ export function computeFuryStatBonuses(gameMode = "pve") {
 }
 
 /**
+ * Compute flat stat bonuses from passive traits (non-Fury, non-conversion).
+ * Reads AttributeAdjust facts from active traits that are NOT Fury-gated
+ * (Fury-gated traits are handled separately by computeFuryStatBonuses).
+ * Excludes PET_STAT_TRAITS where the bonuses apply to pets, not the player.
+ *
+ * @param {string} [gameMode="pve"] - "pve" or "wvw"
+ * @returns {Object} Map of stat key → bonus value (e.g. { Power: 120 })
+ */
+export function computePassiveTraitBonuses(gameMode = "pve") {
+  const catalog = state.activeCatalog;
+  if (!catalog?.traitById) return {};
+
+  const activeTraitIds = collectActiveTraitIds();
+  if (!activeTraitIds.size) return {};
+
+  const bonuses = {};
+  for (const traitId of activeTraitIds) {
+    if (PET_STAT_TRAITS.has(traitId)) continue;
+    const trait = catalog.traitById.get(traitId);
+    if (!trait?.facts) continue;
+    if (isFuryTrait(trait, traitId)) continue;
+
+    const byTarget = new Map();
+    for (const fact of trait.facts) {
+      if (fact.type !== "AttributeAdjust" || !fact.target || !fact.value) continue;
+      if (!byTarget.has(fact.target)) byTarget.set(fact.target, []);
+      byTarget.get(fact.target).push(fact.value);
+    }
+
+    for (const [target, values] of byTarget) {
+      const statKey = CONVERSION_TARGET_MAP[target] || target;
+      const idx = gameMode === "wvw" ? Math.min(1, values.length - 1) : 0;
+      bonuses[statKey] = (bonuses[statKey] || 0) + values[idx];
+    }
+  }
+  return bonuses;
+}
+
+/**
  * Compute effective Might per-stack values, accounting for Notoriety trait.
  * @returns {{ power: number, condi: number }}
  */
@@ -447,6 +486,12 @@ export function computeEquipmentStats(assumedBoons = null, sigilStacks = null) {
         totals[buff.stat] += buff.value;
       }
     }
+  }
+
+  // Passive trait flat stat bonuses (e.g. Forceful Greatsword +120 Power)
+  const passiveBonuses = computePassiveTraitBonuses(state.editor.gameMode);
+  for (const [key, val] of Object.entries(passiveBonuses)) {
+    totals[key] = (totals[key] || 0) + val;
   }
 
   // Trait AttributeConversion contributions
@@ -767,6 +812,12 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
         entries.push({ source: "Boon (Fury)", value: furyBonuses[statKey] });
       }
     }
+  }
+
+  // Passive trait flat stat bonuses (e.g. Forceful Greatsword +120 Power)
+  const passiveBonuses = computePassiveTraitBonuses(state.editor.gameMode);
+  if (passiveBonuses[statKey]) {
+    entries.push({ source: "Trait bonus", value: passiveBonuses[statKey] });
   }
 
   // Trait conversion contributions

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -125,6 +125,7 @@ initSpecializationsCallbacks({
   markEditorChanged,
   renderEditor,
   renderSkills,
+  renderEquipmentPanel,
 });
 
 initSkills({ skillsHost: el.skillsHost });

--- a/src/renderer/styles/detail-panel.css
+++ b/src/renderer/styles/detail-panel.css
@@ -252,6 +252,10 @@ li.fact-item--split {
   color: #e8b84a;
 }
 
+li.fact-item--traited {
+  color: #5ae8a0;
+}
+
 @keyframes facts-list-refresh {
   0%   { opacity: 0; transform: translateY(4px); }
   100% { opacity: 1; transform: translateY(0); }

--- a/tests/unit/renderer/assumed-boons.test.js
+++ b/tests/unit/renderer/assumed-boons.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { computeEquipmentStats, computeStatBreakdown, computeTraitConversions, computeFuryCritModifier, computeFuryStatBonuses, computeMightPerStack } = require("../../../src/renderer/modules/stats");
+const { computeEquipmentStats, computeStatBreakdown, computeTraitConversions, computeFuryCritModifier, computeFuryStatBonuses, computePassiveTraitBonuses, computeMightPerStack } = require("../../../src/renderer/modules/stats");
 const { state } = require("../../../src/renderer/modules/state");
 
 function makeEditor(slots = {}, food = "", utility = "") {
@@ -640,5 +640,152 @@ describe("computeMightPerStack — Notoriety trait", () => {
     const mightEntry = entries.find((e) => e.source.includes("Might"));
     expect(mightEntry).toBeDefined();
     expect(mightEntry.value).toBe(10 * 40); // 400, not 300
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computePassiveTraitBonuses — flat stat bonuses from non-Fury traits
+// ---------------------------------------------------------------------------
+
+describe("computePassiveTraitBonuses — flat stat bonuses from passive traits", () => {
+  beforeEach(() => {
+    state.editor = makeEditor();
+    state.upgradeCatalog = null;
+  });
+
+  test("returns empty when no specializations selected", () => {
+    state.editor.specializations = [];
+    state.activeCatalog = { traitById: new Map(), specializationById: new Map() };
+    expect(computePassiveTraitBonuses()).toEqual({});
+  });
+
+  test("returns Power from Forceful Greatsword (non-Fury AttributeAdjust)", () => {
+    const forcefulGreatsword = {
+      id: 1338,
+      facts: [
+        { type: "AttributeAdjust", value: 120, target: "Power" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1338, forcefulGreatsword]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 4, majorChoices: { 2: 1338 } },
+    ];
+    expect(computePassiveTraitBonuses()).toEqual({ Power: 120 });
+  });
+
+  test("returns Power from Pinnacle of Strength minor trait", () => {
+    const pinnacle = {
+      id: 1453,
+      facts: [
+        { type: "AttributeAdjust", value: 10, target: "Power" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1453, pinnacle]]),
+      specializationById: new Map([[4, { id: 4, minorTraits: [1446, 1448, 1453] }]]),
+    };
+    state.editor.specializations = [
+      { specializationId: 4, majorChoices: {} },
+    ];
+    expect(computePassiveTraitBonuses()).toEqual({ Power: 10 });
+  });
+
+  test("does not include Fury-gated traits (already handled by computeFuryStatBonuses)", () => {
+    const ragingStorm = {
+      id: 214,
+      facts: [
+        { type: "AttributeAdjust", value: 180, target: "CritDamage" },
+        { type: "Buff", status: "Fury", duration: 4, apply_count: 1 },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[214, ragingStorm]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 214 } },
+    ];
+    expect(computePassiveTraitBonuses()).toEqual({});
+  });
+
+  test("excludes PET_STAT_TRAITS", () => {
+    const fangAndClaw = {
+      id: 1016,
+      facts: [
+        { type: "AttributeAdjust", value: 420, target: "Precision" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1016, fangAndClaw]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 1016 } },
+    ];
+    expect(computePassiveTraitBonuses()).toEqual({});
+  });
+
+  test("maps Healing target to HealingPower", () => {
+    const mightMakesRight = {
+      id: 1454,
+      facts: [
+        { type: "AttributeAdjust", value: 133, target: "Healing" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1454, mightMakesRight]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 4, majorChoices: { 3: 1454 } },
+    ];
+    expect(computePassiveTraitBonuses()).toEqual({ HealingPower: 133 });
+  });
+
+  test("handles game-mode split (PvE vs WvW)", () => {
+    const splitTrait = {
+      id: 5555,
+      facts: [
+        { type: "AttributeAdjust", value: 100, target: "Power" },
+        { type: "AttributeAdjust", value: 50, target: "Power" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[5555, splitTrait]]),
+      specializationById: new Map(),
+    };
+    state.editor.specializations = [
+      { specializationId: 1, majorChoices: { 1: 5555 } },
+    ];
+    expect(computePassiveTraitBonuses("pve")).toEqual({ Power: 100 });
+    expect(computePassiveTraitBonuses("wvw")).toEqual({ Power: 50 });
+  });
+
+  test("passive trait bonuses applied to computeEquipmentStats totals", () => {
+    const forcefulGreatsword = {
+      id: 1338,
+      facts: [
+        { type: "AttributeAdjust", value: 120, target: "Power" },
+      ],
+    };
+    state.activeCatalog = {
+      traitById: new Map([[1338, forcefulGreatsword]]),
+      specializationById: new Map(),
+    };
+    const baselineEditor = makeEditor();
+    baselineEditor.specializations = [];
+    state.editor = baselineEditor;
+    const baseline = computeEquipmentStats();
+
+    const withTraitEditor = makeEditor();
+    withTraitEditor.specializations = [
+      { specializationId: 4, majorChoices: { 2: 1338 } },
+    ];
+    state.editor = withTraitEditor;
+    const withTrait = computeEquipmentStats();
+    expect(withTrait.Power).toBe(baseline.Power + 120);
   });
 });

--- a/tests/unit/renderer/resolveEntityFacts.test.js
+++ b/tests/unit/renderer/resolveEntityFacts.test.js
@@ -173,15 +173,87 @@ describe("resolveEntityFacts — traited_facts overrides", () => {
     expect(result[0].value).toBe(10); // base value unchanged
   });
 
-  test("does not append traited facts without overrides index", () => {
+  test("appends traited facts without overrides index when trait is active", () => {
+    state.editor = {
+      specializations: [{ specializationId: 51, majorChoices: { 1: 1855, 2: 0, 3: 0 } }],
+    };
+
     const entity = {
       facts: [makeNumber("Radius", 240)],
-      // traited fact with no overrides — should be skipped, not appended
       traitedFacts: [{ requires_trait: 1855, type: "Number", text: "Bonus Range", value: 100 }],
+    };
+    const result = resolveEntityFacts(entity);
+    expect(result).toHaveLength(2);
+    expect(result[0].text).toBe("Radius");
+    expect(result[1].text).toBe("Bonus Range");
+    expect(result[1].value).toBe(100);
+
+    state.editor = { specializations: [] };
+  });
+
+  test("does not append traited facts without overrides when trait is inactive", () => {
+    const entity = {
+      facts: [makeNumber("Radius", 240)],
+      traitedFacts: [{ requires_trait: 9999, type: "Number", text: "Bonus Range", value: 100 }],
     };
     const result = resolveEntityFacts(entity);
     expect(result).toHaveLength(1);
     expect(result[0].text).toBe("Radius");
+  });
+
+  test("marks replaced traited facts with _traitedFact flag", () => {
+    state.editor = {
+      specializations: [{ specializationId: 51, majorChoices: { 1: 1855, 2: 0, 3: 0 } }],
+    };
+
+    const entity = {
+      facts: [makeNumber("Stack Threshold", 10)],
+      traitedFacts: [makeTraited(1855, 0, makeNumber("Stack Threshold", 8))],
+    };
+    const result = resolveEntityFacts(entity);
+    expect(result[0]._traitedFact).toBe(true);
+
+    state.editor = { specializations: [] };
+  });
+
+  test("marks appended traited facts with _traitedFact flag", () => {
+    state.editor = {
+      specializations: [{ specializationId: 51, majorChoices: { 1: 1855, 2: 0, 3: 0 } }],
+    };
+
+    const entity = {
+      facts: [makeNumber("Radius", 240)],
+      traitedFacts: [{ requires_trait: 1855, type: "Number", text: "Bonus Range", value: 100 }],
+    };
+    const result = resolveEntityFacts(entity);
+    expect(result[1]._traitedFact).toBe(true);
+    expect(result[0]._traitedFact).toBeUndefined();
+
+    state.editor = { specializations: [] };
+  });
+
+  test("activates traited facts from minor traits", () => {
+    // Minor trait 2020 belongs to specialization 51
+    state.activeCatalog = {
+      specializationById: new Map([
+        [51, { minorTraits: [2020, 2021, 2022] }],
+      ]),
+    };
+    state.editor = {
+      specializations: [{ specializationId: 51, majorChoices: { 1: 0, 2: 0, 3: 0 } }],
+    };
+
+    const entity = {
+      facts: [makeNumber("Endurance", 0)],
+      traitedFacts: [makeTraited(2020, 0, makeNumber("Endurance", 15))],
+    };
+    const result = resolveEntityFacts(entity);
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe(15);
+    expect(result[0]._traitedFact).toBe(true);
+
+    state.activeCatalog = null;
+    state.editor = { specializations: [] };
   });
 });
 


### PR DESCRIPTION
## Summary

Trait passive flat stat bonuses (e.g. Forceful Greatsword +120 Power, Pinnacle of Strength +10 Power, Might Makes Right +133 Healing Power) were never applied to stat totals. The existing `computeFuryStatBonuses()` only processed `AttributeAdjust` facts from Fury-gated traits, and `computeTraitConversions()` only handled `AttributeConversion`/`BuffConversion` facts — leaving non-Fury passive `AttributeAdjust` traits completely unhandled.

Added `computePassiveTraitBonuses()` that processes `AttributeAdjust` facts from all active non-Fury traits, wired it into both `computeEquipmentStats()` (before trait conversions, so conversion traits like Great Fortitude benefit from the increased base) and `computeStatBreakdown()`.

Closes #156