### PR TITLE
fix: Signet of Fury not applying Passive and bonus missing Active Bonus (closes #174)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,22 +81,36 @@ jobs:
         if: ${{ vars.DISCORD_WEBHOOK_URL != '' }}
         env:
           DISCORD_WEBHOOK_URL: ${{ vars.DISCORD_WEBHOOK_URL }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
           release_url="https://github.com/darkharasho/axiforge/releases/tag/${tag}"
           notes=$(gh release view "$tag" --json body --jq '.body' 2>/dev/null || echo "")
 
-          # Truncate notes to fit Discord's 2000 char limit (leaving room for header)
-          if [ ${#notes} -gt 1500 ]; then
-            notes="${notes:0:1500}..."
-          fi
+          export TAG="$tag"
+          export RELEASE_URL="$release_url"
+          export NOTES="$notes"
 
           payload=$(python3 -c "
-          import json, sys
-          content = f'**AxiForge ${tag}** released!\n\n${notes}\n\n🔗 {release_url}'
-          if len(content) > 2000:
-              content = content[:1997] + '...'
-          print(json.dumps({'content': content}))
-          " 2>/dev/null || echo '{"content":"AxiForge '"$tag"' released! '"$release_url"'"}')
+          import json, os
+
+          tag = os.environ['TAG']
+          release_url = os.environ['RELEASE_URL']
+          notes = os.environ.get('NOTES', '')
+
+          # Truncate notes for Discord embed description limit (4096 chars)
+          if len(notes) > 3800:
+              notes = notes[:3800] + '\n\n*... see full notes on GitHub*'
+
+          embed = {
+              'title': f'AxiForge {tag}',
+              'url': release_url,
+              'description': notes or 'A new version of AxiForge is available!',
+              'color': 0x5865F2,
+              'footer': {'text': 'AxiForge Release'},
+          }
+
+          print(json.dumps({'embeds': [embed]}))
+          ")
 
           curl -s -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK_URL"

--- a/packages/gw2-data/src/wiki/parser.js
+++ b/packages/gw2-data/src/wiki/parser.js
@@ -271,16 +271,22 @@ function mapWikiFactToApiFact(factType, positional, params, isWvw, isUniversal) 
   }
 
   // ── Effect ────────────────────────────────────────────────────────────
+  // {{skill fact|effect|Signet of Fury (effect)|desc=180 [[Precision]]|effect bonus=Precision}}
+  // {{skill fact|effect|Signet of Fury (effect)|alt=Active Bonus|4|desc=360 [[Precision]], 360 [[Ferocity]]}}
   if (type === "effect") {
     const status = positional[0] ? stripWikiMarkup(positional[0]).trim() : "";
     const duration = parseFloat(stripWikiMarkup(positional[1]) || "0");
-    return {
+    const alt = params.alt ? stripWikiMarkup(params.alt).trim() : "";
+    const desc = params.desc ? stripWikiMarkup(params.desc).trim() : "";
+    const fact = {
       type: "Buff",
-      text: status,
+      text: alt || status,
       status,
       duration,
       apply_count: parseInt(stripWikiMarkup(params.stacks) || "1", 10),
     };
+    if (desc) fact.description = desc;
+    return fact;
   }
 
   // ── Attribute Conversion (gain) ──────────────────────────────────────

--- a/packages/gw2-data/tests/parser.test.js
+++ b/packages/gw2-data/tests/parser.test.js
@@ -236,6 +236,30 @@ describe("mapWikiFactToApiFact", () => {
     });
   });
 
+  test("effect with desc captures description (signet passive)", () => {
+    const fact = mapWikiFactToApiFact("effect", ["Signet of Fury (effect)"], { desc: "180 Precision" }, false, true);
+    expect(fact).toEqual({
+      type: "Buff",
+      text: "Signet of Fury (effect)",
+      status: "Signet of Fury (effect)",
+      duration: 0,
+      apply_count: 1,
+      description: "180 Precision",
+    });
+  });
+
+  test("effect with alt and desc (signet active)", () => {
+    const fact = mapWikiFactToApiFact("effect", ["Signet of Fury (effect)", "4"], { alt: "Active Bonus", desc: "360 Precision, 360 Ferocity" }, false, true);
+    expect(fact).toEqual({
+      type: "Buff",
+      text: "Active Bonus",
+      status: "Signet of Fury (effect)",
+      duration: 4,
+      apply_count: 1,
+      description: "360 Precision, 360 Ferocity",
+    });
+  });
+
   test("barrier with base and coefficient", () => {
     const fact = mapWikiFactToApiFact("barrier", [], { base: "200", coefficient: "0.3" }, true, false);
     expect(fact).toMatchObject({

--- a/src/main/gw2Data/catalog.js
+++ b/src/main/gw2Data/catalog.js
@@ -42,6 +42,39 @@ function clearCatalogCache() {
   _catalogCache.clear();
 }
 
+/**
+ * Transfer icons from API facts to wiki facts that lack them.
+ * Wiki-parsed facts have accurate values but no icon URLs; API facts have
+ * per-fact icons. Match by type + key field (status for Buffs, text for others).
+ */
+function _transferIcons(apiFacts, wikiFacts) {
+  if (!apiFacts?.length || !wikiFacts?.length) return;
+  // Build a lookup from the API facts: type+key → icon
+  const iconMap = new Map();
+  for (const f of apiFacts) {
+    if (!f.icon) continue;
+    // For Buff-type facts, key by status; for others, key by text
+    const key = f.status
+      ? `${f.type || ""}|status:${f.status}`
+      : `${f.type || ""}|text:${f.text || ""}`;
+    if (!iconMap.has(key)) iconMap.set(key, f.icon);
+  }
+  for (const wf of wikiFacts) {
+    if (wf.icon) continue;
+    // Try matching by status first (Buff facts), then by text, then by type only
+    const statusKey = wf.status ? `${wf.type || ""}|status:${wf.status}` : null;
+    // Strip "(effect)" suffix for matching — wiki uses "Signet of Fury (effect)"
+    // but API uses "Signet of Fury"
+    const cleanStatus = wf.status?.replace(/\s*\(effect\)\s*$/i, "");
+    const cleanStatusKey = cleanStatus ? `${wf.type || ""}|status:${cleanStatus}` : null;
+    const textKey = `${wf.type || ""}|text:${wf.text || ""}`;
+    const icon = (statusKey && iconMap.get(statusKey))
+      || (cleanStatusKey && iconMap.get(cleanStatusKey))
+      || iconMap.get(textKey);
+    if (icon) wf.icon = icon;
+  }
+}
+
 function applyWikiFacts(entity, wikiFactsById, overridesMap) {
   // Emergency overrides always win
   if (overridesMap.has(entity.id)) return;
@@ -51,14 +84,17 @@ function applyWikiFacts(entity, wikiFactsById, overridesMap) {
 
   // Only replace facts if wiki actually has fact templates
   if (wikiFacts.pve.length > 0) {
+    _transferIcons(entity.facts, wikiFacts.pve);
     entity.facts = wikiFacts.pve;
   }
   entity.hasSplit = wikiFacts.hasSplit;
 
   if (wikiFacts.wvw) {
+    _transferIcons(entity.wvwFacts || entity.facts, wikiFacts.wvw);
     entity.wvwFacts = wikiFacts.wvw;
   }
   if (wikiFacts.pvp) {
+    _transferIcons(entity.pvpFacts || entity.facts, wikiFacts.pvp);
     entity.pvpFacts = wikiFacts.pvp;
   }
 
@@ -993,4 +1029,5 @@ module.exports = {
   initWikiClient,
   getWikiClient,
   clearCatalogCache,
+  _transferIcons,
 };

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -669,10 +669,14 @@ export async function selectDetail(kind, entity) {
 // ── Fact formatting helpers ──────────────────────────────────────────────────
 
 function formatBuffConditionText(fact) {
-  const name = String(fact.status || fact.text || "Unknown").replace(/\s*\(effect\)\s*$/i, "");
+  const rawStatus = String(fact.status || fact.text || "Unknown").replace(/\s*\(effect\)\s*$/i, "");
+  // Use text as display name when it provides an alternative label (e.g. "Active Bonus")
+  const hasAltText = fact.text && fact.status && fact.text !== fact.status
+    && fact.text !== "Apply Buff/Condition" && !/\(effect\)$/i.test(fact.text);
+  const name = hasAltText ? fact.text : rawStatus;
   const count = Number(fact.apply_count) || 0;
   const stackPart = count > 1 ? ` ×${count}` : "";
-  const duration = fact.duration != null ? ` (${fact.duration}s)` : "";
+  const duration = fact.duration ? ` (${fact.duration}s)` : "";
   // Show description if available, or text if it differs from status (wiki effect facts)
   const extra = fact.description
     ? `: ${fact.description}`

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -308,7 +308,10 @@ export function resolveEntityFacts(entity) {
     if (f.type === "NoData") return true;
     const statusKey = (f.status || "").trim();
     if (statusKey) {
-      const key = `status:${statusKey}|${f.apply_count || ""}`;
+      // Distinguish passive (duration 0) from active (duration > 0) signet-style
+      // buffs that share the same status name (e.g. "Signet of Fury").
+      const durBucket = (f.duration || 0) === 0 ? "p" : "a";
+      const key = `status:${statusKey}|${f.apply_count || ""}|${durBucket}`;
       if (seen.has(key)) return false;
       seen.add(key);
       return true;

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -6,6 +6,7 @@ import {
   STACKING_SIGIL_DEFS,
   MIGHT_POWER_PER_STACK, MIGHT_CONDI_PER_STACK,
   AQUATIC_SLOTS, LAND_ONLY_SLOTS,
+  SIGNET_PASSIVE_BUFFS,
 } from "./engine-bridge.js";
 import { GW2_WEAPONS_BY_ID, getEffectiveStats } from "./constants.js";
 import {
@@ -269,6 +270,24 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
         const key = MAP[m[2]] || m[2];
         if (key === statKey) entries.push({ source: `${utilDef.name}`, value: Number(m[1]) });
       }
+    }
+  }
+
+  // Signet passive buffs
+  const isUnderwater = Boolean(state.editor.underwaterMode);
+  const skills = isUnderwater ? (state.editor.underwaterSkills || {}) : (state.editor.skills || {});
+  const signetSkillIds = [
+    skills.healId,
+    ...(skills.utilityIds || []),
+    skills.eliteId,
+  ].filter(Boolean).map(Number);
+  for (const skillId of signetSkillIds) {
+    const buff = SIGNET_PASSIVE_BUFFS.get(skillId);
+    if (buff && buff.stat === statKey) {
+      const catalog = state.activeCatalog;
+      const skillData = catalog?.skillById?.get(skillId);
+      const name = skillData?.name || `Signet (${skillId})`;
+      entries.push({ source: `Signet (${name})`, value: buff.value, icon: skillData?.icon });
     }
   }
 

--- a/tests/unit/catalog-icon-transfer.test.js
+++ b/tests/unit/catalog-icon-transfer.test.js
@@ -1,0 +1,65 @@
+"use strict";
+
+/**
+ * Tests for _transferIcons — carries API fact icons forward to wiki-parsed facts.
+ * Wiki facts have accurate values but no icon URLs; this bridges the gap.
+ */
+
+const { _transferIcons } = require("../../src/main/gw2Data/catalog");
+
+describe("_transferIcons", () => {
+  test("transfers icon from API Buff fact to matching wiki Buff fact by status", () => {
+    const apiFacts = [
+      { type: "Buff", status: "Signet of Fury", icon: "https://render.guildwars2.com/icon1.png", duration: 0 },
+    ];
+    const wikiFacts = [
+      { type: "Buff", status: "Signet of Fury (effect)", duration: 0, description: "180 Precision" },
+    ];
+    _transferIcons(apiFacts, wikiFacts);
+    expect(wikiFacts[0].icon).toBe("https://render.guildwars2.com/icon1.png");
+  });
+
+  test("transfers icon from API Number fact to matching wiki Number fact by text", () => {
+    const apiFacts = [
+      { type: "Number", text: "Adrenaline", icon: "https://render.guildwars2.com/icon2.png", value: 30 },
+    ];
+    const wikiFacts = [
+      { type: "Number", text: "Adrenaline", value: 30 },
+    ];
+    _transferIcons(apiFacts, wikiFacts);
+    expect(wikiFacts[0].icon).toBe("https://render.guildwars2.com/icon2.png");
+  });
+
+  test("does not overwrite existing wiki fact icon", () => {
+    const apiFacts = [
+      { type: "Number", text: "Damage", icon: "https://render.guildwars2.com/api-icon.png", value: 100 },
+    ];
+    const wikiFacts = [
+      { type: "Number", text: "Damage", icon: "https://render.guildwars2.com/wiki-icon.png", value: 200 },
+    ];
+    _transferIcons(apiFacts, wikiFacts);
+    expect(wikiFacts[0].icon).toBe("https://render.guildwars2.com/wiki-icon.png");
+  });
+
+  test("handles empty or missing arrays gracefully", () => {
+    expect(() => _transferIcons(null, [])).not.toThrow();
+    expect(() => _transferIcons([], null)).not.toThrow();
+    expect(() => _transferIcons([], [])).not.toThrow();
+  });
+
+  test("multiple wiki facts get correct icons from API facts", () => {
+    const apiFacts = [
+      { type: "Buff", status: "Signet of Fury", icon: "https://render.guildwars2.com/signet.png", duration: 0 },
+      { type: "Number", text: "Adrenaline", icon: "https://render.guildwars2.com/adrenaline.png", value: 30 },
+    ];
+    const wikiFacts = [
+      { type: "Buff", status: "Signet of Fury (effect)", duration: 0, description: "180 Precision" },
+      { type: "Buff", status: "Signet of Fury (effect)", text: "Active Bonus", duration: 4, description: "360 Precision, 360 Ferocity" },
+      { type: "Number", text: "Adrenaline", value: 30 },
+    ];
+    _transferIcons(apiFacts, wikiFacts);
+    expect(wikiFacts[0].icon).toBe("https://render.guildwars2.com/signet.png");
+    expect(wikiFacts[1].icon).toBe("https://render.guildwars2.com/signet.png");
+    expect(wikiFacts[2].icon).toBe("https://render.guildwars2.com/adrenaline.png");
+  });
+});

--- a/tests/unit/renderer/resolveEntityFacts.test.js
+++ b/tests/unit/renderer/resolveEntityFacts.test.js
@@ -116,6 +116,21 @@ describe("resolveEntityFacts — signet passive vs active buff", () => {
     expect(signetBuffs[1].duration).toBe(4);
   });
 
+  test("wiki-style effect facts with desc/alt are both kept", () => {
+    const entity = {
+      facts: [
+        { type: "Buff", text: "Signet of Fury (effect)", status: "Signet of Fury (effect)", duration: 0, description: "180 Precision", apply_count: 1 },
+        { type: "Buff", text: "Active Bonus", status: "Signet of Fury (effect)", duration: 4, description: "360 Precision, 360 Ferocity", apply_count: 1 },
+      ],
+      traitedFacts: [],
+    };
+    const result = resolveEntityFacts(entity);
+    const signetBuffs = result.filter((f) => f.status === "Signet of Fury (effect)");
+    expect(signetBuffs).toHaveLength(2);
+    expect(signetBuffs[0].description).toBe("180 Precision");
+    expect(signetBuffs[1].description).toBe("360 Precision, 360 Ferocity");
+  });
+
   test("still deduplicates same-status buffs when both have positive durations", () => {
     const entity = {
       facts: [makeBuff("Quickness", 5), makeBuff("Quickness", 2)],

--- a/tests/unit/renderer/resolveEntityFacts.test.js
+++ b/tests/unit/renderer/resolveEntityFacts.test.js
@@ -95,6 +95,39 @@ describe("resolveEntityFacts — buff deduplication", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Signet passive/active buff deduplication (issue #174)
+// ---------------------------------------------------------------------------
+
+describe("resolveEntityFacts — signet passive vs active buff", () => {
+  test("Signet of Fury: passive (duration 0) and active (duration 4) are both kept", () => {
+    const entity = {
+      facts: [
+        { type: "Recharge", text: "Recharge", value: 16, icon: "" },
+        { type: "Buff", status: "Signet of Fury", duration: 0, description: "Improved precision.", apply_count: 1, icon: "" },
+        { type: "Number", text: "Adrenaline", value: 30, icon: "" },
+        { type: "Buff", status: "Signet of Fury", duration: 4, description: "Improves precision and ferocity.", apply_count: 1, icon: "" },
+      ],
+      traitedFacts: [],
+    };
+    const result = resolveEntityFacts(entity);
+    const signetBuffs = result.filter((f) => f.status === "Signet of Fury");
+    expect(signetBuffs).toHaveLength(2);
+    expect(signetBuffs[0].duration).toBe(0);
+    expect(signetBuffs[1].duration).toBe(4);
+  });
+
+  test("still deduplicates same-status buffs when both have positive durations", () => {
+    const entity = {
+      facts: [makeBuff("Quickness", 5), makeBuff("Quickness", 2)],
+      traitedFacts: [],
+    };
+    const result = resolveEntityFacts(entity);
+    expect(result).toHaveLength(1);
+    expect(result[0].duration).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Text-based deduplication (Stack Threshold, generic numeric facts)
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -7,7 +7,7 @@
  * damage estimates, so correctness is critical.
  */
 
-const { computeSlotStats, computeEquipmentStats, computeBuildConcentration } = require("../../../src/renderer/modules/stats");
+const { computeSlotStats, computeEquipmentStats, computeStatBreakdown, computeBuildConcentration } = require("../../../src/renderer/modules/stats");
 const { state } = require("../../../src/renderer/modules/state");
 const { ARMOR_DEFENSE_BY_WEIGHT, PROFESSION_WEIGHT } = require("../../../src/renderer/modules/constants");
 const { FURY_CRIT_CHANCE, FURY_CRIT_CHANCE_WVW } = require("../../../src/renderer/modules/engine-bridge");
@@ -855,5 +855,61 @@ describe("computeEquipmentStats — signet passive buffs", () => {
     const result = computeEquipmentStats();
     // Engine resolves signet passives via constant map, independent of catalog
     expect(result.Power).toBe(1000 + 180);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeStatBreakdown — signet passive buff contributions (issue #174)
+// ---------------------------------------------------------------------------
+
+describe("computeStatBreakdown — signet passive buffs", () => {
+  const mockCatalog = {
+    skillById: new Map([
+      [14404, { id: 14404, name: "Signet of Might", categories: ["Signet"], facts: [] }],
+      [14410, { id: 14410, name: "Signet of Fury", categories: ["Signet"], facts: [] }],
+    ]),
+    traitById: new Map(),
+    specializationById: new Map(),
+  };
+
+  beforeEach(() => {
+    state.activeCatalog = mockCatalog;
+  });
+  afterEach(() => {
+    state.activeCatalog = null;
+  });
+
+  test("Signet of Fury appears in Precision breakdown with +180", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [14410, 0, 0], eliteId: 0 };
+    const entries = computeStatBreakdown("Precision");
+    const signetEntry = entries.find((e) => e.source.includes("Signet"));
+    expect(signetEntry).toBeDefined();
+    expect(signetEntry.value).toBe(180);
+  });
+
+  test("Signet of Might appears in Power breakdown with +180", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [14404, 0, 0], eliteId: 0 };
+    const entries = computeStatBreakdown("Power");
+    const signetEntry = entries.find((e) => e.source.includes("Signet"));
+    expect(signetEntry).toBeDefined();
+    expect(signetEntry.value).toBe(180);
+  });
+
+  test("no signet entry when no signets equipped", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 };
+    const entries = computeStatBreakdown("Power");
+    const signetEntry = entries.find((e) => e.source.includes("Signet"));
+    expect(signetEntry).toBeUndefined();
+  });
+
+  test("signet does not appear in unrelated stat breakdown", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [14410, 0, 0], eliteId: 0 };
+    const entries = computeStatBreakdown("Power");
+    const signetEntry = entries.find((e) => e.source.includes("Signet"));
+    expect(signetEntry).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Two bugs caused Signet of Fury (and other signets) to appear broken:

1. **Tooltip dedup bug**: The active Buff fact (duration 4s) was being incorrectly deduplicated against the passive Buff fact (duration 0) because both shared the same `status` ("Signet of Fury") and `apply_count` (1). Fixed by including a passive/active duration bucket in the dedup key, so duration-0 (passive) and duration->0 (active) facts are treated as distinct while same-duration duplicates (e.g. Quickness 5s/2s) still dedup correctly.

2. **Stat breakdown missing signet entry**: `computeStatBreakdown()` (used for attribute hover tooltips) did not include signet passive contributions. The engine correctly applied the +180 Precision to the total, but the breakdown hover showed no signet line item, making it appear like the passive wasn't working. Added signet passive buff entries to the breakdown using the same `SIGNET_PASSIVE_BUFFS` map the engine uses.

Closes #174