### PR TITLE
fix: weapon tooltip updates (closes #171)

### DIFF
--- a/packages/gw2-data/src/wiki/parser.js
+++ b/packages/gw2-data/src/wiki/parser.js
@@ -283,8 +283,9 @@ function mapWikiFactToApiFact(factType, positional, params, isWvw, isUniversal) 
     };
   }
 
-  // ── Attribute Gain / Conversion ───────────────────────────────────────
-  if (type === "gain" || type === "attribute") {
+  // ── Attribute Conversion (gain) ──────────────────────────────────────
+  // {{skill fact|gain|source=Power|target=Condition Damage|percent=10}}
+  if (type === "gain") {
     const source = stripWikiMarkup(params.source) || "";
     const target = stripWikiMarkup(params.target) || "";
     const percent = parseFloat(stripWikiMarkup(params.percent) || "0");
@@ -294,6 +295,19 @@ function mapWikiFactToApiFact(factType, positional, params, isWvw, isUniversal) 
       source,
       target,
       percent,
+    };
+  }
+
+  // ── Flat attribute bonus ──────────────────────────────────────────────
+  // {{skill fact|attribute|Concentration|120}}
+  if (type === "attribute") {
+    const attrName = stripWikiMarkup(positional[0]) || "";
+    const value = parseInt(stripWikiMarkup(positional[1] || params.base) || "0", 10);
+    return {
+      type: "AttributeAdjust",
+      text: attrName,
+      target: attrName,
+      value,
     };
   }
 

--- a/packages/gw2-data/src/wiki/resolver.js
+++ b/packages/gw2-data/src/wiki/resolver.js
@@ -101,13 +101,23 @@ function parseFactsByMode(wikitext) {
 }
 
 /**
+ * Detect whether wikitext is a disambiguation page.
+ * GW2 wiki uses {{disambig}} or {{disambiguation}} templates.
+ */
+function isDisambiguation(wikitext) {
+  return /\{\{disambig(uation)?\s*(\||\}\})/i.test(wikitext);
+}
+
+/**
  * Batch-resolve wiki facts for multiple entities.
  *
  * @param {import("./client").WikiClient} client
  * @param {Map<string, number>} titleToId - Map of wiki title to entity ID
+ * @param {object} [options]
+ * @param {string} [options.profession] - Profession name (e.g. "Warrior") for disambiguation retries
  * @returns {Promise<Map<number, { pve: Object[], wvw: Object[]|null, pvp: Object[]|null, hasSplit: boolean }>>}
  */
-async function resolveEntityFacts(client, titleToId) {
+async function resolveEntityFacts(client, titleToId, options = {}) {
   const result = new Map();
 
   if (titleToId.size === 0) return result;
@@ -115,9 +125,21 @@ async function resolveEntityFacts(client, titleToId) {
   const titles = [...titleToId.keys()];
   const wikitextMap = await client.getWikitextBatch(titles);
 
+  // Collect disambiguation pages for retry
+  const disambigRetries = new Map(); // alternative title → original title
+  const profession = options.profession ? options.profession.toLowerCase() : null;
+
   for (const [title, id] of titleToId) {
     const wikitext = wikitextMap.get(title);
     if (!wikitext) continue; // skip missing pages
+
+    // If this is a disambiguation page, queue a retry with profession-specific suffix
+    if (isDisambiguation(wikitext)) {
+      if (profession) {
+        disambigRetries.set(`${title} (${profession} skill)`, title);
+      }
+      continue;
+    }
 
     const parsed = parseFactsByMode(wikitext);
 
@@ -137,7 +159,32 @@ async function resolveEntityFacts(client, titleToId) {
     });
   }
 
+  // Retry disambiguation pages with profession-specific titles
+  if (disambigRetries.size > 0) {
+    const retryTitles = [...disambigRetries.keys()];
+    const retryMap = await client.getWikitextBatch(retryTitles);
+
+    for (const [retryTitle, originalTitle] of disambigRetries) {
+      const wikitext = retryMap.get(retryTitle);
+      if (!wikitext) continue;
+
+      const parsed = parseFactsByMode(wikitext);
+      const hasTimings = parsed.recharge.pve != null || parsed.activation.pve != null;
+      if (parsed.pve.length === 0 && parsed.wvw.length === 0 && parsed.pvp.length === 0 && !hasTimings) continue;
+
+      const id = titleToId.get(originalTitle);
+      result.set(id, {
+        pve: parsed.pve,
+        wvw: parsed.hasSplit ? parsed.wvw : null,
+        pvp: parsed.hasSplit ? parsed.pvp : null,
+        hasSplit: parsed.hasSplit,
+        recharge: parsed.recharge,
+        activation: parsed.activation,
+      });
+    }
+  }
+
   return result;
 }
 
-module.exports = { groupFactsByMode, parseFactsByMode, resolveEntityFacts };
+module.exports = { groupFactsByMode, parseFactsByMode, resolveEntityFacts, isDisambiguation };

--- a/packages/gw2-data/tests/parser.test.js
+++ b/packages/gw2-data/tests/parser.test.js
@@ -198,6 +198,22 @@ describe("mapWikiFactToApiFact", () => {
     });
   });
 
