### PR TITLE
fix: prevent save from deleting equipped weapons

### DIFF
--- a/src/main/gw2Data/catalog.js
+++ b/src/main/gw2Data/catalog.js
@@ -905,7 +905,7 @@ async function getProfessionCatalog(professionId, lang = "en", gameMode = "pve")
     throw new Error("Missing profession id.");
   }
 
-  const cacheKey = `${professionId}:${lang}`;
+  const cacheKey = `${professionId}:${lang}:${gameMode}`;
   if (_catalogCache.has(cacheKey)) return _catalogCache.get(cacheKey);
   if (_catalogInflight.has(cacheKey)) return _catalogInflight.get(cacheKey);
 

--- a/src/renderer/modules/editor.js
+++ b/src/renderer/modules/editor.js
@@ -272,13 +272,19 @@ export function enforceEditorConsistency(options = {}) {
     }
   }
 
-  // Clear weapons that the new profession cannot equip
+  // Clear weapons that the new profession cannot equip.
+  // Guard: only clear when we have weapon data to validate against.  Without
+  // professionWeapons every lookup returns undefined and all weapons are wiped,
+  // which is the root cause of the "save deletes weapons" bug.
   const profWeapons = catalog.professionWeapons || {};
+  const hasProfWeapons = Object.keys(profWeapons).length > 0;
   const equip = state.editor.equipment;
