### PR TITLE
feat: implement wiki shared-name resolution with per-entity title hints

### DIFF
--- a/packages/gw2-data/src/wiki/resolver.js
+++ b/packages/gw2-data/src/wiki/resolver.js
@@ -133,26 +133,38 @@ function extractInfoboxId(wikitext) {
 /**
  * Batch-resolve wiki facts for multiple entities.
  *
+ * Accepts a per-entity title map so that the caller (catalog) can provide
+ * disambiguated wiki titles for entities that share a display name.
+ * Internally deduplicates fetches by title — if multiple IDs point to the
+ * same wiki title, the page is fetched once and the parsed facts are shared.
+ *
  * @param {import("./client").WikiClient} client
- * @param {Map<string, number>} titleToId - Map of wiki title to entity ID
+ * @param {Map<number, string>} idToTitle - Map of entity ID to wiki title
  * @param {object} [options]
  * @param {string} [options.profession] - Profession name (e.g. "Warrior") for disambiguation retries
  * @returns {Promise<Map<number, { pve: Object[], wvw: Object[]|null, pvp: Object[]|null, hasSplit: boolean }>>}
  */
-async function resolveEntityFacts(client, titleToId, options = {}) {
+async function resolveEntityFacts(client, idToTitle, options = {}) {
   const result = new Map();
 
-  if (titleToId.size === 0) return result;
+  if (idToTitle.size === 0) return result;
 
-  const titles = [...titleToId.keys()];
+  // Group by title → id[] for batch fetching (avoids duplicate requests)
+  const titleToIds = new Map();
+  for (const [id, title] of idToTitle) {
+    if (!titleToIds.has(title)) titleToIds.set(title, []);
+    titleToIds.get(title).push(id);
+  }
+
+  const titles = [...titleToIds.keys()];
   const wikitextMap = await client.getWikitextBatch(titles);
 
   // Collect disambiguation pages and name collisions for retry
   const disambigRetries = new Map(); // alternative title → original title
-  const nameCollisionRetries = new Map(); // original title → id (wrong infobox type / wrong ID)
+  const nameCollisionRetries = new Map(); // original title → id[] (wrong infobox type / wrong ID)
   const profession = options.profession ? options.profession.toLowerCase() : null;
 
-  for (const [title, id] of titleToId) {
+  for (const [title, ids] of titleToIds) {
     const wikitext = wikitextMap.get(title);
     if (!wikitext) continue; // skip missing pages
 
@@ -165,8 +177,6 @@ async function resolveEntityFacts(client, titleToId, options = {}) {
     }
 
     // Check if page has a Skill or Trait infobox (right page type).
-    // Don't check the specific ID — multiple entities can share a name,
-    // and titleToFirstId may map to a different entity than the wiki page lists.
     const hasSkillOrTraitInfobox = /\{\{(?:Skill|Trait) infobox\b/i.test(wikitext);
     if (!hasSkillOrTraitInfobox) {
       // Wrong page type (location, weapon, NPC, etc.) or no infobox.
@@ -176,17 +186,18 @@ async function resolveEntityFacts(client, titleToId, options = {}) {
       const hasFacts = parsed.pve.length > 0 || parsed.wvw.length > 0 || parsed.pvp.length > 0 || hasTimings;
       if (hasFacts) {
         // Has facts but no infobox — accept it (existing behavior)
-        result.set(id, {
+        const factEntry = {
           pve: parsed.pve,
           wvw: parsed.hasSplit ? parsed.wvw : null,
           pvp: parsed.hasSplit ? parsed.pvp : null,
           hasSplit: parsed.hasSplit,
           recharge: parsed.recharge,
           activation: parsed.activation,
-        });
+        };
+        for (const id of ids) result.set(id, factEntry);
       } else {
         // No infobox AND no facts — likely a wrong page type, queue retry
-        nameCollisionRetries.set(title, id);
+        nameCollisionRetries.set(title, ids);
       }
       continue;
     }
@@ -200,14 +211,34 @@ async function resolveEntityFacts(client, titleToId, options = {}) {
     // keep API facts instead of replacing them with empty arrays.
     if (parsed.pve.length === 0 && parsed.wvw.length === 0 && parsed.pvp.length === 0 && !hasTimings) continue;
 
-    result.set(id, {
+    const factEntry = {
       pve: parsed.pve,
       wvw: parsed.hasSplit ? parsed.wvw : null,
       pvp: parsed.hasSplit ? parsed.pvp : null,
       hasSplit: parsed.hasSplit,
       recharge: parsed.recharge,
       activation: parsed.activation,
-    });
+    };
+
+    // Apply facts to ALL IDs sharing this title. Many skills have multiple API IDs
+    // that map to a single wiki page (e.g. True Nature per legend, Deploy Jade Sphere
+    // per attunement). Giving all IDs the same facts is correct for these variants.
+    for (const id of ids) result.set(id, factEntry);
+
+    // If the page's infobox ID doesn't cover all requesting IDs, queue the unmatched
+    // ones for prefix search — they might be genuinely different entities (e.g. "Maul"
+    // the ranger greatsword vs "Maul" the pet skill). If prefix search finds a better
+    // page, it overwrites the initially-shared facts.
+    if (ids.length > 1) {
+      const infoboxIds = new Set(extractInfoboxId(wikitext));
+      if (infoboxIds.size > 0) {
+        const unmatched = ids.filter((id) => !infoboxIds.has(id));
+        if (unmatched.length > 0) {
+          const existing = nameCollisionRetries.get(title) || [];
+          nameCollisionRetries.set(title, [...existing, ...unmatched]);
+        }
+      }
+    }
   }
 
   // Retry disambiguation pages with profession-specific titles
@@ -223,19 +254,22 @@ async function resolveEntityFacts(client, titleToId, options = {}) {
       const hasTimings = parsed.recharge.pve != null || parsed.activation.pve != null;
       if (parsed.pve.length === 0 && parsed.wvw.length === 0 && parsed.pvp.length === 0 && !hasTimings) continue;
 
-      const id = titleToId.get(originalTitle);
-      result.set(id, {
+      const ids = titleToIds.get(originalTitle);
+      const factEntry = {
         pve: parsed.pve,
         wvw: parsed.hasSplit ? parsed.wvw : null,
         pvp: parsed.hasSplit ? parsed.pvp : null,
         hasSplit: parsed.hasSplit,
         recharge: parsed.recharge,
         activation: parsed.activation,
-      });
+      };
+      for (const id of ids) result.set(id, factEntry);
     }
   }
 
-  // Retry name collision pages via prefix search for "Name (" variants
+  // Retry name collision pages via prefix search for "Name (" variants.
+  // This handles both wrong-type pages (location instead of skill) and infobox ID
+  // mismatches (page is about a different entity with the same name).
   if (nameCollisionRetries.size > 0) {
     // Prefix-search all colliding titles in parallel to find candidate pages
     const searchPromises = [];
@@ -246,23 +280,22 @@ async function resolveEntityFacts(client, titleToId, options = {}) {
     }
     const searchResults = await Promise.all(searchPromises);
 
-    // Collect all candidate titles for a single batch fetch
+    // Collect all candidate titles for a single batch fetch.
+    // Accept any disambiguated page (not just "skill"/"trait" suffixes) — pet skill
+    // pages use family names like "Maul (porcine)". The infobox type/ID check after
+    // fetching is the real filter.
     const candidateToOriginal = new Map(); // candidate title → original title
     for (const { originalTitle, candidates } of searchResults) {
       for (const candidate of candidates) {
-        // Only consider candidates that look like "Name (... skill)" or "Name (... trait)"
-        // Exclude subpages like "Name (skill)/history"
-        if (candidate.includes("/")) continue;
-        if (/\(.*(?:skill|trait)\)$/i.test(candidate)) {
-          candidateToOriginal.set(candidate, originalTitle);
-        }
+        if (candidate.includes("/")) continue; // exclude subpages
+        candidateToOriginal.set(candidate, originalTitle);
       }
     }
 
     if (candidateToOriginal.size > 0) {
       const candidateWikitext = await client.getWikitextBatch([...candidateToOriginal.keys()]);
 
-      // Group candidates by original title, try each until one has a Skill/Trait infobox with facts
+      // Group candidates by original title
       const candidatesByOriginal = new Map(); // original title → [candidate titles]
       for (const [candidate, original] of candidateToOriginal) {
         if (!candidatesByOriginal.has(original)) candidatesByOriginal.set(original, []);
@@ -270,7 +303,11 @@ async function resolveEntityFacts(client, titleToId, options = {}) {
       }
 
       for (const [originalTitle, candidates] of candidatesByOriginal) {
+        const unresolvedIds = new Set(nameCollisionRetries.get(originalTitle));
+
         for (const candidate of candidates) {
+          if (unresolvedIds.size === 0) break;
+
           const wikitext = candidateWikitext.get(candidate);
           if (!wikitext) continue;
 
@@ -280,16 +317,30 @@ async function resolveEntityFacts(client, titleToId, options = {}) {
           const hasTimings = parsed.recharge.pve != null || parsed.activation.pve != null;
           if (parsed.pve.length === 0 && parsed.wvw.length === 0 && parsed.pvp.length === 0 && !hasTimings) continue;
 
-          const id = nameCollisionRetries.get(originalTitle);
-          result.set(id, {
+          const factEntry = {
             pve: parsed.pve,
             wvw: parsed.hasSplit ? parsed.wvw : null,
             pvp: parsed.hasSplit ? parsed.pvp : null,
             hasSplit: parsed.hasSplit,
             recharge: parsed.recharge,
             activation: parsed.activation,
-          });
-          break; // found a valid candidate for this title
+          };
+
+          // Match candidate to specific requesting IDs by infobox ID
+          const infoboxIds = extractInfoboxId(wikitext);
+          const matched = infoboxIds.filter((id) => unresolvedIds.has(id));
+
+          if (matched.length > 0) {
+            for (const id of matched) {
+              result.set(id, factEntry);
+              unresolvedIds.delete(id);
+            }
+          } else if (infoboxIds.length === 0) {
+            // No infobox IDs extractable — apply to all remaining (legacy fallback)
+            for (const id of unresolvedIds) result.set(id, factEntry);
+            unresolvedIds.clear();
+          }
+          // If infobox IDs exist but don't match any requesting ID, skip this candidate
         }
       }
     }

--- a/packages/gw2-data/tests/resolver.test.js
+++ b/packages/gw2-data/tests/resolver.test.js
@@ -145,12 +145,12 @@ describe("resolveEntityFacts", () => {
       }),
     });
 
-    const titleToId = new Map([
-      ["Fireball", 5489],
-      ["Heal", 5503],
+    const idToTitle = new Map([
+      [5489, "Fireball"],
+      [5503, "Heal"],
     ]);
 
-    const result = await resolveEntityFacts(client, titleToId);
+    const result = await resolveEntityFacts(client, idToTitle);
 
     expect(result.size).toBe(2);
     expect(result.get(5489).pve.length).toBeGreaterThan(0);
@@ -181,12 +181,12 @@ describe("resolveEntityFacts", () => {
       }),
     });
 
-    const titleToId = new Map([
-      ["Fireball", 5489],
-      ["Nonexistent Skill", 9999],
+    const idToTitle = new Map([
+      [5489, "Fireball"],
+      [9999, "Nonexistent Skill"],
     ]);
 
-    const result = await resolveEntityFacts(client, titleToId);
+    const result = await resolveEntityFacts(client, idToTitle);
 
     expect(result.size).toBe(1);
     expect(result.has(5489)).toBe(true);
@@ -194,8 +194,8 @@ describe("resolveEntityFacts", () => {
   });
 
   test("returns empty map for empty input", async () => {
-    const titleToId = new Map();
-    const result = await resolveEntityFacts(client, titleToId);
+    const idToTitle = new Map();
+    const result = await resolveEntityFacts(client, idToTitle);
 
     expect(result.size).toBe(0);
     expect(mockFetch).not.toHaveBeenCalled();
@@ -228,8 +228,8 @@ describe("resolveEntityFacts", () => {
       }),
     });
 
-    const titleToId = new Map([["Charge", 14401]]);
-    const result = await resolveEntityFacts(client, titleToId, { profession: "Warrior" });
+    const idToTitle = new Map([[14401, "Charge"]]);
+    const result = await resolveEntityFacts(client, idToTitle, { profession: "Warrior" });
 
     expect(result.size).toBe(1);
     expect(result.has(14401)).toBe(true);
@@ -252,8 +252,8 @@ describe("resolveEntityFacts", () => {
       }),
     });
 
-    const titleToId = new Map([["Charge", 14401]]);
-    const result = await resolveEntityFacts(client, titleToId);
+    const idToTitle = new Map([[14401, "Charge"]]);
+    const result = await resolveEntityFacts(client, idToTitle);
 
     expect(result.size).toBe(0);
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -300,8 +300,8 @@ describe("resolveEntityFacts", () => {
       }),
     });
 
-    const titleToId = new Map([["Ring of Fire", 5765]]);
-    const result = await resolveEntityFacts(client, titleToId, { profession: "Elementalist" });
+    const idToTitle = new Map([[5765, "Ring of Fire"]]);
+    const result = await resolveEntityFacts(client, idToTitle, { profession: "Elementalist" });
 
     expect(result.size).toBe(1);
     expect(result.has(5765)).toBe(true);
@@ -344,8 +344,8 @@ describe("resolveEntityFacts", () => {
       }),
     });
 
-    const titleToId = new Map([["Zap", 63281]]);
-    const result = await resolveEntityFacts(client, titleToId, { profession: "Elementalist" });
+    const idToTitle = new Map([[63281, "Zap"]]);
+    const result = await resolveEntityFacts(client, idToTitle, { profession: "Elementalist" });
 
     expect(result.size).toBe(1);
     expect(result.has(63281)).toBe(true);
@@ -366,8 +366,8 @@ describe("resolveEntityFacts", () => {
       }),
     });
 
-    const titleToId = new Map([["Fireball", 5489]]);
-    const result = await resolveEntityFacts(client, titleToId, { profession: "Elementalist" });
+    const idToTitle = new Map([[5489, "Fireball"]]);
+    const result = await resolveEntityFacts(client, idToTitle, { profession: "Elementalist" });
 
     expect(result.size).toBe(1);
     expect(result.has(5489)).toBe(true);
@@ -398,8 +398,8 @@ describe("resolveEntityFacts", () => {
       }),
     });
 