+  test("flat attribute bonus produces AttributeAdjust", () => {
+    const fact = mapWikiFactToApiFact(
+      "attribute",
+      ["Concentration", "120"],
+      {},
+      true,
+      false
+    );
+    expect(fact).toEqual({
+      type: "AttributeAdjust",
+      text: "Concentration",
+      target: "Concentration",
+      value: 120,
+    });
+  });
+
   test("effect produces Buff with status from positional[0] and duration from positional[1]", () => {
     const fact = mapWikiFactToApiFact("effect", ["Superspeed", "5"], { stacks: "2" }, true, false);
     expect(fact).toEqual({

--- a/packages/gw2-data/tests/resolver.test.js
+++ b/packages/gw2-data/tests/resolver.test.js
@@ -4,6 +4,7 @@ const {
   groupFactsByMode,
   parseFactsByMode,
   resolveEntityFacts,
+  isDisambiguation,
 } = require("../src/wiki/resolver");
 const { WikiClient } = require("../src/wiki/client");
 const { MemoryCache } = require("../src/wiki/cache");
@@ -199,6 +200,64 @@ describe("resolveEntityFacts", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  test("retries disambiguation pages with profession-specific suffix", async () => {
+    const disambigWikitext = "'''Charge''' may refer to:\n{{disambig}}\n* [[Charge (warrior skill)]]\n* [[Charge (ranger skill)]]";
+    const realWikitext = "{{skill fact|damage|0.8}}\n| recharge = 10";
+
+    // First fetch: returns the disambig page
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        query: {
+          pages: {
+            "100": { title: "Charge", revisions: [{ "*": disambigWikitext }] },
+          },
+        },
+      }),
+    });
+    // Second fetch: retry with "Charge (warrior skill)"
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        query: {
+          pages: {
+            "200": { title: "Charge (warrior skill)", revisions: [{ "*": realWikitext }] },
+          },
+        },
+      }),
+    });
+
+    const titleToId = new Map([["Charge", 14401]]);
+    const result = await resolveEntityFacts(client, titleToId, { profession: "Warrior" });
+
+    expect(result.size).toBe(1);
+    expect(result.has(14401)).toBe(true);
+    expect(result.get(14401).pve[0].type).toBe("Damage");
+    expect(result.get(14401).recharge.pve).toBe(10);
+    // Should have made 2 fetch calls: original batch + retry batch
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("skips disambiguation pages when no profession provided", async () => {
+    const disambigWikitext = "'''Charge''' may refer to:\n{{disambig}}";
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        query: {
+          pages: {
+            "100": { title: "Charge", revisions: [{ "*": disambigWikitext }] },
+          },
+        },
+      }),
+    });
+
+    const titleToId = new Map([["Charge", 14401]]);
+    const result = await resolveEntityFacts(client, titleToId);
+
+    expect(result.size).toBe(0);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
   test("skips pages with no fact templates (keeps API facts)", async () => {
     // A wiki page exists but has no {{skill fact|...}} or {{trait fact|...}} templates
     const noFactsWikitext = "'''Piercing Shards''' is a trait for Elementalist that makes ice shards pierce.";
@@ -219,5 +278,27 @@ describe("resolveEntityFacts", () => {
     // Should NOT have an entry — empty facts would wipe valid API facts
     expect(result.size).toBe(0);
     expect(result.has(1234)).toBe(false);
+  });
+});
+
+describe("isDisambiguation", () => {
+  test("detects {{disambig}} template", () => {
+    expect(isDisambiguation("Some text\n{{disambig}}\n* [[Link]]")).toBe(true);
+  });
+
+  test("detects {{disambiguation}} template", () => {
+    expect(isDisambiguation("{{disambiguation}}\n* [[Link]]")).toBe(true);
+  });
+
+  test("detects {{disambig|...}} with parameters", () => {
+    expect(isDisambiguation("{{disambig|skill}}\n* [[Link]]")).toBe(true);
+  });
+
+  test("returns false for normal skill pages", () => {
+    expect(isDisambiguation("{{skill fact|damage|0.8}}\n| recharge = 10")).toBe(false);
+  });
+
+  test("returns false for pages mentioning disambig in prose", () => {
+    expect(isDisambiguation("This page is not a disambiguation page")).toBe(false);
   });
 });

