### PR TITLE
fix: Weapon swapping adds 1 infusion (closes #201)

### DIFF
--- a/packages/gw2-data/src/engine/attributes.js
+++ b/packages/gw2-data/src/engine/attributes.js
@@ -305,13 +305,25 @@ function computeAttributes(ctx, catalogs) {
 
   // -------------------------------------------------------------------------
   // Step 5: Infusions — per slot, flatMap arrays, lookup infixUpgrade.attributes
+  // For mainhand weapon slots, limit infusion count based on weapon type:
+  // 1H weapons get 1 infusion slot, 2H/aquatic weapons get 2.
   // -------------------------------------------------------------------------
   const infusionStats = zeroStats();
   if (equipment.infusions && catalogs.infusionById) {
     for (const [slotKey, infusionIds] of Object.entries(equipment.infusions)) {
       if (excluded.has(slotKey)) continue;
       const ids = Array.isArray(infusionIds) ? infusionIds : [infusionIds];
-      for (const infId of ids) {
+      // Cap infusion slots for mainhand weapons: 2H = 2, 1H = 1
+      let maxSlots = ids.length;
+      if (slotKey.startsWith("mainhand") || slotKey.startsWith("aquatic")) {
+        const weaponType = weapons[slotKey] || "";
+        if (weaponType && !slotKey.startsWith("aquatic")) {
+          maxSlots = TWO_HAND_WEAPON_TYPES.has(weaponType) ? 2 : 1;
+        }
+      }
+      const limit = Math.min(ids.length, maxSlots);
+      for (let i = 0; i < limit; i++) {
+        const infId = ids[i];
         if (!infId) continue;
         const inf = catalogs.infusionById.get(Number(infId));
         if (!inf?.infixUpgrade?.attributes) continue;

--- a/packages/gw2-data/tests/engine/attributes.test.js
+++ b/packages/gw2-data/tests/engine/attributes.test.js
@@ -166,6 +166,75 @@ describe("computeAttributes", () => {
     expect(result.infusions.Power).toBe(10);
   });
 
+  test("1H mainhand infusions count only 1 slot, not full array length (issue #201)", () => {
+    const catalogs = makeCatalogs({
+      infusionById: new Map([[49431, { name: "+5 Power", infixUpgrade: { attributes: [{ attribute: "Power", modifier: 5 }] } }]]),
+    });
+    // mainhand1 has a 1H weapon (axe) with a 2-entry infusion array both filled
+    const ctx = makeCtx({
+      activeWeaponSet: 1,
+      equipment: {
+        slots: {},
+        weapons: { mainhand1: "axe" },
+        runes: {},
+        infusions: { mainhand1: [49431, 49431] },
+      },
+    });
+    const result = computeAttributes(ctx, catalogs);
+    // Only 1 infusion should be counted for a 1H weapon, not 2
+    expect(result.infusions.Power).toBe(5);
+  });
+
+  test("2H mainhand infusions count both slots (issue #201)", () => {
+    const catalogs = makeCatalogs({
+      infusionById: new Map([[49431, { name: "+5 Power", infixUpgrade: { attributes: [{ attribute: "Power", modifier: 5 }] } }]]),
+    });
+    // mainhand1 has a 2H weapon (greatsword) with both infusion slots filled
+    const ctx = makeCtx({
+      activeWeaponSet: 1,
+      equipment: {
+        slots: {},
+        weapons: { mainhand1: "greatsword" },
+        runes: {},
+        infusions: { mainhand1: [49431, 49431] },
+      },
+    });
+    const result = computeAttributes(ctx, catalogs);
+    // Both infusions should be counted for a 2H weapon
+    expect(result.infusions.Power).toBe(10);
+  });
+
+  test("weapon swap does not change infusion count between 2H and 1H+1H sets (issue #201)", () => {
+    const catalogs = makeCatalogs({
+      infusionById: new Map([[49431, { name: "+5 Power", infixUpgrade: { attributes: [{ attribute: "Power", modifier: 5 }] } }]]),
+    });
+    // Set 1: greatsword (2H) with 2 infusions
+    // Set 2: axe (1H) + axe offhand (1H), each with 1 infusion
+    const baseEquipment = {
+      slots: {},
+      weapons: { mainhand1: "greatsword", mainhand2: "axe", offhand2: "axe" },
+      runes: {},
+      infusions: {
+        mainhand1: [49431, 49431],
+        offhand1: [""],
+        mainhand2: [49431, 49431],  // BUG: both filled by "Fill Infusions"
+        offhand2: [49431],
+      },
+    };
+
+    // Set 1 active: greatsword = 2 infusions
+    const ctx1 = makeCtx({ activeWeaponSet: 1, equipment: { ...baseEquipment } });
+    const result1 = computeAttributes(ctx1, catalogs);
+
+    // Set 2 active: axe+axe = 2 infusions (1 mainhand + 1 offhand)
+    const ctx2 = makeCtx({ activeWeaponSet: 2, equipment: { ...baseEquipment } });
+    const result2 = computeAttributes(ctx2, catalogs);
+
+    // Both sets should contribute the same number of infusion stats
+    expect(result1.infusions.Power).toBe(10);  // 2 infusions × 5 Power
+    expect(result2.infusions.Power).toBe(10);  // 2 infusions × 5 Power (not 3!)
+  });
+
   test("assumed Might boons add Power and ConditionDamage", () => {
     const ctx = makeCtx({ assumedBoons: { might: 25 } });
     const result = computeAttributes(ctx, makeCatalogs());

--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -165,11 +165,18 @@ function computePublishStats(equipment, upgradeCatalog, profession, gameMode) {
       }
     };
 
-    // Infusions
+    // Infusions — cap mainhand weapon slots to 1 infusion for 1H weapons (issue #201)
     const infusions = equipment.infusions || {};
-    for (const v of Object.values(infusions)) {
+    for (const [slotKey, v] of Object.entries(infusions)) {
       const ids = Array.isArray(v) ? v : [v];
-      for (const id of ids) {
+      let maxSlots = ids.length;
+      if (slotKey.startsWith("mainhand")) {
+        const weaponType = weapons[slotKey] || "";
+        if (weaponType && !TWO_HAND_WEAPON_IDS.has(weaponType)) maxSlots = 1;
+      }
+      const limit = Math.min(ids.length, maxSlots);
+      for (let i = 0; i < limit; i++) {
+        const id = ids[i];
         if (!id) continue;
         const def = upgradeCatalog.infusionById?.get(Number(id));
         if (def) addInfixAttributes(def.infixUpgrade);

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -385,18 +385,23 @@ function _buildTimingBadges(entity, alacrity, burstRecharge) {
 }
 
 function _renderStatBreakdown(entries, total, statName) {
+  // Check if any entry has an icon — if so, add a spacer to icon-less rows for alignment
+  const hasAnyIcon = entries.some((e) => e.svgIcon || e.icon);
   const lines = entries.map((e) => {
     let iconHtml = "";
     if (e.svgIcon) {
       iconHtml = `<span class="breakdown-svg-icon">${e.svgIcon}</span>`;
     } else if (e.icon) {
       iconHtml = `<img class="fact-status-icon" src="${escapeHtml(e.icon)}" alt="" aria-hidden="true">`;
+    } else if (hasAnyIcon) {
+      iconHtml = `<span class="breakdown-svg-icon"></span>`;
     }
     const countSuffix = e.count > 1 ? ` <span class="breakdown-count">\u00d7${e.count}</span>` : "";
     const pill = e.category ? `<span class="breakdown-pill breakdown-pill--${e.category}">${e.category}</span>` : "";
     return `<li>${iconHtml}<span class="breakdown-value">+${e.value}</span> ${pill}${escapeHtml(e.source)}${countSuffix}</li>`;
   });
-  lines.push(`<li class="breakdown-total"><span class="breakdown-value">${total}</span> Total ${escapeHtml(statName)}</li>`);
+  const totalSpacer = hasAnyIcon ? `<span class="breakdown-svg-icon"></span>` : "";
+  lines.push(`<li class="breakdown-total">${totalSpacer}<span class="breakdown-value">${total}</span> Total ${escapeHtml(statName)}</li>`);
   return `<ul class="hover-preview__breakdown">${lines.join("")}</ul>`;
 }
 

--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -385,23 +385,12 @@ function _buildTimingBadges(entity, alacrity, burstRecharge) {
 }
 
 function _renderStatBreakdown(entries, total, statName) {
-  // Check if any entry has an icon — if so, add a spacer to icon-less rows for alignment
-  const hasAnyIcon = entries.some((e) => e.svgIcon || e.icon);
   const lines = entries.map((e) => {
-    let iconHtml = "";
-    if (e.svgIcon) {
-      iconHtml = `<span class="breakdown-svg-icon">${e.svgIcon}</span>`;
-    } else if (e.icon) {
-      iconHtml = `<img class="fact-status-icon" src="${escapeHtml(e.icon)}" alt="" aria-hidden="true">`;
-    } else if (hasAnyIcon) {
-      iconHtml = `<span class="breakdown-svg-icon"></span>`;
-    }
     const countSuffix = e.count > 1 ? ` <span class="breakdown-count">\u00d7${e.count}</span>` : "";
     const pill = e.category ? `<span class="breakdown-pill breakdown-pill--${e.category}">${e.category}</span>` : "";
-    return `<li>${iconHtml}<span class="breakdown-value">+${e.value}</span> ${pill}${escapeHtml(e.source)}${countSuffix}</li>`;
+    return `<li><span class="breakdown-value">+${e.value}</span> ${pill}${escapeHtml(e.source)}${countSuffix}</li>`;
   });
-  const totalSpacer = hasAnyIcon ? `<span class="breakdown-svg-icon"></span>` : "";
-  lines.push(`<li class="breakdown-total">${totalSpacer}<span class="breakdown-value">${total}</span> Total ${escapeHtml(statName)}</li>`);
+  lines.push(`<li class="breakdown-total"><span class="breakdown-value">${total}</span> Total ${escapeHtml(statName)}</li>`);
   return `<ul class="hover-preview__breakdown">${lines.join("")}</ul>`;
 }
 

--- a/src/renderer/modules/equipment.js
+++ b/src/renderer/modules/equipment.js
@@ -607,9 +607,12 @@ export function renderEquipmentPanel() {
                 equip.weapons[ofKey] = "";
                 equip.slots[ofKey] = "";
               }
-              // Clear second sigil on the mainhand when swapping to one-handed
+              // Clear second sigil/infusion on the mainhand when swapping to one-handed
               if (!newFlags.includes("TwoHand") && equip.sigils?.[slotDef.key]) {
                 equip.sigils[slotDef.key][1] = "";
+              }
+              if (!newFlags.includes("TwoHand") && Array.isArray(equip.infusions?.[slotDef.key])) {
+                equip.infusions[slotDef.key][1] = "";
               }
               _markEditorChanged();
               renderEquipmentPanel();
@@ -709,7 +712,15 @@ export function renderEquipmentPanel() {
       } else {
         if (!equip.infusions) equip.infusions = {};
         if (Array.isArray(equip.infusions[key])) {
-          equip.infusions[key] = equip.infusions[key].map(() => newVal);
+          // For mainhand weapon slots, only fill infusion slots matching weapon type
+          const weaponType = weapons[key] || "";
+          const wDef = GW2_WEAPONS_BY_ID.get(weaponType);
+          const isTwoHand = wDef?.hand === "two" || (
+            !key.startsWith("offhand") && !key.startsWith("aquatic") &&
+            (state.activeCatalog?.professionWeapons?.[weaponType]?.flags || []).includes("TwoHand")
+          );
+          const maxSlots = key.startsWith("mainhand") && weaponType && !isTwoHand ? 1 : equip.infusions[key].length;
+          equip.infusions[key] = equip.infusions[key].map((_, i) => i < maxSlots ? newVal : "");
         } else {
           equip.infusions[key] = newVal;
         }

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -183,13 +183,21 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
     }
   }
 
-  // Infusions
+  // Infusions — cap mainhand weapon slots to 1 infusion for 1H weapons (issue #201)
   if (upgradeCatalog) {
     const toStatKey = (attr) => attr === "Healing" ? "HealingPower" : attr === "BoonDuration" ? "Concentration" : attr === "ConditionDuration" ? "Expertise" : attr;
     const infusions = state.editor.equipment?.infusions || {};
+    const TWO_HAND_TYPES = new Set(["greatsword", "hammer", "longbow", "shortbow", "rifle", "staff", "spear", "trident", "harpoon-gun"]);
     const allInfusions = Object.entries(infusions)
       .filter(([k]) => !EXCLUDED_SLOTS.has(k))
-      .flatMap(([, v]) => Array.isArray(v) ? v : [v]);
+      .flatMap(([slotKey, v]) => {
+        const ids = Array.isArray(v) ? v : [v];
+        if (slotKey.startsWith("mainhand") && !slotKey.startsWith("aquatic")) {
+          const weaponType = weapons[slotKey] || "";
+          if (weaponType && !TWO_HAND_TYPES.has(weaponType)) return ids.slice(0, 1);
+        }
+        return ids;
+      });
     for (const id of allInfusions) {
       if (!id) continue;
       const def = upgradeCatalog.infusionById?.get(Number(id));


### PR DESCRIPTION
## Summary
Mainhand weapon infusion arrays always have 2 entries in state (to accommodate 2H weapons), but the engine, stat breakdown, and publish stats counted ALL entries regardless of weapon type. When a 1H weapon was equipped and infusions were filled (via "Fill Infusions" or manual selection), both array entries were counted — giving 2 infusions instead of 1 for each 1H mainhand. This caused +1 infusion when swapping from a 2H weapon set (correctly 2 mainhand infusions) to a 1H+OH set (incorrectly 3 weapon infusions instead of 2).

**Fixes across 4 files:**
- **Engine** (`packages/gw2-data/src/engine/attributes.js`): Cap infusion iteration based on `TWO_HAND_WEAPON_TYPES` — 1H mainhands only count the first infusion entry
- **Stat breakdown** (`src/renderer/modules/stats.js`): Same cap for the UI stat detail hover display
- **Publish stats** (`src/main/statsCompute.js`): Same cap for exported/published build stat computation
- **Equipment UI** (`src/renderer/modules/equipment.js`): Clear the 2nd infusion entry when switching mainhand from 2H to 1H, and limit "Fill Infusions" to only fill valid slots based on weapon type

Closes #201