-    const titleToId = new Map([["Some Place", 12345]]);
-    const result = await resolveEntityFacts(client, titleToId, { profession: "Warrior" });
+    const idToTitle = new Map([[12345, "Some Place"]]);
+    const result = await resolveEntityFacts(client, idToTitle, { profession: "Warrior" });
 
     expect(result.size).toBe(0);
   });
@@ -440,8 +440,8 @@ describe("resolveEntityFacts", () => {
       }),
     });
 
-    const titleToId = new Map([["Pulmonary Impact", 62710]]);
-    const result = await resolveEntityFacts(client, titleToId, { profession: "Harbinger" });
+    const idToTitle = new Map([[62710, "Pulmonary Impact"]]);
+    const result = await resolveEntityFacts(client, idToTitle, { profession: "Harbinger" });
 
     expect(result.size).toBe(1);
     expect(result.has(62710)).toBe(true);
@@ -483,11 +483,147 @@ describe("resolveEntityFacts", () => {
       }),
     });
 
-    const titleToId = new Map([["Some Skill", 1234]]);
-    const result = await resolveEntityFacts(client, titleToId); // no profession
+    const idToTitle = new Map([[1234, "Some Skill"]]);
+    const result = await resolveEntityFacts(client, idToTitle); // no profession
 
     expect(result.size).toBe(1);
     expect(result.has(1234)).toBe(true);
