### PR TITLE
fix: Infusion Calculations (closes #167)

### DIFF
--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -156,7 +156,7 @@ function computePublishStats(equipment, upgradeCatalog, profession, gameMode) {
 
   // Infusion/enrichment stat contributions (via infix_upgrade.attributes)
   if (upgradeCatalog) {
-    const toStatKey = (attr) => attr === "Healing" ? "HealingPower" : attr === "ConditionDamage" ? "ConditionDamage" : attr;
+    const toStatKey = (attr) => attr === "Healing" ? "HealingPower" : attr === "BoonDuration" ? "Concentration" : attr === "ConditionDuration" ? "Expertise" : attr;
     const addInfixAttributes = (infixUpgrade) => {
       if (!infixUpgrade?.attributes) return;
       for (const attr of infixUpgrade.attributes) {

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -338,8 +338,8 @@ export function computeEquipmentStats(assumedBoons = null, sigilStacks = null) {
     // Helper: resolve API attribute name to our stat key
     const toStatKey = (attr) =>
       attr === "Healing" ? "HealingPower"
-      : attr === "ConditionDamage" ? "ConditionDamage"
-      : attr === "HealingPower" ? "HealingPower"
+      : attr === "BoonDuration" ? "Concentration"
+      : attr === "ConditionDuration" ? "Expertise"
       : attr;
 
     // Helper: add infix_upgrade.attributes to totals
@@ -705,7 +705,7 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
 
   // Infusions
   if (upgradeCatalog) {
-    const toStatKey = (attr) => attr === "Healing" ? "HealingPower" : attr;
+    const toStatKey = (attr) => attr === "Healing" ? "HealingPower" : attr === "BoonDuration" ? "Concentration" : attr === "ConditionDuration" ? "Expertise" : attr;
     const infusions = state.editor.equipment?.infusions || {};
     const allInfusions = Object.entries(infusions)
       .filter(([k]) => !EXCLUDED_SLOTS.has(k))

--- a/tests/unit/statsCompute.test.js
+++ b/tests/unit/statsCompute.test.js
@@ -305,6 +305,93 @@ describe("computePublishStats", () => {
     expect(result.stats.Power).toBe(1000 + 125);
   });
 
+  // ── Infusion calculations (issue #167) ───────────────────────────────
+
+  test("Concentration infusion (BoonDuration attribute) adds to Concentration", () => {
+    const equipment = {
+      slots: {},
+      runes: {},
+      infusions: { head: "86986" }, // Concentration WvW Infusion
+    };
+    const upgradeCatalog = {
+      runeById: new Map(),
+      infusionById: new Map([[86986, {
+        id: 86986, name: "Concentration WvW Infusion",
+        infixUpgrade: { attributes: [{ attribute: "BoonDuration", modifier: 5 }] },
+      }]]),
+      enrichmentById: new Map(),
+      foodById: new Map(),
+      utilityById: new Map(),
+    };
+    const result = computePublishStats(equipment, upgradeCatalog, "Guardian");
+    expect(result.stats.Concentration).toBe(5);
+  });
+
+  test("Expertise infusion (ConditionDuration attribute) adds to Expertise", () => {
+    const equipment = {
+      slots: {},
+      runes: {},
+      infusions: { head: "87218" }, // Expertise WvW Infusion
+    };
+    const upgradeCatalog = {
+      runeById: new Map(),
+      infusionById: new Map([[87218, {
+        id: 87218, name: "Expertise WvW Infusion",
+        infixUpgrade: { attributes: [{ attribute: "ConditionDuration", modifier: 5 }] },
+      }]]),
+      enrichmentById: new Map(),
+      foodById: new Map(),
+      utilityById: new Map(),
+    };
+    const result = computePublishStats(equipment, upgradeCatalog, "Guardian");
+    expect(result.stats.Expertise).toBe(5);
+  });
+
+  test("multiple infusions across slots sum correctly", () => {
+    const equipment = {
+      slots: {},
+      runes: {},
+      infusions: {
+        head: "86986",
+        shoulders: "86986",
+        ring1: ["86986", "86986", "86986"],
+      },
+    };
+    const upgradeCatalog = {
+      runeById: new Map(),
+      infusionById: new Map([[86986, {
+        id: 86986, name: "Concentration WvW Infusion",
+        infixUpgrade: { attributes: [{ attribute: "BoonDuration", modifier: 5 }] },
+      }]]),
+      enrichmentById: new Map(),
+      foodById: new Map(),
+      utilityById: new Map(),
+    };
+    const result = computePublishStats(equipment, upgradeCatalog, "Guardian");
+    // 2 single-slot + 3 in ring1 array = 5 infusions × 5 = 25
+    expect(result.stats.Concentration).toBe(25);
+  });
+
+  test("Power infusion adds to Power (standard attribute name)", () => {
+    const equipment = {
+      slots: {},
+      runes: {},
+      infusions: { head: "39336" },
+    };
+    const upgradeCatalog = {
+      runeById: new Map(),
+      infusionById: new Map([[39336, {
+        id: 39336, name: "Mighty Infusion",
+        infixUpgrade: { attributes: [{ attribute: "Power", modifier: 5 }] },
+      }]]),
+      enrichmentById: new Map(),
+      foodById: new Map(),
+      utilityById: new Map(),
+    };
+    const result = computePublishStats(equipment, upgradeCatalog, "Guardian");
+    expect(result.stats.Power).toBe(1000 + 5);
+  });
+
   test("food with 'to All Attributes' adds to every stat", () => {
     const equipment = { slots: {}, runes: {}, infusions: {}, food: "91713", utility: "" };
     const upgradeCatalog = {


### PR DESCRIPTION
## Summary

The GW2 API uses `BoonDuration` and `ConditionDuration` as attribute names in `infix_upgrade.attributes` for Concentration and Expertise infusions respectively. The `toStatKey` mapping function in both the renderer (`stats.js`) and publish (`statsCompute.js`) stat computation only handled the `Healing` → `HealingPower` alias, causing all Concentration and Expertise infusions (including WvW infusions and Agony+stat combo infusions) to be silently ignored in attribute calculations.

Added the missing `BoonDuration` → `Concentration` and `ConditionDuration` → `Expertise` mappings to all three `toStatKey` instances (main computation, publish computation, and stat breakdown tooltip).

Closes #167