### PR TITLE
fix: @Weapons Tags dont work in Published web version (closes #186)

### DIFF
--- a/src/site/render-notes.js
+++ b/src/site/render-notes.js
@@ -4,6 +4,7 @@
 import { marked } from "marked";
 import { bindHoverPreview } from "@renderer/modules/detail-panel.js";
 import { decodeHtmlEntities } from "@renderer/modules/utils.js";
+import { GW2_WEAPONS_BY_ID } from "@renderer/modules/constants.js";
 
 export function renderNotes(build) {
   const container = document.createElement("div");
@@ -47,8 +48,8 @@ export function renderNotes(build) {
   }
 
   // Resolve @[category:id:Name] patterns
-  html = html.replace(/@\[(\w+):(\d+):([^\]]+)\]/g, (match, category, id, name) => {
-    const numId = Number(id);
+  html = html.replace(/@\[(\w+):([\w]+):([^\]]+)\]/g, (match, category, id, name) => {
+    const numId = /^\d+$/.test(id) ? Number(id) : id;
     let resolved = null;
     let resolvedCategory = category;
     switch (category) {
@@ -61,6 +62,11 @@ export function renderNotes(build) {
       case "infusion": resolved = infusionById.get(numId); break;
       case "enrichment": resolved = enrichmentById.get(numId); break;
       case "relic": resolved = relicById.get(numId); break;
+      case "weapon": {
+        const w = GW2_WEAPONS_BY_ID.get(id);
+        resolved = w ? { id: w.id, name: w.label, icon: w.icon } : null;
+        break;
+      }
       case "item": {
         const itemMaps = [["rune", runeById], ["sigil", sigilById], ["food", foodById], ["utility", utilityById], ["infusion", infusionById], ["enrichment", enrichmentById], ["relic", relicById]];
         for (const [cat, map] of itemMaps) {
@@ -93,7 +99,8 @@ export function renderNotes(build) {
   // Bind hover tooltips
   container.querySelectorAll(".notes-mention").forEach((chip) => {
     const type = chip.dataset.type;
-    const id = Number(chip.dataset.id);
+    const rawId = chip.dataset.id;
+    const id = /^\d+$/.test(rawId) ? Number(rawId) : rawId;
     const kind = type === "trait" ? "trait" : type === "skill" ? "skill" : `equip-${type}`;
 
     bindHoverPreview(chip, kind, () => {
@@ -107,6 +114,7 @@ export function renderNotes(build) {
         case "infusion": return infusionById.get(id) || null;
         case "enrichment": return enrichmentById.get(id) || null;
         case "relic": return relicById.get(id) || null;
+        case "weapon": { const w = GW2_WEAPONS_BY_ID.get(id); return w ? { id: w.id, name: w.label, icon: w.icon } : null; }
         case "item": return runeById.get(id) || sigilById.get(id) || foodById.get(id) || utilityById.get(id) || infusionById.get(id) || enrichmentById.get(id) || relicById.get(id) || null;
         default: return null;
       }

--- a/src/site/vite.config.js
+++ b/src/site/vite.config.js
@@ -18,9 +18,15 @@ export default defineConfig({
   server: {
     fs: { allow: [projectRoot] },
   },
+  optimizeDeps: {
+    include: ["@axi/gw2-data", "@axi/gw2-data/engine"],
+  },
   build: {
     outDir: "../../dist/site",
     emptyOutDir: true,
+    commonjsOptions: {
+      include: [/packages\/gw2-data/, /node_modules/],
+    },
     rollupOptions: {
       input: {
         main: path.resolve(__dirname, "index.html"),

--- a/tests/unit/site/render-notes-mentions.test.js
+++ b/tests/unit/site/render-notes-mentions.test.js
@@ -25,7 +25,7 @@ const renderNotesSrc = fs.readFileSync(RENDER_NOTES_PATH, "utf-8");
 const renderBuildSrc = fs.readFileSync(RENDER_BUILD_PATH, "utf-8");
 
 // All categories that the app's notes.js resolveReference handles
-const ALL_CATEGORIES = ["skill", "trait", "rune", "sigil", "food", "utility", "infusion", "enrichment", "relic", "item"];
+const ALL_CATEGORIES = ["skill", "trait", "rune", "sigil", "food", "utility", "infusion", "enrichment", "relic", "item", "weapon"];
 
 describe("SPA render-notes.js — mention category coverage", () => {
   test.each(ALL_CATEGORIES)(
@@ -69,6 +69,23 @@ describe("SPA render-notes.js — lookup map construction", () => {
       expect(renderNotesSrc).toMatch(pattern);
     }
   );
+});
+
+describe("SPA render-notes.js — weapon mention support (issue #186)", () => {
+  test("mention regex accepts non-numeric IDs (e.g. weapon string IDs like 'sword')", () => {
+    // The mention regex must use [\\w]+ (not \\d+) for the ID capture group,
+    // because weapon IDs are strings like "sword", "greatsword", etc.
+    // Extract the regex from the @[category:id:Name] replacement
+    const regexMatch = renderNotesSrc.match(/@\\\[.*?\]\//);
+    // The ID capture group should accept word characters, not just digits
+    expect(renderNotesSrc).toMatch(/@\\\[.*\[\\w\]\+.*\]\//);
+  });
+
+  test("weapon mentions do not require numeric ID conversion", () => {
+    // Weapon IDs are strings — the code should NOT blindly Number() them
+    // Check that there's weapon-specific handling that preserves string IDs
+    expect(renderNotesSrc).toMatch(/weapon/);
+  });
 });
 
 describe("SPA render-notes.js — catalogNotesMentions integration", () => {


### PR DESCRIPTION
## Summary

**Two fixes in this PR:**

### 1. Blank SPA page — `require is not defined` (critical)
The `@axi/gw2-data` workspace package uses CommonJS (`require`/`module.exports`), but Vite skips CJS-to-ESM conversion for linked workspace packages by default. This caused the entire SPA to crash with `require is not defined` on page load.

**Fix:** Added `optimizeDeps.include` and `build.commonjsOptions.include` to `src/site/vite.config.js` so Vite properly converts the CJS engine code during both dev and production builds.

### 2. @Weapons tags not rendering in published builds
The SPA `render-notes.js` had two bugs preventing weapon mentions (`@[weapon:sword:Sword]`) from rendering:

1. **Regex mismatch**: The mention regex used `(\d+)` for the ID capture group, but weapon IDs are strings like `"sword"`. Changed to `([\w]+)` to match both numeric and string IDs.

2. **Missing `case "weapon"` handlers**: The mention-resolve switch and hover-binding switch had no `weapon` case. Added weapon resolution using the existing `GW2_WEAPONS_BY_ID` map from constants.

Closes #186