+  });
+
+  test("resolves different facts for entities with disambiguated titles", async () => {
+    const weaponSkillWikitext = "{{Skill infobox\n| id = 12525\n}}\n{{skill fact|damage|1.5}}\n| recharge = 4";
+    const petSkillWikitext = "{{Skill infobox\n| id = 41406\n}}\n{{skill fact|damage|0.8}}\n| recharge = 10";
+
+    // Both titles fetched in a single batch
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        query: {
+          pages: {
+            "1": { title: "Maul (ranger greatsword skill)", revisions: [{ "*": weaponSkillWikitext }] },
+            "2": { title: "Maul (porcine)", revisions: [{ "*": petSkillWikitext }] },
+          },
+        },
+      }),
+    });
+
+    // Two different IDs, each with their own disambiguated title
+    const idToTitle = new Map([
+      [12525, "Maul (ranger greatsword skill)"],
+      [41406, "Maul (porcine)"],
+    ]);
+
+    const result = await resolveEntityFacts(client, idToTitle, { profession: "Ranger" });
+
+    expect(result.size).toBe(2);
+    // Weapon skill gets its own facts
+    expect(result.get(12525).pve[0].type).toBe("Damage");
+    expect(result.get(12525).recharge.pve).toBe(4);
+    // Pet skill gets different facts
+    expect(result.get(41406).pve[0].type).toBe("Damage");
+    expect(result.get(41406).recharge.pve).toBe(10);
+    // Only one batch fetch needed (both titles in the same request)
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses infobox ID matching to refine facts for colliding names", async () => {
+    // Wiki page "Maul" is about the ranger greatsword skill (id 12525).
+    // A pet skill (id 41406) shares the name "Maul" — it initially gets the same
+    // facts, but the resolver's prefix search finds a better-matched page and
+    // overwrites with the correct facts.
+    const mainPageWikitext = "{{Skill infobox\n| id = 12525\n}}\n{{skill fact|damage|1.5}}\n| recharge = 4";
+    const petPageWikitext = "{{Skill infobox\n| id = 41406\n}}\n{{skill fact|damage|0.8}}\n| recharge = 10";
+
+    // Initial batch: both IDs request "Maul"
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        query: {
+          pages: {
+            "1": { title: "Maul", revisions: [{ "*": mainPageWikitext }] },
+          },
+        },
+      }),
+    });
+
+    // Prefix search for "Maul (" returns candidates
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        query: {
+          prefixsearch: [
+            { title: "Maul (porcine)" },
+            { title: "Maul (ranger greatsword skill)" },
+          ],
+        },
+      }),
+    });
+
+    // Batch fetch of prefix search candidates
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        query: {
+          pages: {
+            "2": { title: "Maul (porcine)", revisions: [{ "*": petPageWikitext }] },
+            "3": { title: "Maul (ranger greatsword skill)", revisions: [{ "*": mainPageWikitext }] },
+          },
+        },
+      }),
+    });
+
+    // Both IDs share the same bare title "Maul"
+    const idToTitle = new Map([
+      [12525, "Maul"],
+      [41406, "Maul"],
+    ]);
+
+    const result = await resolveEntityFacts(client, idToTitle, { profession: "Ranger" });
+
+    expect(result.size).toBe(2);
+    // Weapon skill matched by infobox ID on the main page
+    expect(result.get(12525).recharge.pve).toBe(4);
+    // Pet skill: initially got main page facts, then overwritten by prefix search match
+    expect(result.get(41406).recharge.pve).toBe(10);
+  });
+
+  test("shares facts across variant IDs when page lists matching infobox ID", async () => {
+    // "True Nature" has multiple API IDs (one per legend) but one wiki page.
+    // The wiki lists only one ID in its infobox. All IDs should get the facts,
+    // and unmatched IDs get queued for prefix search (which finds nothing, so
+    // they keep the initially-shared facts).
+    const wikitext = "{{Skill infobox\n| id = 29393\n}}\n{{skill fact|damage|0.5}}\n| recharge = 1";
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        query: {
+          pages: {
+            "1": { title: "True Nature", revisions: [{ "*": wikitext }] },
+          },
+        },
+      }),
+    });
+
+    // Prefix search for unmatched IDs — finds nothing useful
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ query: { prefixsearch: [] } }),
+    });
+
+    const idToTitle = new Map([
+      [29393, "True Nature"],
+      [51675, "True Nature"],
+      [51714, "True Nature"],
+    ]);
+
+    const result = await resolveEntityFacts(client, idToTitle);
+
+    // All 3 IDs should have facts (shared from the one wiki page)
+    expect(result.size).toBe(3);
+    expect(result.get(29393).recharge.pve).toBe(1);
+    expect(result.get(51675).recharge.pve).toBe(1);
+    expect(result.get(51714).recharge.pve).toBe(1);
   });
 
   test("skips pages with no fact templates (keeps API facts)", async () => {
@@ -504,8 +640,8 @@ describe("resolveEntityFacts", () => {
       }),
     });
 
