### PR TITLE
fix: clear in-memory catalog cache when user clears API cache

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -24,7 +24,7 @@ const {
   publishSiteBundle,
   deleteFile,
 } = require("./githubApi");
-const { getProfessionList, getProfessionCatalog, getUpgradeCatalog, getWikiSummary, getWikiRelatedData, initDiskCache, clearDiskCache, initWikiClient } = require("./gw2Data");
+const { getProfessionList, getProfessionCatalog, getUpgradeCatalog, getWikiSummary, getWikiRelatedData, initDiskCache, clearDiskCache, initWikiClient, clearCatalogCache } = require("./gw2Data");
 const { slugifyBuildName, generateFileId, generateEncryptionKey, getDefaultBuildName } = require("./buildEncryption");
 const { buildSpaBundle, buildEncryptedBuildFile, buildEncryptedCompFile, buildRedirectFile } = require("./siteBundle");
 const { serializeForPublish } = require("./buildPublish");
@@ -766,7 +766,7 @@ app.whenReady().then(async () => {
     getProfessionCatalog(professionId, "en", gameMode)
   );
   ipcMain.handle("gw2:get-upgrade-catalog", async () => getUpgradeCatalog("en"));
-  ipcMain.handle("gw2:clear-cache", async () => clearDiskCache());
+  ipcMain.handle("gw2:clear-cache", async () => { clearCatalogCache(); return clearDiskCache(); });
   ipcMain.handle("wiki:get-summary", async (_e, title) => getWikiSummary(title));
   ipcMain.handle("wiki:get-related-data", async (_e, title) => getWikiRelatedData(title));
   ipcMain.handle("wiki:resolve-entity-facts", async (_e, entityNames) => {


### PR DESCRIPTION
## Summary
- The clear-cache IPC handler only called `clearDiskCache()`, leaving `_catalogCache` and `_upgradeCatalogCache` stale in memory
- After clearing cache, the app served empty catalog data from memory, resulting in empty weapon dropdowns
- Now also calls `clearCatalogCache()` to flush in-memory caches

## Test plan
- [x] All 1485 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)