### PR TITLE
fix: critical strike calculation (closes #193)

### DIFF
--- a/packages/gw2-data/src/engine/attributes.js
+++ b/packages/gw2-data/src/engine/attributes.js
@@ -489,7 +489,7 @@ function computeAttributes(ctx, catalogs) {
     }
   }
 
-  const critChance = Math.min(100, 5 + (total.Precision - 895) / 21 + furyCritBonus);
+  const critChance = Math.min(100, (total.Precision - 895) / 21 + furyCritBonus);
   const critDamage = 150 + total.Ferocity / 15;
   const conditionDuration = total.Expertise / 15;
   const boonDuration = total.Concentration / 15;

--- a/packages/gw2-data/tests/engine/attributes.test.js
+++ b/packages/gw2-data/tests/engine/attributes.test.js
@@ -183,8 +183,8 @@ describe("computeAttributes", () => {
   test("derived crit chance formula", () => {
     const ctx = makeCtx();
     const result = computeAttributes(ctx, makeCatalogs());
-    // Base precision 1000: critChance = 5 + (1000 - 895) / 21 = 5 + 5 = 10
-    expect(result.derived.critChance).toBeCloseTo(10, 0);
+    // Base precision 1000: critChance = (1000 - 895) / 21 = 5%
+    expect(result.derived.critChance).toBeCloseTo(5, 0);
   });
 
   test("derived armor includes weight class defense", () => {

--- a/src/renderer/modules/equipment.js
+++ b/src/renderer/modules/equipment.js
@@ -1494,7 +1494,7 @@ export function renderEquipmentPanel() {
   const gm = state.editor.gameMode || "pve";
   const furyCritPct = (gm === "wvw" ? FURY_CRIT_CHANCE_WVW : FURY_CRIT_CHANCE) + computeFuryCritModifier(state);
   const furyCrit = _assumedBoons.fury ? furyCritPct : 0;
-  const critChance = Math.min(100, 5 + ((computed.Precision || 1000) - 895) / 21.0 + popMod("Critical Chance") + furyCrit);
+  const critChance = Math.min(100, ((computed.Precision || 1000) - 895) / 21.0 + popMod("Critical Chance") + furyCrit);
   const critDamage = 150 + (computed.Ferocity || 0) / 15.0 + popMod("Critical Damage");
   const condDuration = (computed.Expertise || 0) / 15.0 + popMod("Condition Duration");
   const boonDuration = (computed.Concentration || 0) / 15.0 + popMod("Boon Duration");

--- a/tests/e2e/specs/equipment.spec.js
+++ b/tests/e2e/specs/equipment.spec.js
@@ -1290,11 +1290,10 @@ test.describe("Equipment — Stats Display", () => {
     const statsSection = panel.locator(".equip-section").filter({ hasText: "Attributes" }).first();
 
     // Base Precision = 1000
-    // Crit Chance = 5 + (Precision - 895) / 21.0
-    // = 5 + (1000 - 895) / 21.0
-    // = 5 + 105 / 21.0
-    // = 5 + 5.0
-    // = 10.0%
+    // Crit Chance = (Precision - 895) / 21.0
+    // = (1000 - 895) / 21.0
+    // = 105 / 21.0
+    // = 5.0%
     const precisionRow = statsSection.locator(".equip-stat-row").nth(1); // Precision is second row
     const derivedCell = precisionRow.locator(".equip-stat-cell--derived");
     await expect(derivedCell).toBeVisible();
@@ -1303,7 +1302,7 @@ test.describe("Equipment — Stats Display", () => {
     expect(critLabel.trim()).toBe("Crit Chance");
 
     const critValue = await derivedCell.locator(".equip-stat-value").textContent();
-    expect(critValue.trim()).toBe("10.0%");
+    expect(critValue.trim()).toBe("5.0%");
 
     // Now enable Fury (+25% crit chance) and verify it updates
     const boonsSection = panel.locator(".equip-boons");
@@ -1314,7 +1313,7 @@ test.describe("Equipment — Stats Display", () => {
     await window.waitForTimeout(500);
 
     const critWithFury = await derivedCell.locator(".equip-stat-value").textContent();
-    expect(critWithFury.trim()).toBe("35.0%"); // 10.0% + 25% from Fury
+    expect(critWithFury.trim()).toBe("30.0%"); // 5.0% + 25% from Fury
 
     // The crit value should have the boosted class
     const isBoosted = await derivedCell.locator(".equip-stat-value").evaluate(

--- a/tests/unit/critChance.test.js
+++ b/tests/unit/critChance.test.js
@@ -1,0 +1,63 @@
+"use strict";
+
+/**
+ * Tests for Critical Strike Chance calculation (issue #193).
+ *
+ * GW2 formula at level 80: Critical Chance = (Precision - 895) / 21
+ * Base Precision is 1000, so base crit chance = (1000 - 895) / 21 = 5%.
+ */
+
+const { computeAttributes } = require("@axi/gw2-data/engine");
+
+function makeCtx(overrides = {}) {
+  return {
+    profession: "Warrior",
+    specializations: [],
+    equipment: {
+      slots: {},
+      weapons: {},
+      runes: {},
+      infusions: {},
+      enrichment: null,
+      food: null,
+      utility: null,
+    },
+    gameMode: "pve",
+    underwaterMode: false,
+    activeWeaponSet: 1,
+    skills: {},
+    assumedBoons: null,
+    sigilStacks: null,
+    ...overrides,
+  };
+}
+
+function makeCatalogs() {
+  return {
+    traitById: new Map(),
+    skillById: new Map(),
+    specializationById: new Map(),
+    runeById: new Map(),
+    foodById: new Map(),
+    utilityById: new Map(),
+    sigilById: new Map(),
+    relicById: new Map(),
+  };
+}
+
+describe("Critical Strike Chance formula (issue #193)", () => {
+  test("base precision 1000 gives 5% crit chance, not 10%", () => {
+    const ctx = makeCtx();
+    const result = computeAttributes(ctx, makeCatalogs());
+    // GW2 formula: (1000 - 895) / 21 = 5.0%
+    expect(result.derived.critChance).toBeCloseTo(5.0, 1);
+  });
+
+  test("precision 2000 gives correct crit chance", () => {
+    const ctx = makeCtx();
+    const result = computeAttributes(ctx, makeCatalogs());
+    // With 1000 base precision: (1000 - 895) / 21 ≈ 5.0
+    // The formula should NOT add an extra 5%
+    expect(result.derived.critChance).toBeLessThan(6);
+  });
+});


### PR DESCRIPTION
## Summary

The Critical Strike Chance formula had an erroneous `5 +` term that double-counted the base crit chance. The correct GW2 formula is `(Precision - 895) / 21`, which naturally yields 5% at the base 1000 Precision. The old code added an extra 5% on top, making all crit chance values 5% too high.

Fixed in two locations:
- `packages/gw2-data/src/engine/attributes.js` (engine calculation)
- `src/renderer/modules/equipment.js` (UI display calculation)

Closes #193