-    const titleToId = new Map([["Piercing Shards", 1234]]);
-    const result = await resolveEntityFacts(client, titleToId);
+    const idToTitle = new Map([[1234, "Piercing Shards"]]);
+    const result = await resolveEntityFacts(client, idToTitle);
 
     // Should NOT have an entry — empty facts would wipe valid API facts
     expect(result.size).toBe(0);

--- a/src/main/gw2Data/catalog.js
+++ b/src/main/gw2Data/catalog.js
@@ -100,6 +100,35 @@ const {
   UNTAMED_UNLEASHED_AMBUSH,
 } = require("./overrides");
 
+// Pet ID → wiki family name for disambiguation of pet skills.
+// The GW2 API does not expose pet family; this is derived from the wiki's naming convention.
+// Unique pets (e.g. Bristleback, Smokescale) are omitted — their skills rarely collide.
+const PET_ID_TO_FAMILY = new Map([
+  // Avian
+  [44, "avian"], [10, "avian"], [32, "avian"], [30, "avian"], [31, "avian"], [72, "avian"],
+  // Bear
+  [23, "bear"], [20, "bear"], [24, "bear"], [25, "bear"], [5, "bear"],
+  // Canine
+  [8, "canine"], [29, "canine"], [4, "canine"], [28, "canine"], [22, "canine"],
+  // Devourer
+  [6, "devourer"], [26, "devourer"], [27, "devourer"],
+  // Drake
+  [18, "drake"], [7, "drake"], [45, "drake"], [19, "drake"], [12, "drake"],
+  // Feline
+  [9, "feline"], [3, "feline"], [11, "feline"], [54, "feline"], [47, "feline"],
+  [55, "feline"], [1, "feline"], [63, "feline"], [70, "feline"],
+  // Jellyfish
+  [41, "jellyfish"], [43, "jellyfish"], [42, "jellyfish"],
+  // Moa
+  [13, "moa"], [15, "moa"], [16, "moa"], [17, "moa"], [14, "moa"],
+  // Porcine
+  [38, "porcine"], [37, "porcine"], [2, "porcine"], [39, "porcine"], [64, "porcine"],
+  // Spider
+  [33, "spider"], [34, "spider"], [36, "spider"], [35, "spider"],
+  // Wyvern
+  [48, "wyvern"], [51, "wyvern"],
+]);
+
 async function getProfessionList(lang = "en") {
   return PROFESSIONS_STATIC
     .filter((entry) => entry?.id)
@@ -703,34 +732,70 @@ async function _buildProfessionCatalog(professionId, lang = "en", gameMode = "pv
   });
 
   // ── Wiki fact resolution ─────────────────────────────────────────────────
