### PR TITLE
fix: Berserker Blood Reaction Trait (closes #175)

### DIFF
--- a/packages/gw2-data/data/overrides.json
+++ b/packages/gw2-data/data/overrides.json
@@ -18,5 +18,9 @@
   "trait:1831": {
     "burstRechargeReduction": 10,
     "description": "Primal Rage: API omits 10% burst recharge reduction fact"
+  },
+  "trait:2046": {
+    "berserkConditional": true,
+    "description": "Fatal Frenzy: stat bonuses only apply while in berserk mode"
   }
 }

--- a/packages/gw2-data/src/engine/attributes.js
+++ b/packages/gw2-data/src/engine/attributes.js
@@ -391,11 +391,14 @@ function computeAttributes(ctx, catalogs) {
   const traitStats = zeroStats();
   const modifiers = collectModifiers(ctx, catalogs, overrides);
   const furyAssumed = Boolean(ctx.assumedBoons?.fury);
+  const berserkActive = Boolean(ctx.berserkActive);
 
   for (const mod of modifiers) {
     if (mod.type !== "flatBonus") continue;
-    // Apply if: passive (condition === null) OR fury condition and fury is assumed
-    if (mod.condition === null || (mod.condition === "fury" && furyAssumed)) {
+    // Apply if: passive (condition === null), fury (when assumed), or berserk (when toggled)
+    if (mod.condition === null
+        || (mod.condition === "fury" && furyAssumed)
+        || (mod.condition === "berserk" && berserkActive)) {
       if (mod.target in traitStats) {
         traitStats[mod.target] += mod.value;
       }

--- a/packages/gw2-data/src/engine/modifiers.js
+++ b/packages/gw2-data/src/engine/modifiers.js
@@ -135,9 +135,19 @@ function collectModifiers(ctx, catalogs, overrides) {
     }
 
     // 5. BuffConversion / AttributeConversion facts — conversion
+    //    Group by source+target pair and pick PvE (index 0) or WvW (index 1),
+    //    mirroring the dedup logic used for AttributeAdjust facts above.
+    const convByPair = new Map();
     for (const fact of trait.facts) {
       if (fact.type !== "AttributeConversion" && fact.type !== "BuffConversion") continue;
       if (!fact.source || !fact.target || !fact.percent) continue;
+      const pairKey = `${fact.source}|${fact.target}`;
+      if (!convByPair.has(pairKey)) convByPair.set(pairKey, []);
+      convByPair.get(pairKey).push(fact);
+    }
+    for (const [, facts] of convByPair) {
+      const idx = gameMode === "wvw" ? Math.min(1, facts.length - 1) : 0;
+      const fact = facts[idx];
       const targetKey = CONVERSION_TARGET_MAP[fact.target] || fact.target;
       modifiers.push({
         source,

--- a/packages/gw2-data/src/engine/modifiers.js
+++ b/packages/gw2-data/src/engine/modifiers.js
@@ -113,7 +113,8 @@ function collectModifiers(ctx, catalogs, overrides) {
     if (!trait?.facts) continue;
 
     const fury = isFuryTrait(trait, traitId, overrides);
-    const condition = fury ? "fury" : null;
+    const condition = override?.berserkConditional ? "berserk"
+      : fury ? "fury" : null;
 
     // 4. AttributeAdjust facts — flatBonus
     const byTarget = new Map();

--- a/packages/gw2-data/src/wiki/parser.js
+++ b/packages/gw2-data/src/wiki/parser.js
@@ -2,6 +2,18 @@
 
 const { stripWikiMarkup } = require("../facts/normalize");
 
+// Wiki uses human-readable attribute names; normalize to API stat keys.
+const WIKI_ATTR_MAP = {
+  "Condition Damage": "ConditionDamage",
+  "Healing Power": "HealingPower",
+  "Boon Duration": "BoonDuration",
+  "Condition Duration": "ConditionDuration",
+  "Critical Damage": "CritDamage",
+};
+function normalizeAttr(name) {
+  return WIKI_ATTR_MAP[name] || name;
+}
+
 // Fact types to silently ignore
 const SKIP_TYPES = new Set([
   "text",
@@ -290,11 +302,12 @@ function mapWikiFactToApiFact(factType, positional, params, isWvw, isUniversal) 
   }
 
   // ── Attribute Conversion (gain) ──────────────────────────────────────
-  // {{skill fact|gain|source=Power|target=Condition Damage|percent=10}}
+  // Named:      {{skill fact|gain|source=Power|target=Condition Damage|percent=10}}
+  // Positional: {{skill fact|Gain|Ferocity|Precision|12}}  (target, source, percent)
   if (type === "gain") {
-    const source = stripWikiMarkup(params.source) || "";
-    const target = stripWikiMarkup(params.target) || "";
-    const percent = parseFloat(stripWikiMarkup(params.percent) || "0");
+    const source = normalizeAttr(stripWikiMarkup(params.source || positional[1]) || "");
+    const target = normalizeAttr(stripWikiMarkup(params.target || positional[0]) || "");
+    const percent = parseFloat(stripWikiMarkup(params.percent || positional[2]) || "0");
     return {
       type: "BuffConversion",
       text: "Attribute Conversion",

--- a/packages/gw2-data/tests/engine/attributes.test.js
+++ b/packages/gw2-data/tests/engine/attributes.test.js
@@ -211,6 +211,34 @@ describe("computeAttributes", () => {
     expect(result.total.Power).toBe(1100);
   });
 
+  test("berserk-conditional trait bonuses only apply when berserkActive", () => {
+    const catalogs = makeCatalogs({
+      traitById: new Map([[2046, {
+        id: 2046,
+        slot: "Minor",
+        description: "Fatal Frenzy",
+        facts: [
+          { type: "AttributeAdjust", target: "Power", value: 150 },
+          { type: "AttributeAdjust", target: "ConditionDamage", value: 300 },
+        ],
+      }]]),
+      specializationById: new Map([[18, { id: 18, minorTraits: [2046] }]]),
+    });
+    const baseCtx = {
+      specializations: [{ id: 18, majorChoices: {} }],
+    };
+
+    // Without berserk: bonuses NOT applied
+    const resultOff = computeAttributes(makeCtx({ ...baseCtx, berserkActive: false }), catalogs);
+    expect(resultOff.traits.Power).toBe(0);
+    expect(resultOff.traits.ConditionDamage).toBe(0);
+
+    // With berserk: bonuses applied
+    const resultOn = computeAttributes(makeCtx({ ...baseCtx, berserkActive: true }), catalogs);
+    expect(resultOn.traits.Power).toBe(150);
+    expect(resultOn.traits.ConditionDamage).toBe(300);
+  });
+
   test("signet passive buffs added", () => {
     const ctx = makeCtx({
       skills: { healId: null, utilityIds: [], eliteId: null },

--- a/packages/gw2-data/tests/engine/modifiers.test.js
+++ b/packages/gw2-data/tests/engine/modifiers.test.js
@@ -346,6 +346,27 @@ describe("collectModifiers()", () => {
   // Blood Reaction bug: GW2 API returns multiple BuffConversion facts for
   // same source→target pair with different percentages (PvE/WvW variants).
   // Only the first (PvE) or second (WvW) should be used — not all summed.
+  it("marks berserkConditional override traits with condition: 'berserk'", () => {
+    const traitId = 2046;
+    const trait = {
+      slot: "Minor",
+      description: "Fatal Frenzy",
+      facts: [
+        { type: "AttributeAdjust", target: "Power", value: 150 },
+        { type: "AttributeAdjust", target: "ConditionDamage", value: 300 },
+      ],
+    };
+    const catalogs = makeCatalogs({ [traitId]: trait });
+    const ctx = makeCtx([{ id: 1, majorChoices: { 1: traitId } }]);
+    const overrides = makeOverrides({ "trait:2046": { berserkConditional: true } });
+
+    const mods = collectModifiers(ctx, catalogs, overrides);
+    const flatMods = mods.filter((m) => m.type === "flatBonus");
+    expect(flatMods).toHaveLength(2);
+    expect(flatMods[0].condition).toBe("berserk");
+    expect(flatMods[1].condition).toBe("berserk");
+  });
+
   it("deduplicates BuffConversion facts by source+target (PvE picks first)", () => {
     const traitId = 2011;
     const trait = {

--- a/packages/gw2-data/tests/engine/modifiers.test.js
+++ b/packages/gw2-data/tests/engine/modifiers.test.js
@@ -342,4 +342,53 @@ describe("collectModifiers()", () => {
     const mods = collectModifiers(ctx, {}, makeOverrides());
     expect(mods).toEqual([]);
   });
+
+  // Blood Reaction bug: GW2 API returns multiple BuffConversion facts for
+  // same source→target pair with different percentages (PvE/WvW variants).
+  // Only the first (PvE) or second (WvW) should be used — not all summed.
+  it("deduplicates BuffConversion facts by source+target (PvE picks first)", () => {
+    const traitId = 2011;
+    const trait = {
+      slot: "Major",
+      description: "Blood Reaction",
+      facts: [
+        { type: "BuffConversion", source: "Precision", target: "CritDamage", percent: 12 },
+        { type: "BuffConversion", source: "Precision", target: "CritDamage", percent: 10 },
+        { type: "BuffConversion", source: "Precision", target: "CritDamage", percent: 5 },
+        { type: "BuffConversion", source: "Power", target: "ConditionDamage", percent: 10 },
+        { type: "BuffConversion", source: "Power", target: "ConditionDamage", percent: 15 },
+      ],
+    };
+    const catalogs = makeCatalogs({ [traitId]: trait });
+    const ctx = makeCtx([{ id: 1, majorChoices: { 1: traitId } }], "pve");
+
+    const mods = collectModifiers(ctx, catalogs, makeOverrides());
+    const convMods = mods.filter((m) => m.type === "conversion");
+    expect(convMods).toHaveLength(2);
+    expect(convMods[0]).toMatchObject({ sourceAttr: "Precision", target: "Ferocity", percent: 12 });
+    expect(convMods[1]).toMatchObject({ sourceAttr: "Power", target: "ConditionDamage", percent: 10 });
+  });
+
+  it("deduplicates BuffConversion facts by source+target (WvW picks second)", () => {
+    const traitId = 2011;
+    const trait = {
+      slot: "Major",
+      description: "Blood Reaction",
+      facts: [
+        { type: "BuffConversion", source: "Precision", target: "CritDamage", percent: 12 },
+        { type: "BuffConversion", source: "Precision", target: "CritDamage", percent: 10 },
+        { type: "BuffConversion", source: "Precision", target: "CritDamage", percent: 5 },
+        { type: "BuffConversion", source: "Power", target: "ConditionDamage", percent: 10 },
+        { type: "BuffConversion", source: "Power", target: "ConditionDamage", percent: 15 },
+      ],
+    };
+    const catalogs = makeCatalogs({ [traitId]: trait });
+    const ctx = makeCtx([{ id: 1, majorChoices: { 1: traitId } }], "wvw");
+
+    const mods = collectModifiers(ctx, catalogs, makeOverrides());
+    const convMods = mods.filter((m) => m.type === "conversion");
+    expect(convMods).toHaveLength(2);
+    expect(convMods[0]).toMatchObject({ sourceAttr: "Precision", target: "Ferocity", percent: 10 });
+    expect(convMods[1]).toMatchObject({ sourceAttr: "Power", target: "ConditionDamage", percent: 15 });
+  });
 });

--- a/packages/gw2-data/tests/parser.test.js
+++ b/packages/gw2-data/tests/parser.test.js
@@ -198,6 +198,41 @@ describe("mapWikiFactToApiFact", () => {
     });
   });
 
+  test("attribute gain/conversion with positional params", () => {
+    // {{skill fact|Gain|Ferocity|Precision|12}} → positional[0]=Ferocity (target),
+    // positional[1]=Precision (source), positional[2]=12 (percent)
+    const fact = mapWikiFactToApiFact(
+      "gain",
+      ["Ferocity", "Precision", "12"],
+      {},
+      false,
+      false
+    );
+    expect(fact).toMatchObject({
+      type: "BuffConversion",
+      source: "Precision",
+      target: "Ferocity",
+      percent: 12,
+    });
+  });
+
+  test("attribute gain/conversion normalizes wiki attribute names", () => {
+    // {{skill fact|Gain|Condition Damage|Power|15}} — "Condition Damage" → "ConditionDamage"
+    const fact = mapWikiFactToApiFact(
+      "gain",
+      ["Condition Damage", "Power", "15"],
+      {},
+      false,
+      false
+    );
+    expect(fact).toMatchObject({
+      type: "BuffConversion",
+      source: "Power",
+      target: "ConditionDamage",
+      percent: 15,
+    });
+  });
+
   test("flat attribute bonus produces AttributeAdjust", () => {
     const fact = mapWikiFactToApiFact(
       "attribute",

--- a/src/renderer/modules/engine-bridge.js
+++ b/src/renderer/modules/engine-bridge.js
@@ -44,6 +44,13 @@ export function buildEngineCtx(state, assumedBoons = null, sigilStacks = null) {
   const equipment = editor.equipment || {};
   const isUnderwater = Boolean(editor.underwaterMode);
 
+  // Determine if berserk mode is toggled on (Warrior/Berserker spec 18).
+  const activeKit = Number(editor.activeKit) || 0;
+  const hasBerserker = (editor.specializations || []).some(
+    (s) => Number(s?.specializationId || s?.id) === 18
+  );
+  const berserkActive = hasBerserker && activeKit > 0;
+
   return {
     profession: editor.profession || "",
     specializations: (editor.specializations || []).map((s) => ({
@@ -67,6 +74,7 @@ export function buildEngineCtx(state, assumedBoons = null, sigilStacks = null) {
     skills: isUnderwater ? (editor.underwaterSkills || {}) : (editor.skills || {}),
     assumedBoons,
     sigilStacks,
+    berserkActive,
   };
 }
 

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -1537,6 +1537,7 @@ export function renderSkills() {
             state.editor.activeKit = resolvedKit === skill.id ? 0 : skill.id;
           }
           renderSkills();
+          _renderEquipmentPanel(); // refresh stats (e.g. berserk-conditional bonuses)
         });
         iconBtn.append(toggleBadge);
       }
@@ -1588,7 +1589,7 @@ export function renderSkills() {
             if (!_readOnly && skill) selectDetail("skill", skill);
             return;
           }
-          if (isStatic && ((skill?.bundleSkills?.length ?? 0) > 0 || isBeastmodeToggle || isUnleashToggle || isGunsaberToggle || isDragonTriggerToggle)) {
+          if (isStatic && ((skill?.bundleSkills?.length ?? 0) > 0 || isBeastmodeToggle || isUnleashToggle || isBerserkToggle || isGunsaberToggle || isDragonTriggerToggle)) {
             // Static bundle skill (shroud, Photon Forge, beastmode, Unleash, Gunsaber, Dragon Trigger, etc.): toggle active state.
             if (isGunsaberToggle) {
               state.editor.activeKit = resolvedKit === 62745 ? 0 : 62745;

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -1601,6 +1601,7 @@ export function renderSkills() {
               state.editor.activeKit = resolvedKit === skill.id ? 0 : skill.id;
             }
             renderSkills();
+            _renderEquipmentPanel(); // refresh stats (e.g. berserk-conditional bonuses)
             if (!_readOnly && skill) selectDetail("skill", skill);
             return;
           } else if (isStatic && !isToolbelt) {


### PR DESCRIPTION
## Summary

Three fixes for Berserker trait stat calculations:

**1. Stat calculation — duplicate conversions summed (engine):** The GW2 API returns multiple `BuffConversion` facts per source→target pair (PvE/WvW/PvP balance variants). `collectModifiers()` was pushing all of them, causing the engine to sum 12% + 10% + 5% = 27% instead of 12%. Fixed by grouping by source+target pair and picking the correct game-mode index.

**2. Tooltip display — wiki parser couldn't parse gain facts:** The wiki uses positional parameters for gain facts (`{{skill fact|Gain|Ferocity|Precision|12}}`) but the parser only handled named parameters, producing `0%`. Also added attribute name normalization (`"Condition Damage"` → `"ConditionDamage"`).

**3. Fatal Frenzy — applied unconditionally instead of during berserk only:** The minor trait Fatal Frenzy (2046) grants +150 Power / +300 Condition Damage only while in berserk mode. Added `berserkConditional` override, passes `berserkActive` state from the UI toggle through the engine context, and gates the bonuses — matching the existing fury condition pattern.

Closes #175