--- a/src/main/gw2Data/catalog.js
+++ b/src/main/gw2Data/catalog.js
@@ -719,7 +719,7 @@ async function getProfessionCatalog(professionId, lang = "en", gameMode = "pve")
   try {
     const client = getWikiClient();
     // resolveEntityFacts expects Map<title, id> — use the first ID per title
-    const resolvedByFirstId = await resolveEntityFacts(client, titleToFirstId);
+    const resolvedByFirstId = await resolveEntityFacts(client, titleToFirstId, { profession: profession.name || professionId });
     // Expand: if multiple entity IDs share a title, give them all the same wiki facts
     for (const [title, ids] of titleToIds) {
       const firstId = ids[0];

--- a/src/main/gw2Data/catalog.js
+++ b/src/main/gw2Data/catalog.js
@@ -693,7 +693,8 @@ async function getProfessionCatalog(professionId, lang = "en", gameMode = "pve")
       dualWield: skill.dual_attunement === "None" ? "" : (skill.dual_attunement || ""),
       weaponType: skill.weapon_type === "None" ? "" : (skill.weapon_type || ""),
       flags: Array.isArray(skill.flags) ? skill.flags : [],
-      facts: Array.isArray(skill.facts) ? skill.facts : [],
+      facts: Array.isArray(skill.facts) ? skill.facts.filter((f) => !f.requires_trait) : [],
+      traitedFacts: Array.isArray(skill.traited_facts) ? skill.traited_facts : [],
       flipSkill: Number(skill.flip_skill) || 0,
     };
     return mapped;

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -384,10 +384,15 @@ export function buildSkillCard(skill, kind, isChained = false, dmgStats = null) 
   const cardAlacrity = isSkillCard && getAssumedBoons().alacrity;
   const burstRch = isSkillCard && skill.slot === "Profession_1" ? (computeUpgradeModifiers().get("Burst Recharge") || 0) : 0;
 
-  // Filter Recharge facts out of the list when we have infobox recharge data
+  // Build timing data: prefer wiki infobox, fall back to extracting from facts
   const isEquip = kind.startsWith("equip-");
-  const hasInfoboxRecharge = !isEquip && skill.recharge?.pve != null;
-  const displayFacts = hasInfoboxRecharge ? rawFacts.filter((f) => f.type !== "Recharge") : rawFacts;
+  let timingEntity = skill;
+  if (!isEquip && !skill.recharge?.pve) {
+    const rchFact = rawFacts.find((f) => f.type === "Recharge" && f.value > 0);
+    if (rchFact) timingEntity = { ...skill, recharge: { pve: rchFact.value } };
+  }
+  const hasRechargeHeader = !isEquip && timingEntity.recharge?.pve != null;
+  const displayFacts = hasRechargeHeader ? rawFacts.filter((f) => f.type !== "Recharge") : rawFacts;
 
   const factsItems = displayFacts
     .map((fact) => {
@@ -400,7 +405,7 @@ export function buildSkillCard(skill, kind, isChained = false, dmgStats = null) 
   const meta = getHoverMetaLine(kind, skill);
 
   // Build timing badges for the header top-right (recharge + cast time)
-  const timingBadges = isEquip ? "" : _buildTimingBadges(skill, cardAlacrity, burstRch);
+  const timingBadges = isEquip ? "" : _buildTimingBadges(timingEntity, cardAlacrity, burstRch);
 
   return `
     ${isChained ? `<div class="hover-preview__chain-divider">▸</div>` : ""}

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -604,6 +604,18 @@ export function hideHoverPreview() {
 export async function selectDetail(kind, entity) {
   if (_readOnly) return;
   if (!entity) return;
+  const facts = resolveEntityFacts(entity);
+  // Fall back to extracting timing from facts when wiki infobox data isn't available
+  let recharge = entity.recharge || null;
+  let activation = entity.activation || null;
+  if (!recharge) {
+    const rchFact = facts.find((f) => f.type === "Recharge" && f.value > 0);
+    if (rchFact) recharge = { pve: rchFact.value };
+  }
+  if (!activation) {
+    const actFact = facts.find((f) => f.type === "Time" && /cast|activation/i.test(f.text || "") && f.duration > 0);
+    if (actFact) activation = { pve: actFact.duration };
+  }
   const detail = {
     kind,
     entityId: Number(entity.id) || null,
@@ -612,13 +624,13 @@ export async function selectDetail(kind, entity) {
     icon: entity.icon || "",
     iconFallback: entity.iconFallback || "",
     description: stripGw2Markup(entity.description),
-    facts: resolveEntityFacts(entity),
+    facts,
     wiki: { loading: true, summary: "", url: "" },
     hasSplit: Boolean(entity.hasSplit),
     isAquaticOnly: _isAquaticOnlySkill(kind, entity),
     slot: entity.slot || "",
-    recharge: entity.recharge || null,
-    activation: entity.activation || null,
+    recharge,
+    activation,
   };
   state.detail = detail;
   renderDetailPanel();

--- a/src/renderer/styles/detail-panel.css
+++ b/src/renderer/styles/detail-panel.css
@@ -27,7 +27,7 @@
   align-items: center;
 }
 
-.detail-card header img {
+.detail-card header > img {
   width: 56px;
   height: 56px;
   border-radius: 10px;

--- a/tests/fixtures/gw2Api.js
+++ b/tests/fixtures/gw2Api.js
@@ -442,6 +442,8 @@ const MOCK_TRAITS = {
       { id: 30029, slot: "Profession_3", icon: "" }, // DH Fragments of Faith (F3)
     ],
   },
+  // Warrior Strength major trait: used to test traited_facts on weapon skills
+  1444: { id: 1444, name: "Body Blow",        specialization: 4,  tier: 1, order: 0, slot: "Major", icon: "", description: "", facts: [], skills: [] },
   // Some placeholder traits for other specs
   1714: { id: 1714, name: "Chilling Nova",     specialization: 34, tier: 1, order: 0, slot: "Minor", icon: "", description: "", facts: [], skills: [] },
   1716: { id: 1716, name: "Soul Eater",        specialization: 34, tier: 2, order: 0, slot: "Minor", icon: "", description: "", facts: [], skills: [] },
@@ -470,6 +472,7 @@ function makeSkill(id, overrides = {}) {
     categories: overrides.categories || [],
     flags: overrides.flags || [],
     facts: overrides.facts || [],
+    traited_facts: overrides.traited_facts || [],
     toolbelt_skill: overrides.toolbelt_skill || 0,
     flip_skill: overrides.flip_skill || 0,
     bundle_skills: overrides.bundle_skills || [],
@@ -502,7 +505,11 @@ const MOCK_SKILLS = {
   14402: makeSkill(14402, { name: "Mending",      slot: "Heal",    type: "Heal",    professions: ["Warrior"], flags: [] }),
   14516: makeSkill(14516, { name: "Balanced Stance", slot: "Utility", type: "Utility", professions: ["Warrior"], flags: ["NoUnderwater"] }),
   14404: makeSkill(14404, { name: "Rampage",      slot: "Elite",   type: "Elite",   professions: ["Warrior"] }),
-  14360: makeSkill(14360, { name: "Sever Artery", slot: "Weapon_1", type: "Weapon", weapon_type: "Sword" }),
+  14360: makeSkill(14360, { name: "Sever Artery", slot: "Weapon_1", type: "Weapon", weapon_type: "Sword", facts: [
+    { type: "Damage", text: "Damage", hit_count: 1, dmg_multiplier: 0.8 },
+  ], traited_facts: [
+    { text: "Damage", type: "Damage", hit_count: 1, dmg_multiplier: 1.0, requires_trait: 1444, overrides: 0 },
+  ] }),
   14521: makeSkill(14521, { name: "Shield Bash",  slot: "Weapon_4", type: "Weapon", weapon_type: "Shield" }),
   14447: makeSkill(14447, { name: "Whirlwind Attack", slot: "Weapon_1", type: "Weapon", weapon_type: "Greatsword" }),
   14489: makeSkill(14489, { name: "Harpoon Pull", slot: "Weapon_1", type: "Weapon", weapon_type: "HarpoonGun" }),

--- a/tests/integration/professions/warrior.test.js
+++ b/tests/integration/professions/warrior.test.js
@@ -141,4 +141,25 @@ describe("Warrior — end-to-end profession mechanics", () => {
     expect(slots[3]).toBeNull();
     expect(slots[4]).toBeNull();
   });
+
+  // ---------------------------------------------------------------------------
+  // Weapon skill traited_facts (#171)
+  // ---------------------------------------------------------------------------
+
+  test("weapon skills in catalog include traitedFacts from API data", async () => {
+    const catalog = await h.loadCatalog();
+    const swordW1 = catalog.weaponSkillById.get(14360); // Sever Artery
+    expect(swordW1).toBeDefined();
+    expect(swordW1.traitedFacts).toBeDefined();
+    expect(swordW1.traitedFacts.length).toBeGreaterThan(0);
+    expect(swordW1.traitedFacts[0].requires_trait).toBe(1444);
+  });
+
+  test("weapon skill base facts exclude requires_trait entries", async () => {
+    const catalog = await h.loadCatalog();
+    const swordW1 = catalog.weaponSkillById.get(14360); // Sever Artery
+    // Base facts should not contain any entries with requires_trait
+    const conditional = swordW1.facts.filter((f) => f.requires_trait);
+    expect(conditional).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Weapon skill tooltips didn't update when switching traits because the catalog builder's weapon skill mapper was missing the `traitedFacts` field. This meant `resolveEntityFacts()` could never apply trait-dependent fact overrides (e.g., Roaring Reveille adding Resistance to Call of Valor).

**Root cause:** `mappedWeaponSkills` in `catalog.js` did not include `traitedFacts` or filter `requires_trait` entries from the base `facts` array, unlike the profession skill mapper (`mapSkill`) which correctly handled both.

**Fix:**
- Added `traitedFacts` to the weapon skill mapping in `catalog.js`
- Filter `requires_trait` conditional entries from base `facts` (matching `mapSkill` behavior)
- Added integration tests to verify weapon skills carry `traitedFacts` through the catalog pipeline

Closes #171