-  // Build title → IDs mapping. Multiple entities can share a name (e.g. a skill
-  // and a trait both called "Mending"), so map each title to all matching IDs.
-  // The wiki page is fetched once and the parsed facts are applied to every entity.
-  const titleToIds = new Map();
-  const titleToFirstId = new Map(); // for resolveEntityFacts (needs Map<title, id>)
-  for (const entity of [...mappedSkills, ...mappedTraits, ...mappedWeaponSkills]) {
-    if (!entity.name) continue;
-    if (!titleToIds.has(entity.name)) {
-      titleToIds.set(entity.name, []);
-      titleToFirstId.set(entity.name, entity.id);
+  // Build per-entity id → wiki title map. Each entity gets a wiki title to look up;
+  // the resolver deduplicates fetches by title and uses infobox ID matching to
+  // route the right facts to the right entity when names collide.
+  //
+  // Most entities use their bare display name. Pet family skills get pre-disambiguated
+  // with family names (e.g. "Maul (porcine)") because the wiki consistently uses this
+  // convention — this avoids extra round-trips for the resolver's prefix search fallback.
+  //
+  // NOTE: Pet skill IDs also appear in mappedSkills (Ranger's profession.skills lists
+  // them as Profession_1 slots), so we must build the pet family map BEFORE iterating
+  // entities to ensure disambiguation applies regardless of which array contributes the ID.
+
+  // Build skill ID → pet family name lookup from pets data
+  const petFamilyBySkillId = new Map();
+  for (const pet of pets) {
+    const family = PET_ID_TO_FAMILY.get(pet.id) || "";
+    if (!family) continue;
+    for (const skill of pet.skills) {
+      if (skill.id && !petFamilyBySkillId.has(skill.id)) {
+        petFamilyBySkillId.set(skill.id, family);
+      }
     }
-    titleToIds.get(entity.name).push(entity.id);
+  }
+
+  // First pass: add all entities with bare names (deduplicated by ID)
+  const idToTitle = new Map();
+  const seenIds = new Set();
+
+  for (const entity of [...mappedSkills, ...mappedTraits, ...mappedWeaponSkills]) {
+    if (!entity.name || seenIds.has(entity.id)) continue;
+    // Skip synthetic/placeholder entries that have no wiki pages
+    if (entity.id === 999999 || entity.name === "Locked") continue;
+    seenIds.add(entity.id);
+    idToTitle.set(entity.id, entity.name);
+  }
+
+  // Add pet skills not already covered by mappedSkills
+  for (const pet of pets) {
+    for (const skill of pet.skills) {
+      if (!skill.name || seenIds.has(skill.id)) continue;
+      seenIds.add(skill.id);
+      idToTitle.set(skill.id, skill.name);
+    }
+  }
+
+  // Second pass: disambiguate pet family skills whose bare name collides with
+  // another entity. Only add "(family)" suffixes when the name is shared — unique
+  // pet skill names resolve to their bare wiki page just fine.
+  const nameToIds = new Map();
+  for (const [id, title] of idToTitle) {
+    if (!nameToIds.has(title)) nameToIds.set(title, []);
+    nameToIds.get(title).push(id);
+  }
+  for (const [id, title] of idToTitle) {
+    const family = petFamilyBySkillId.get(id);
+    if (family && nameToIds.get(title).length > 1) {
+      idToTitle.set(id, `${title} (${family})`);
+    }
   }
 
   let wikiFactsById = new Map();
   try {
     const client = getWikiClient();
-    // resolveEntityFacts expects Map<title, id> — use the first ID per title
-    const resolvedByFirstId = await resolveEntityFacts(client, titleToFirstId, { profession: profession.name || professionId });
-    // Expand: if multiple entity IDs share a title, give them all the same wiki facts
-    for (const [title, ids] of titleToIds) {
-      const firstId = ids[0];
-      const facts = resolvedByFirstId.get(firstId);
-      if (!facts) continue;
-      for (const id of ids) {
-        wikiFactsById.set(id, facts);
-      }
-    }
+    wikiFactsById = await resolveEntityFacts(client, idToTitle, { profession: profession.name || professionId });
   } catch (err) {
     console.warn("[catalog] Wiki fact resolution failed, using API facts:", err.message);
   }
@@ -744,13 +809,29 @@ async function _buildProfessionCatalog(professionId, lang = "en", gameMode = "pv
   for (const ws of mappedWeaponSkills) {
     applyWikiFacts(ws, wikiFactsById, KNOWN_SKILL_FACTS_OVERRIDES);
   }
+  // Apply wiki facts to pet skills (nested inside pets[].skills[])
+  for (const pet of pets) {
+    for (const skill of pet.skills) {
+      const wikiFacts = wikiFactsById.get(skill.id);
+      if (!wikiFacts) continue;
+      if (wikiFacts.pve.length > 0) skill.facts = wikiFacts.pve;
+      skill.hasSplit = wikiFacts.hasSplit;
+      if (wikiFacts.wvw) skill.wvwFacts = wikiFacts.wvw;
+      if (wikiFacts.pvp) skill.pvpFacts = wikiFacts.pvp;
+      if (wikiFacts.recharge) skill.recharge = wikiFacts.recharge;
+      if (wikiFacts.activation) skill.activation = wikiFacts.activation;
+    }
+  }
 
   // Log missing pages for monitoring
   const resolved = new Set([...wikiFactsById.keys()]).size;
-  const total = titleToFirstId.size;
+  const total = idToTitle.size;
   if (resolved < total) {
-    const missing = [...titleToFirstId.keys()].filter((t) => !wikiFactsById.has(titleToFirstId.get(t)));
-    console.warn(`[catalog] Wiki facts: ${resolved}/${total} resolved. Missing: ${missing.slice(0, 10).join(", ")}${missing.length > 10 ? ` (+${missing.length - 10} more)` : ""}`);
+    const missingIds = [...idToTitle.keys()].filter((id) => !wikiFactsById.has(id));
+    const missingNames = [...new Set(missingIds.map((id) => idToTitle.get(id)))];
+    const preview = missingNames.slice(0, 10).join(", ");
+    const extra = missingNames.length > 10 ? ` (+${missingNames.length - 10} more)` : "";
+    console.warn(`[catalog] Wiki facts: ${resolved}/${total} resolved. Missing: ${preview}${extra}`);
   }
 
   const catalog = {


### PR DESCRIPTION
## Summary

- Refactors wiki fact resolution to use per-entity `id→title` maps instead of deduplicating by name, so entities sharing a display name (e.g. "Maul" the ranger skill vs "Maul" the pet skill) get the correct wiki facts
- Adds pet skill wiki resolution with family-based disambiguation (e.g. "Maul (feline)", "Bite (bear)") when names collide
- Uses infobox ID matching to validate that wiki page facts belong to the requesting entity, with prefix search fallback for mismatches
- Improves overall wiki fact resolution from ~85% to ~94% across all professions

## Test plan

- [x] All 1450 existing tests pass
- [x] New tests cover per-entity disambiguation, infobox ID matching, and multi-ID fact sharing
- [x] Dev server confirms improved resolution rates for all 9 professions
- [ ] Manual verification: skill tooltips show correct wiki-sourced facts
- [ ] Verify same-named skills across professions get distinct facts

🤖 Generated with [Claude Code](https://claude.com/claude-code)