### PR TITLE
fix: Fatal Frenzy missing Condition Damage and wrong PvE/WvW split (closes #176)

### DIFF
--- a/packages/gw2-data/src/engine/modifiers.js
+++ b/packages/gw2-data/src/engine/modifiers.js
@@ -112,13 +112,19 @@ function collectModifiers(ctx, catalogs, overrides) {
 
     if (!trait?.facts) continue;
 
+    // Use per-mode facts when the wiki pipeline has separated them;
+    // fall back to trait.facts (which may contain mixed-mode duplicates).
+    const modeFacts = gameMode === "wvw" && trait.wvwFacts ? trait.wvwFacts
+      : gameMode === "pvp" && trait.pvpFacts ? trait.pvpFacts
+      : trait.facts;
+
     const fury = isFuryTrait(trait, traitId, overrides);
     const condition = override?.berserkConditional ? "berserk"
       : fury ? "fury" : null;
 
     // 4. AttributeAdjust facts — flatBonus
     const byTarget = new Map();
-    for (const fact of trait.facts) {
+    for (const fact of modeFacts) {
       if (fact.type !== "AttributeAdjust" || !fact.target || fact.value == null) continue;
       if (!byTarget.has(fact.target)) byTarget.set(fact.target, []);
       byTarget.get(fact.target).push(fact.value);
@@ -139,7 +145,7 @@ function collectModifiers(ctx, catalogs, overrides) {
     //    Group by source+target pair and pick PvE (index 0) or WvW (index 1),
     //    mirroring the dedup logic used for AttributeAdjust facts above.
     const convByPair = new Map();
-    for (const fact of trait.facts) {
+    for (const fact of modeFacts) {
       if (fact.type !== "AttributeConversion" && fact.type !== "BuffConversion") continue;
       if (!fact.source || !fact.target || !fact.percent) continue;
       const pairKey = `${fact.source}|${fact.target}`;
@@ -162,7 +168,7 @@ function collectModifiers(ctx, catalogs, overrides) {
 
     // 6. Fury traits with "Critical Chance Increase" Percent facts — critChance
     if (fury) {
-      const critFacts = trait.facts.filter(
+      const critFacts = modeFacts.filter(
         (f) => f.type === "Percent" && f.text === "Critical Chance Increase" && f.percent
       );
       if (critFacts.length > 0) {
@@ -178,7 +184,7 @@ function collectModifiers(ctx, catalogs, overrides) {
 
     // 7. Minor traits with "burst" in description and "Recharge Reduced" Percent facts
     if (trait.slot === "Minor" && trait.description?.toLowerCase().includes("burst")) {
-      const rechargeFacts = trait.facts.filter(
+      const rechargeFacts = modeFacts.filter(
         (f) => f.type === "Percent" && f.text === "Recharge Reduced" && f.percent
       );
       for (const fact of rechargeFacts) {

--- a/packages/gw2-data/src/wiki/parser.js
+++ b/packages/gw2-data/src/wiki/parser.js
@@ -325,7 +325,7 @@ function mapWikiFactToApiFact(factType, positional, params, isWvw, isUniversal) 
     return {
       type: "AttributeAdjust",
       text: attrName,
-      target: attrName,
+      target: normalizeAttr(attrName),
       value,
     };
   }

--- a/packages/gw2-data/tests/engine/modifiers.test.js
+++ b/packages/gw2-data/tests/engine/modifiers.test.js
@@ -367,6 +367,70 @@ describe("collectModifiers()", () => {
     expect(flatMods[1].condition).toBe("berserk");
   });
 
+  it("uses wvwFacts for flatBonus when gameMode is wvw and wvwFacts exists", () => {
+    const traitId = 2046;
+    const trait = {
+      slot: "Minor",
+      description: "Fatal Frenzy",
+      facts: [
+        { type: "AttributeAdjust", target: "Power", value: 300 },
+        { type: "AttributeAdjust", target: "ConditionDamage", value: 300 },
+      ],
+      wvwFacts: [
+        { type: "AttributeAdjust", target: "Power", value: 150 },
+        { type: "AttributeAdjust", target: "ConditionDamage", value: 300 },
+      ],
+    };
+    const catalogs = makeCatalogs({ [traitId]: trait });
+    const overrides = makeOverrides({ "trait:2046": { berserkConditional: true } });
+
+    const wvwMods = collectModifiers(
+      makeCtx([{ id: 1, majorChoices: { 1: traitId } }], "wvw"),
+      catalogs, overrides
+    );
+    const wvwFlat = wvwMods.filter((m) => m.type === "flatBonus");
+    expect(wvwFlat).toHaveLength(2);
+    const powerMod = wvwFlat.find((m) => m.target === "Power");
+    const condiMod = wvwFlat.find((m) => m.target === "ConditionDamage");
+    expect(powerMod.value).toBe(150);
+    expect(condiMod.value).toBe(300);
+
+    // PvE should still use trait.facts
+    const pveMods = collectModifiers(
+      makeCtx([{ id: 1, majorChoices: { 1: traitId } }], "pve"),
+      catalogs, overrides
+    );
+    const pveFlat = pveMods.filter((m) => m.type === "flatBonus");
+    const pvePower = pveFlat.find((m) => m.target === "Power");
+    expect(pvePower.value).toBe(300);
+  });
+
+  it("uses wvwFacts for conversions when gameMode is wvw and wvwFacts exists", () => {
+    const traitId = 2011;
+    const trait = {
+      slot: "Major",
+      description: "Blood Reaction",
+      facts: [
+        { type: "BuffConversion", source: "Precision", target: "CritDamage", percent: 12 },
+        { type: "BuffConversion", source: "Power", target: "ConditionDamage", percent: 15 },
+      ],
+      wvwFacts: [
+        { type: "BuffConversion", source: "Precision", target: "CritDamage", percent: 5 },
+        { type: "BuffConversion", source: "Power", target: "ConditionDamage", percent: 10 },
+      ],
+    };
+    const catalogs = makeCatalogs({ [traitId]: trait });
+
+    const wvwMods = collectModifiers(
+      makeCtx([{ id: 1, majorChoices: { 1: traitId } }], "wvw"),
+      catalogs, makeOverrides()
+    );
+    const convMods = wvwMods.filter((m) => m.type === "conversion");
+    expect(convMods).toHaveLength(2);
+    expect(convMods.find((m) => m.target === "Ferocity").percent).toBe(5);
+    expect(convMods.find((m) => m.target === "ConditionDamage").percent).toBe(10);
+  });
+
   it("deduplicates BuffConversion facts by source+target (PvE picks first)", () => {
     const traitId = 2011;
     const trait = {

--- a/packages/gw2-data/tests/engine/overrides.test.js
+++ b/packages/gw2-data/tests/engine/overrides.test.js
@@ -14,8 +14,8 @@ describe("overrides module", () => {
       expect(overrides).toBeInstanceOf(Map);
     });
 
-    it("contains exactly 5 entries", () => {
-      expect(overrides.size).toBe(5);
+    it("contains exactly 6 entries", () => {
+      expect(overrides.size).toBe(6);
     });
 
     it("trait:1719 has implicitFury: true", () => {

--- a/packages/gw2-data/tests/parser.test.js
+++ b/packages/gw2-data/tests/parser.test.js
@@ -249,6 +249,22 @@ describe("mapWikiFactToApiFact", () => {
     });
   });
 
+  test("flat attribute bonus normalizes multi-word attribute names", () => {
+    // {{skill fact|attribute|Condition Damage|300}} — "Condition Damage" → "ConditionDamage"
+    const fact = mapWikiFactToApiFact(
+      "attribute",
+      ["Condition Damage", "300"],
+      {},
+      true,
+      false
+    );
+    expect(fact).toMatchObject({
+      type: "AttributeAdjust",
+      target: "ConditionDamage",
+      value: 300,
+    });
+  });
+
   test("effect produces Buff with status from positional[0] and duration from positional[1]", () => {
     const fact = mapWikiFactToApiFact("effect", ["Superspeed", "5"], { stacks: "2" }, true, false);
     expect(fact).toEqual({


### PR DESCRIPTION
## Summary

Fatal Frenzy trait had two bugs causing incorrect stat calculations:

1. **Condition Damage not applied**: The wiki parser's `attribute` fact type didn't normalize multi-word attribute names (e.g. `"Condition Damage"` → `"ConditionDamage"`). The engine silently dropped the unrecognized key, so the +300 Condition Damage bonus was never added.

2. **PvE/WvW split ignored**: The modifiers engine always read `trait.facts` (PvE facts) regardless of game mode. When the wiki pipeline separates facts into per-mode arrays (`facts` for PvE, `wvwFacts` for WvW), the engine now selects the correct array based on the active game mode. This fixes Fatal Frenzy showing PvE Power (+300) in WvW instead of the correct +150.

### Changes
- `parser.js`: Apply `normalizeAttr()` to `attribute` fact target (systemic fix — affects all wiki-parsed attribute facts)
- `modifiers.js`: Use `trait.wvwFacts` / `trait.pvpFacts` when available for the active game mode
- Added test coverage for both bugs
- Fixed pre-existing overrides test count (5 → 6 after PR #189)

Closes #176