-  if (equip?.weapons) {
+  if (hasProfWeapons && equip?.weapons) {
     for (const [key, weaponId] of Object.entries(equip.weapons)) {
       if (!weaponId) continue;
       const wData = profWeapons[weaponId];
+      // If the weapon isn't in professionWeapons at all, the profession cannot
+      // equip it — clear it.  If it IS present, check flag compatibility.
       const isOffhand = key.startsWith("offhand");
       const isMainhand = key.startsWith("mainhand");
       let valid = false;

--- a/tests/unit/renderer/save-weapons.test.js
+++ b/tests/unit/renderer/save-weapons.test.js
@@ -1,0 +1,199 @@
+"use strict";
+
+const { state, createEmptyEditor } = require("../../../src/renderer/modules/state");
+const { enforceEditorConsistency, loadBuildIntoEditor, serializeEditorToBuild } = require("../../../src/renderer/modules/editor");
+
+function normalizeCatalog(raw) {
+  return {
+    ...raw,
+    specializationById: new Map((raw.specializations || []).map((e) => [Number(e.id), e])),
+    traitById: new Map((raw.traits || []).map((e) => [Number(e.id), e])),
+    skillById: new Map((raw.skills || []).map((e) => [Number(e.id), e])),
+    weaponSkillById: new Map((raw.weaponSkills || []).map((e) => [Number(e.id), e])),
+    legendById: new Map((raw.legends || []).map((e) => [String(e.id), e])),
+    petById: new Map((raw.pets || []).map((e) => [Number(e.id), e])),
+  };
+}
+
+function makeWarriorCatalog() {
+  return normalizeCatalog({
+    specializations: [
+      { id: 4, name: "Strength", elite: false },
+      { id: 36, name: "Arms", elite: false },
+      { id: 18, name: "Berserker", elite: true },
+    ],
+    traits: [],
+    skills: [],
+    weaponSkills: [],
+    legends: [],
+    pets: [],
+    professionWeapons: {
+      greatsword: { flags: ["TwoHand"], specialization: 0, skills: [] },
+      axe: { flags: ["Mainhand", "Offhand"], specialization: 0, skills: [] },
+      sword: { flags: ["Mainhand", "Offhand"], specialization: 0, skills: [] },
+      mace: { flags: ["Mainhand", "Offhand"], specialization: 0, skills: [] },
+      hammer: { flags: ["TwoHand"], specialization: 0, skills: [] },
+      longbow: { flags: ["TwoHand"], specialization: 0, skills: [] },
+      rifle: { flags: ["TwoHand"], specialization: 0, skills: [] },
+      dagger: { flags: ["Mainhand", "Offhand"], specialization: 68, skills: [] },
+      shield: { flags: ["Offhand"], specialization: 0, skills: [] },
+      warhorn: { flags: ["Offhand"], specialization: 0, skills: [] },
+    },
+  });
+}
+
+beforeEach(() => {
+  state.editor = createEmptyEditor("Warrior");
+  state.professions = [{ id: "Warrior", name: "Warrior" }];
+  state.activeCatalog = null;
+});
+
+describe("enforceEditorConsistency — weapon preservation", () => {
+  test("preserves valid weapons for the profession", () => {
+    state.activeCatalog = makeWarriorCatalog();
+    state.editor.equipment.weapons.mainhand1 = "greatsword";
+    state.editor.equipment.weapons.mainhand2 = "axe";
+    state.editor.equipment.weapons.offhand2 = "shield";
+
+    enforceEditorConsistency();
+
+    expect(state.editor.equipment.weapons.mainhand1).toBe("greatsword");
+    expect(state.editor.equipment.weapons.mainhand2).toBe("axe");
+    expect(state.editor.equipment.weapons.offhand2).toBe("shield");
+  });
+
+  test("clears weapons the profession cannot equip", () => {
+    state.activeCatalog = makeWarriorCatalog();
+    state.editor.equipment.weapons.mainhand1 = "scepter"; // Warrior can't use scepter
+
+    enforceEditorConsistency();
+
+    expect(state.editor.equipment.weapons.mainhand1).toBe("");
+  });
+
+  test("clears mainhand weapon that only has Offhand flag", () => {
+    state.activeCatalog = makeWarriorCatalog();
+    state.editor.equipment.weapons.mainhand1 = "shield"; // Shield is offhand only
+
+    enforceEditorConsistency();
+
+    expect(state.editor.equipment.weapons.mainhand1).toBe("");
+  });
+
+  test("clears offhand weapon that only has Mainhand/TwoHand flag", () => {
+    state.activeCatalog = makeWarriorCatalog();
+    state.editor.equipment.weapons.offhand1 = "greatsword"; // Two-handed, not valid offhand
+
+    enforceEditorConsistency();
+
+    expect(state.editor.equipment.weapons.offhand1).toBe("");
+  });
+
+  test("does NOT clear weapons when professionWeapons is empty", () => {
+    state.activeCatalog = normalizeCatalog({
+      specializations: [],
+      traits: [],
+      skills: [],
+      weaponSkills: [],
+      legends: [],
+      pets: [],
+      professionWeapons: {},
+    });
+    state.editor.equipment.weapons.mainhand1 = "greatsword";
+    state.editor.equipment.weapons.mainhand2 = "axe";
+
+    enforceEditorConsistency();
+
+    // Weapons should survive because we can't validate without weapon data
+    expect(state.editor.equipment.weapons.mainhand1).toBe("greatsword");
+    expect(state.editor.equipment.weapons.mainhand2).toBe("axe");
+  });
+
+  test("does NOT clear weapons when catalog has no professionWeapons key", () => {
+    state.activeCatalog = normalizeCatalog({
+      specializations: [],
+      traits: [],
+      skills: [],
+      weaponSkills: [],
+      legends: [],
+      pets: [],
+    });
+    state.editor.equipment.weapons.mainhand1 = "greatsword";
+
+    enforceEditorConsistency();
+
+    expect(state.editor.equipment.weapons.mainhand1).toBe("greatsword");
+  });
+});
+
+describe("save round-trip — weapons survive", () => {
+  test("weapons survive serialize → load → enforceConsistency", async () => {
+    state.activeCatalog = makeWarriorCatalog();
+    state.editor.profession = "Warrior";
+    state.editor.equipment.weapons.mainhand1 = "greatsword";
+    state.editor.equipment.weapons.mainhand2 = "axe";
+    state.editor.equipment.weapons.offhand2 = "warhorn";
+
+    // Serialize (mimics what saveCurrentBuild does)
+    const serialized = serializeEditorToBuild();
+
+    expect(serialized.equipment.weapons.mainhand1).toBe("greatsword");
+    expect(serialized.equipment.weapons.mainhand2).toBe("axe");
+    expect(serialized.equipment.weapons.offhand2).toBe("warhorn");
+
+    // Load back (mimics what loadBuildIntoEditor does, minus _setProfession)
+    await loadBuildIntoEditor(serialized, { captureBaseline: false });
+
+    // Manually set catalog and enforce (since _setProfession is a no-op in tests)
+    state.activeCatalog = makeWarriorCatalog();
+    enforceEditorConsistency();
+
+    expect(state.editor.equipment.weapons.mainhand1).toBe("greatsword");
+    expect(state.editor.equipment.weapons.mainhand2).toBe("axe");
+    expect(state.editor.equipment.weapons.offhand2).toBe("warhorn");
+  });
+
+  test("weapons survive when catalog is missing during enforceConsistency", async () => {
+    state.activeCatalog = makeWarriorCatalog();
+    state.editor.profession = "Warrior";
+    state.editor.equipment.weapons.mainhand1 = "greatsword";
+    state.editor.equipment.weapons.mainhand2 = "axe";
+
+    const serialized = serializeEditorToBuild();
+    await loadBuildIntoEditor(serialized, { captureBaseline: false });
+
+    // Catalog is null (simulates race condition or load failure)
+    state.activeCatalog = null;
+    enforceEditorConsistency();
+
+    // Weapons should survive because enforceEditorConsistency returns early
+    expect(state.editor.equipment.weapons.mainhand1).toBe("greatsword");
+    expect(state.editor.equipment.weapons.mainhand2).toBe("axe");
+  });
+
+  test("weapons survive when catalog has empty professionWeapons during enforceConsistency", async () => {
+    state.activeCatalog = makeWarriorCatalog();
+    state.editor.profession = "Warrior";
+    state.editor.equipment.weapons.mainhand1 = "greatsword";
+    state.editor.equipment.weapons.mainhand2 = "axe";
+
+    const serialized = serializeEditorToBuild();
+    await loadBuildIntoEditor(serialized, { captureBaseline: false });
+
+    // Catalog loaded but professionWeapons is empty (incomplete catalog)
+    state.activeCatalog = normalizeCatalog({
+      specializations: [{ id: 4, name: "Strength", elite: false }],
+      traits: [],
+      skills: [],
+      weaponSkills: [],
+      legends: [],
+      pets: [],
+      professionWeapons: {},
+    });
+    enforceEditorConsistency();
+
+    // Weapons should NOT be cleared — we can't validate without weapon data
+    expect(state.editor.equipment.weapons.mainhand1).toBe("greatsword");
+    expect(state.editor.equipment.weapons.mainhand2).toBe("axe");
+  });
+});


### PR DESCRIPTION
## Summary

When `enforceEditorConsistency()` runs with an empty `professionWeapons` catalog (race condition during save→reload, incomplete load, or missing data), every weapon lookup returns `undefined`, causing `valid` to stay `false` and all equipped weapons to be silently cleared — including their stat selections, sigils, and infusions.

**Root cause:** The weapon-clearing loop at `editor.js:275-306` unconditionally clears any weapon that can't be looked up in `catalog.professionWeapons`. When `professionWeapons` is empty `{}`, *every* weapon fails the lookup and gets wiped.

**Fix:**
1. Guard the weapon-clearing loop: skip entirely when `professionWeapons` has no entries (can't validate without data)
2. Fix the main-process catalog cache key to include `gameMode`, preventing stale catalog reuse across PvE/WvW/PvP mode switches

**Tests:** 9 new tests covering weapon preservation, invalid weapon clearing, and empty-catalog edge cases. All 1485 tests pass.

## Test plan
- [ ] Equip greatsword + axe on a Warrior build, click Save → weapons should persist
- [ ] Switch game modes (PvE ↔ WvW) and verify weapons persist
- [ ] Switch professions and verify incompatible weapons are still cleared
- [ ] Create a new build, equip weapons, save for the first time → weapons persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)