### PR TITLE
feat: allow builds to belong to multiple comps (closes #173)

### DIFF
--- a/src/main/buildStore.js
+++ b/src/main/buildStore.js
@@ -88,14 +88,19 @@ class BuildStore {
     await this.#writeJson(this.buildsPath, builds);
   }
 
-  async clearCompFromBuilds(compIds) {
+  async clearCompFromBuilds(compIdsToRemove) {
     const builds = await this.#readJson(this.buildsPath, []);
+    const removeSet = new Set(compIdsToRemove);
+    let changed = false;
     for (const build of builds) {
-      if (compIds.includes(build.compId)) {
-        build.compId = null;
+      const arr = Array.isArray(build.compIds) ? build.compIds : [];
+      const filtered = arr.filter((id) => !removeSet.has(id));
+      if (filtered.length !== arr.length) {
+        build.compIds = filtered;
+        changed = true;
       }
     }
-    await this.#writeJson(this.buildsPath, builds);
+    if (changed) await this.#writeJson(this.buildsPath, builds);
   }
 
   async getAuth() {
@@ -129,6 +134,20 @@ class BuildStore {
 
   async #writeJson(filePath, data) {
     await fs.writeFile(filePath, JSON.stringify(data, null, 2), "utf8");
+  }
+
+  async migrateCompIdToCompIds() {
+    const raw = await this.#readJson(this.buildsPath, []);
+    if (!Array.isArray(raw)) return;
+    let changed = false;
+    for (const build of raw) {
+      if (typeof build.compId === "string" && build.compId && !Array.isArray(build.compIds)) {
+        build.compIds = [build.compId];
+        delete build.compId;
+        changed = true;
+      }
+    }
+    if (changed) await this.#writeJson(this.buildsPath, raw);
   }
 
   async getSetting(key) {
@@ -173,8 +192,7 @@ function normalizeBuild(input, fallbackCreatedAt) {
     // Library organization fields
     folderId:
       typeof input.folderId === "string" ? input.folderId : null,
-    compId:
-      typeof input.compId === "string" ? input.compId : null,
+    compIds: normalizeCompIds(input),
     pinned: Boolean(input.pinned),
     sortOrder:
       typeof input.sortOrder === "number" && Number.isFinite(input.sortOrder)
@@ -334,6 +352,17 @@ function normalizeImages(value) {
     }
   }
   return result;
+}
+
+function normalizeCompIds(input) {
+  if (Array.isArray(input.compIds)) {
+    return input.compIds.filter((id) => typeof id === "string" && id);
+  }
+  // Migrate legacy single compId to array
+  if (typeof input.compId === "string" && input.compId) {
+    return [input.compId];
+  }
+  return [];
 }
 
 function asString(value, maxLen) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -212,6 +212,7 @@ async function migrateCompGameModes(buildStore, compStore) {
 
 app.whenReady().then(async () => {
   await store.init();
+  await store.migrateCompIdToCompIds();
   await folderStore.init();
   await compStore.init();
   await initDiskCache(dataDir);
@@ -481,14 +482,14 @@ app.whenReady().then(async () => {
       partyLines: [],
     });
 
-    // Create new builds for each unique decoded build, wiring compId immediately
+    // Create new builds for each unique decoded build, wiring compIds immediately
     const newBuildIds = [];
     const buildRefToId = new Map();
     for (const build of decoded.builds) {
       const saved = await store.upsertBuild({
         ...build,
         title: build.title || "Imported Build",
-        compId: comp.id,
+        compIds: [comp.id],
       });
       newBuildIds.push(saved.id);
       buildRefToId.set(build, saved.id);
@@ -654,7 +655,8 @@ app.whenReady().then(async () => {
     }
 
     const allBuilds = await store.listBuilds();
-    const compBuilds = allBuilds.filter((b) => b.compId === compId);
+    const buildIdSet = new Set(comp.buildIds || []);
+    const compBuilds = allBuilds.filter((b) => buildIdSet.has(b.id));
 
     // ── 2. Ensure repo infrastructure ─────────────────────────────────
     progress("repo");

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -69,6 +69,7 @@
           <button class="subnav__item subnav__item--active" data-subtab="build" type="button"><svg class="subnav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.75 13.5L14.25 2.25L12 10.5H20.25L9.75 21.75L12 13.5H3.75Z"/></svg> Build</button>
           <button class="subnav__item" data-subtab="equipment" type="button"><svg class="subnav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M11.4194 15.1694L17.25 21C18.2855 22.0355 19.9645 22.0355 21 21C22.0355 19.9645 22.0355 18.2855 21 17.25L15.1233 11.3733M11.4194 15.1694L13.9155 12.1383C14.2315 11.7546 14.6542 11.5132 15.1233 11.3733M11.4194 15.1694L6.76432 20.8219C6.28037 21.4096 5.55897 21.75 4.79768 21.75C3.39064 21.75 2.25 20.6094 2.25 19.2023C2.25 18.441 2.59044 17.7196 3.1781 17.2357L10.0146 11.6056M15.1233 11.3733C15.6727 11.2094 16.2858 11.1848 16.8659 11.2338C16.9925 11.2445 17.1206 11.25 17.25 11.25C19.7353 11.25 21.75 9.23528 21.75 6.75C21.75 6.08973 21.6078 5.46268 21.3523 4.89779L18.0762 8.17397C16.9605 7.91785 16.0823 7.03963 15.8262 5.92397L19.1024 2.64774C18.5375 2.39223 17.9103 2.25 17.25 2.25C14.7647 2.25 12.75 4.26472 12.75 6.75C12.75 6.87938 12.7555 7.00749 12.7662 7.13411C12.8571 8.20956 12.6948 9.39841 11.8617 10.0845L11.7596 10.1686M10.0146 11.6056L5.90901 7.5H4.5L2.25 3.75L3.75 2.25L7.5 4.5V5.90901L11.7596 10.1686M10.0146 11.6056L11.7596 10.1686M18.375 18.375L15.75 15.75M4.86723 19.125H4.87473V19.1325H4.86723V19.125Z"/></svg> Equipment</button>
           <button class="subnav__item" data-subtab="notes" type="button"><svg class="subnav__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M16.8617 4.48667L18.5492 2.79917C19.2814 2.06694 20.4686 2.06694 21.2008 2.79917C21.9331 3.53141 21.9331 4.71859 21.2008 5.45083L10.5822 16.0695C10.0535 16.5981 9.40144 16.9868 8.68489 17.2002L6 18L6.79978 15.3151C7.01323 14.5986 7.40185 13.9465 7.93052 13.4178L16.8617 4.48667ZM16.8617 4.48667L19.5 7.12499M18 14V18.75C18 19.9926 16.9926 21 15.75 21H5.25C4.00736 21 3 19.9926 3 18.75V8.24999C3 7.00735 4.00736 5.99999 5.25 5.99999H10"/></svg> Notes</button>
+          <button class="subnav__item" data-subtab="comps" type="button"><svg class="subnav__icon" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="1" width="6" height="6" rx="1"/><rect x="9" y="1" width="6" height="6" rx="1"/><rect x="1" y="9" width="6" height="6" rx="1"/><rect x="9" y="9" width="6" height="6" rx="1"/></svg> Comps</button>
           <div class="subnav__actions">
             <span id="saveStatus" class="subnav__save-status"></span>
             <button id="saveBuildBtn" class="btn btn-secondary subnav__save-btn" type="button">
@@ -390,6 +391,11 @@
             <!-- Notes subtab -->
             <div id="subtab-notes" class="subtab hidden">
               <div id="notesPanel"></div>
+            </div>
+
+            <!-- Comps subtab -->
+            <div id="subtab-comps" class="subtab hidden">
+              <div id="compsPanel"></div>
             </div>
 
           </main>

--- a/src/renderer/modules/comps/comp-detail.js
+++ b/src/renderer/modules/comps/comp-detail.js
@@ -644,8 +644,9 @@ function renderPartyLine(pl, idx, totalCap) {
 // ─── Build Pool ──────────────────────────────────────────────────────────────
 
 function renderBuildPool(comp) {
-  // Builds in this comp are those with compId matching
-  const compBuilds = state.builds.filter((b) => b.compId === comp.id);
+  // Builds in this comp are those listed in comp.buildIds
+  const buildIdSet = new Set(comp.buildIds || []);
+  const compBuilds = state.builds.filter((b) => buildIdSet.has(b.id));
   const search = (state.compPoolSearch || "").toLowerCase();
 
   const poolEntries = compBuilds.map((build) => ({ type: "build", build }));
@@ -663,7 +664,19 @@ function renderBuildPool(comp) {
 
   const cards = filtered.map((entry) => {
     if (entry.type === "missing") return renderMissingMiniBuildCard(entry.id);
-    return renderMiniBuildCard(entry.build, state.upgradeCatalog);
+    const b = entry.build;
+    const otherComps = (state.comps || []).filter(
+      (c) => c.id !== comp.id && (c.buildIds || []).includes(b.id),
+    );
+    const totalComps = otherComps.length + 1;
+    const otherNames = otherComps.map((c) => c.name || "Untitled Comp");
+    const tooltip = totalComps === 1
+      ? "Linked build — lives in your library"
+      : `Linked in ${totalComps} comps: ${[comp.name, ...otherNames].join(", ")}`;
+    const label = totalComps > 1 ? `${totalComps} comps` : "linked";
+    return renderMiniBuildCard(b, state.upgradeCatalog, {
+      linkBadge: { label, tooltip },
+    });
   }).join("");
 
   return `
@@ -692,9 +705,10 @@ function openAddBuildModal(comp) {
   const overlay = document.createElement("div");
   overlay.className = "comp-picker-overlay";
 
-  // Available builds: those not already in this comp (and not in another comp)
+  // Available builds: those not already in this comp
+  const currentBuildIds = new Set(comp.buildIds || []);
   const available = state.builds.filter((b) => {
-    if (b.compId) return false;
+    if (currentBuildIds.has(b.id)) return false;
     if (comp.gameMode && b.gameMode !== comp.gameMode) return false;
     return true;
   });
@@ -718,11 +732,16 @@ function openAddBuildModal(comp) {
       const checked = selected.has(b.id) ? "checked" : "";
       const displayName = escapeHtml(getDisplayName(b));
       const gear = escapeHtml(resolveStatPackage(b));
+      const otherCompCount = (b.compIds || []).length;
+      const compBadge = otherCompCount > 0
+        ? `<span class="comp-picker-row__comp-count" title="Used in ${otherCompCount} comp${otherCompCount === 1 ? "" : "s"}">${otherCompCount} comp${otherCompCount === 1 ? "" : "s"}</span>`
+        : "";
       return `
         <label class="comp-picker-row ${pClass}" data-build-id="${escapeHtml(b.id)}">
           <input type="checkbox" class="comp-picker-row__checkbox" value="${escapeHtml(b.id)}" ${checked} />
           <span class="comp-picker-row__icon">${icon}</span>
           <span class="comp-picker-row__name">${displayName}</span>
+          ${compBadge}
           <span class="comp-picker-row__prof">${gear}</span>
         </label>
       `;
@@ -788,11 +807,12 @@ function openAddBuildModal(comp) {
 
     overlay.querySelector("[data-action='picker-add']")?.addEventListener("click", async () => {
       if (selected.size === 0) return;
-      // Move each selected build into this comp
+      // Add this comp to each selected build's compIds
       for (const buildId of selected) {
         const build = state.builds.find((b) => b.id === buildId);
         if (build) {
-          await window.desktopApi.saveBuild({ ...build, compId: comp.id, folderId: null });
+          const newCompIds = [...new Set([...(build.compIds || []), comp.id])];
+          await window.desktopApi.saveBuild({ ...build, compIds: newCompIds });
         }
       }
       // Add to comp's buildIds and lock gameMode if not already set
@@ -802,7 +822,6 @@ function openAddBuildModal(comp) {
         comp.gameMode = firstSelectedBuild?.gameMode || null;
       }
       await saveAndSync(comp);
-      // Reload builds since we modified them
       state.builds = await window.desktopApi.listBuilds();
       overlay.remove();
       _callbacks.onRerender?.();
@@ -1188,10 +1207,11 @@ function bindPoolEvents(container, comp) {
       const buildId = btn.dataset.buildId;
       if (!buildId) return;
 
-      // Clear compId on the build — moves it back to root
+      // Remove this comp from the build's compIds
       const build = state.builds.find((b) => b.id === buildId);
       if (build) {
-        await window.desktopApi.saveBuild({ ...build, compId: null });
+        const newCompIds = (build.compIds || []).filter((id) => id !== comp.id);
+        await window.desktopApi.saveBuild({ ...build, compIds: newCompIds });
       }
 
       // Remove from buildIds and party line slots

--- a/src/renderer/modules/editor.js
+++ b/src/renderer/modules/editor.js
@@ -716,7 +716,8 @@ export async function loadBuildIntoEditor(build, options = {}) {
     activePetSlot: build.activePetSlot === "terrestrial2" ? "terrestrial2" : "terrestrial1",
     gameMode: String(build.gameMode || "pve"),
     folderId: build.folderId || "",
-    compId: build.compId || "",
+    compIds: Array.isArray(build.compIds) ? [...build.compIds] : [],
+    activeCompId: "",
   };
 
   // Expand statPackage into empty slots (e.g. uniform axicode imports)
@@ -876,6 +877,12 @@ export function serializeEditorToBuild() {
     activePetSlot: state.editor.activePetSlot === "terrestrial2" ? "terrestrial2" : "terrestrial1",
     gameMode: String(state.editor.gameMode || "pve"),
     folderId: state.editor.folderId || undefined,
-    compId: state.editor.compId || undefined,
+    compIds: (() => {
+      const ids = [...(state.editor.compIds || [])];
+      if (state.editor.activeCompId && !ids.includes(state.editor.activeCompId)) {
+        ids.push(state.editor.activeCompId);
+      }
+      return ids.length ? ids : undefined;
+    })(),
   };
 }

--- a/src/renderer/modules/library/axicode-io.js
+++ b/src/renderer/modules/library/axicode-io.js
@@ -244,14 +244,14 @@ export async function handleAxicodeImport(targetFolderId, renderLibrary, showToa
       await window.desktopApi.saveBuild(build);
     } else if (action === "copy") {
       const copy = { ...build, id: crypto.randomUUID(), title: nextCopyTitle(build.title, existingBuildTitles) };
-      if (targetFolderId && !build.folderId && !build.compId) copy.folderId = targetFolderId;
+      if (targetFolderId && !build.folderId) copy.folderId = targetFolderId;
       existingBuildTitles.push(copy.title);
       await window.desktopApi.saveBuild(copy);
       undoActions.push({ type: "build", action: "create", id: copy.id });
     } else {
       // No conflict
       const toSave = { ...build };
-      if (targetFolderId && !build.folderId && !build.compId) toSave.folderId = targetFolderId;
+      if (targetFolderId && !build.folderId) toSave.folderId = targetFolderId;
       await window.desktopApi.saveBuild(toSave);
       undoActions.push({ type: "build", action: "create", id: toSave.id });
     }

--- a/src/renderer/modules/library/content.js
+++ b/src/renderer/modules/library/content.js
@@ -141,7 +141,7 @@ function tagPillsHtml(build) {
 }
 
 function compBadgeHtml(comp) {
-  const count = state.builds.filter((b) => b.compId === comp.id).length;
+  const count = (comp.buildIds || []).length;
   const label = count === 1 ? "1 build" : `${count} builds`;
   return `<span class="lib-list-row__badge">${label}</span>`;
 }
@@ -335,7 +335,8 @@ function renderTableView(container) {
   }
 
   function renderTreeComp(c) {
-    const compBuilds = state.builds.filter((b) => b.compId === c.id);
+    const compBuildIdSet = new Set(c.buildIds || []);
+    const compBuilds = state.builds.filter((b) => compBuildIdSet.has(b.id));
     const count = compBuilds.length;
     const countLabel = count === 1 ? "1 build" : `${count} builds`;
     const tags = (c.tags || []).map((t) => escapeHtml(t)).join(", ");
@@ -546,7 +547,8 @@ function renderColumnsView(container) {
     const selectedComp = (state.comps || []).find((c) => c.id === selectedId);
     if (selectedComp) {
       // Comp selected: show its builds in next column, no sub-folders or sub-comps
-      const compBuilds = state.builds.filter((b) => b.compId === selectedId);
+      const selectedCompBuildIds = new Set(selectedComp.buildIds || []);
+      const compBuilds = state.builds.filter((b) => selectedCompBuildIds.has(b.id));
       columns.push({ folders: [], builds: compBuilds, comps: [], parentId: selectedId });
       break; // comps are flat — no further nesting
     }

--- a/src/renderer/modules/library/context-menu.js
+++ b/src/renderer/modules/library/context-menu.js
@@ -29,6 +29,7 @@ import {
   scissorsIcon,
   axiforgeIcon,
   compPlusIcon,
+  squaresIcon,
 } from "./heroicons.js";
 
 let _callbacks = {};
@@ -44,8 +45,9 @@ let _activeSubmenu = null;
 export function initContextMenu(callbacks) {
   _callbacks = callbacks || {};
 
-  document.addEventListener("click", (e) => {
-    if (_activeMenu && !_activeMenu.contains(e.target)) {
+  document.addEventListener("mousedown", (e) => {
+    if (_activeMenu && !_activeMenu.contains(e.target) &&
+        !(_activeSubmenu && _activeSubmenu.contains(e.target))) {
       closeMenu();
     }
   });
@@ -55,6 +57,10 @@ export function initContextMenu(callbacks) {
       closeMenu();
     }
   });
+
+  window.addEventListener("scroll", () => {
+    if (_activeMenu) closeMenu();
+  }, true);
 }
 
 /** Remove any active context menu from the DOM. */
@@ -134,7 +140,7 @@ function showBuildMenu(x, y, buildId, build) {
     _item(globeAltIcon, "Publish", null, () => _callbacks.onPublish?.(buildId)),
     _sep(),
     _item(informationCircleIcon, "Build Info", null, () => _callbacks.onBuildInfo?.(buildId)),
-    _item(trashIcon, "Delete", "Del", () => _callbacks.onDelete?.([buildId]), true),
+    ..._buildUnlinkOrDeleteItems(buildId, build),
   ];
   _showMenu(x, y, items);
 }
@@ -152,7 +158,7 @@ function showMultiSelectMenu(x, y, ids) {
     _item(scissorsIcon, "Cut", "Ctrl+X", () => _callbacks.onCutJson?.(ids)),
     _item(arrowUpTrayIcon, "Export (.axicode)", null, () => _callbacks.onExportAxicode?.("selection")),
     _sep(),
-    _item(trashIcon, `Delete ${count} Builds`, null, () => _callbacks.onDelete?.(ids), true),
+    ..._multiSelectUnlinkOrDeleteItems(ids),
   ];
   _showMenu(x, y, items);
 }
@@ -236,6 +242,75 @@ function showEmptyMenu(x, y) {
     _item(null, "Select All", "Ctrl+A", () => _callbacks.onSelectAll?.()),
   ];
   _showMenu(x, y, items);
+}
+
+// ─── Build unlink / delete items ──────────────────────────────────────────────
+
+function _buildUnlinkOrDeleteItems(buildId, build) {
+  const compIds = Array.isArray(build?.compIds) ? build.compIds : [];
+  const inCompView = state.currentFolder?.type === "comp";
+
+  if (inCompView) {
+    return [
+      _item(squaresIcon, "Unlink from Comp", null, () =>
+        _callbacks.onRemoveBuildFromComp?.(buildId, state.currentFolder.id)),
+    ];
+  }
+
+  const items = [];
+  if (compIds.length > 0) {
+    const comps = (state.comps || []).filter((c) => compIds.includes(c.id));
+    if (comps.length === 1) {
+      const c = comps[0];
+      items.push(
+        _item(squaresIcon, `Unlink from ${escapeHtml(c.name)}`, null, () =>
+          _callbacks.onRemoveBuildFromComp?.(buildId, c.id)),
+      );
+    } else if (comps.length > 1) {
+      items.push(
+        _submenuItem(squaresIcon, `Unlink from Comp (${comps.length})`, comps.map((c) =>
+          _item(null, escapeHtml(c.name), null, () =>
+            _callbacks.onRemoveBuildFromComp?.(buildId, c.id)),
+        )),
+      );
+    }
+  }
+  items.push(_item(trashIcon, "Delete", "Del", () => _callbacks.onDelete?.([buildId]), true));
+  return items;
+}
+
+function _multiSelectUnlinkOrDeleteItems(ids) {
+  const count = ids.length;
+  const inCompView = state.currentFolder?.type === "comp";
+
+  if (inCompView) {
+    return [
+      _item(squaresIcon, `Unlink ${count} Builds`, null, () => {
+        for (const id of ids) _callbacks.onRemoveBuildFromComp?.(id, state.currentFolder.id);
+      }),
+    ];
+  }
+
+  const items = [];
+  const linkedIds = ids.filter((id) => {
+    const b = state.builds.find((x) => x.id === id);
+    return b && Array.isArray(b.compIds) && b.compIds.length > 0;
+  });
+
+  if (linkedIds.length > 0) {
+    items.push(
+      _item(squaresIcon, `Unlink ${linkedIds.length} from Comps`, null, () => {
+        for (const id of linkedIds) {
+          const b = state.builds.find((x) => x.id === id);
+          for (const compId of (b?.compIds || [])) {
+            _callbacks.onRemoveBuildFromComp?.(id, compId);
+          }
+        }
+      }),
+    );
+  }
+  items.push(_item(trashIcon, `Delete ${count} Builds`, null, () => _callbacks.onDelete?.(ids), true));
+  return items;
 }
 
 // ─── Move to Folder submenu items ──────────────────────────────────────────────

--- a/src/renderer/modules/library/folder-store.js
+++ b/src/renderer/modules/library/folder-store.js
@@ -61,7 +61,10 @@ export function getVisibleBuilds() {
   if (folder) {
     if (folder.type === "comp") {
       // Inside a comp: show builds that belong to this comp
-      builds = builds.filter((b) => b.compId === folder.id);
+      const compBuildIds = new Set(
+        (state.comps || []).find((c) => c.id === folder.id)?.buildIds || [],
+      );
+      builds = builds.filter((b) => compBuildIds.has(b.id));
     } else if (folder.id === "__all-comps") {
       // "All Comps" smart folder: no builds shown
       return [];
@@ -73,9 +76,6 @@ export function getVisibleBuilds() {
         (b) => (b.gameMode || "pve") === folder.id,
       );
     } else {
-      // Non-smart views: exclude builds that are inside an existing comp
-      const compIds = new Set((state.comps || []).map((c) => c.id));
-      builds = builds.filter((b) => !b.compId || !compIds.has(b.compId));
       if (folder.type === "custom") {
         builds = builds.filter((b) => b.folderId === folder.id);
       } else if (folder.type === "all") {
@@ -85,8 +85,8 @@ export function getVisibleBuilds() {
       }
     }
   } else {
-    // Root: only show builds not in any folder or comp
-    builds = builds.filter((b) => !b.folderId && !b.compId);
+    // Root: only show builds not in any folder
+    builds = builds.filter((b) => !b.folderId);
   }
 
   // Apply filter dropdowns (multi-select arrays)

--- a/src/renderer/modules/library/library.js
+++ b/src/renderer/modules/library/library.js
@@ -229,7 +229,7 @@ function handleNewBuild() {
   // Preserve current location so the build is saved into the right place
   if (state.editor) {
     if (state.currentFolder?.type === "comp") {
-      state.editor.compId = state.currentFolder.id;
+      state.editor.activeCompId = state.currentFolder.id;
     } else if (state.currentFolder?.type === "custom") {
       state.editor.folderId = state.currentFolder.id;
     }
@@ -347,6 +347,7 @@ async function handleDuplicate(buildId) {
   const copy = { ...build };
   delete copy.id;
   copy.title = `${build.title || "Untitled"} (Copy)`;
+  copy.compIds = [];
   await window.desktopApi.saveBuild(copy);
   state.builds = await window.desktopApi.listBuilds();
   renderLibrary();
@@ -383,7 +384,23 @@ async function handleMoveTo(ids, folderId) {
 async function handleDelete(ids) {
   const count = ids.length;
   const label = count === 1 ? "this build" : `${count} builds`;
-  const confirmed = await showConfirm(`Delete ${label}?`, "This cannot be undone.");
+
+  const affectedComps = new Set();
+  for (const id of ids) {
+    const build = state.builds.find((b) => b.id === id);
+    if (build && Array.isArray(build.compIds)) {
+      for (const cid of build.compIds) affectedComps.add(cid);
+    }
+  }
+  let detail = "This cannot be undone.";
+  if (affectedComps.size > 0) {
+    const compNames = [...affectedComps]
+      .map((cid) => (state.comps || []).find((c) => c.id === cid)?.name || "Untitled Comp")
+      .join(", ");
+    detail = `${count === 1 ? "This build is" : "These builds are"} linked to ${affectedComps.size} comp${affectedComps.size !== 1 ? "s" : ""}: ${compNames}. Deleting will remove ${count === 1 ? "it" : "them"} from ${affectedComps.size === 1 ? "that comp" : "those comps"}. This cannot be undone.`;
+  }
+
+  const confirmed = await showConfirm(`Delete ${label}?`, detail);
   if (!confirmed) return;
   for (const id of ids) {
     await window.desktopApi.deleteBuild(id);
@@ -520,7 +537,8 @@ async function addImportedBuildToActiveComp(saved) {
     showToast(`Build imported but not added to comp (locked to ${modeName}).`, "warning");
     return;
   }
-  await window.desktopApi.saveBuild({ ...saved, compId, folderId: null });
+  const newCompIds = [...new Set([...(saved.compIds || []), compId])];
+  await window.desktopApi.saveBuild({ ...saved, compIds: newCompIds });
   const currentBuildIds = Array.isArray(comp.buildIds) ? [...comp.buildIds] : [];
   if (!currentBuildIds.includes(saved.id)) {
     currentBuildIds.push(saved.id);
@@ -676,7 +694,7 @@ async function handlePasteJson(targetId) {
       // Capture old locations before moving
       const oldLocations = idsToMove.map((id) => {
         const b = state.builds.find((b) => b.id === id);
-        return { id, folderId: b?.folderId || null, compId: b?.compId || null };
+        return { id, folderId: b?.folderId || null, compIds: [...(b?.compIds || [])] };
       });
       // Capture comp state before paste so undo can restore it
       const oldTargetComp = compId ? state.comps?.find((c) => c.id === compId) : null;
@@ -714,9 +732,9 @@ async function handlePasteJson(targetId) {
         for (const id of filteredToMove) {
           const build = state.builds.find((b) => b.id === id);
           if (build) {
-            await window.desktopApi.saveBuild({ ...build, compId, folderId: null });
+            const newCompIds = [...new Set([...(build.compIds || []), compId])];
+            await window.desktopApi.saveBuild({ ...build, compIds: newCompIds });
           }
-          // Also add to comp's buildIds for party line tracking
           const comp = state.comps?.find((c) => c.id === compId);
           if (comp && !(comp.buildIds || []).includes(id)) {
             const newGameMode = comp.gameMode || state.builds.find((b) => b.id === id)?.gameMode || null;
@@ -733,9 +751,9 @@ async function handlePasteJson(targetId) {
         await moveBuilds(idsToMove, folderId);
       }
       pushUndo({ type: "cut-paste", undo: async () => {
-        for (const { id, folderId, compId } of oldLocations) {
+        for (const { id, folderId, compIds } of oldLocations) {
           const build = state.builds.find((b) => b.id === id);
-          if (build) await window.desktopApi.saveBuild({ ...build, folderId, compId });
+          if (build) await window.desktopApi.saveBuild({ ...build, folderId, compIds });
         }
         // Restore comp state if the paste was into a comp
         if (compId && oldTargetCompSnapshot) {
@@ -791,7 +809,7 @@ async function handlePasteJson(targetId) {
       const originalTitle = String(source.title || source.name || "Imported Build");
       const title = nextCopyTitle(originalTitle, existingTitles);
       existingTitles.push(title);
-      const copy = { ...source, title, folderId: compId ? null : folderId, compId: compId || null };
+      const copy = { ...source, title, folderId: folderId || undefined, compIds: compId ? [compId] : [] };
       delete copy.id;
       const saved = await window.desktopApi.saveBuild(copy);
       if (saved?.id) pastedIds.push(saved.id);
@@ -911,9 +929,12 @@ async function handleDuplicateComp(compId) {
 }
 
 async function handleDropBuildsOnComp(buildIds, compId) {
+  const compBuildIdSet = new Set(
+    (state.comps?.find((c) => c.id === compId)?.buildIds) || [],
+  );
   const builds = buildIds
     .map((id) => state.builds.find((b) => b.id === id))
-    .filter((b) => b && b.compId !== compId);
+    .filter((b) => b && !compBuildIdSet.has(b.id));
   if (builds.length === 0) return;
 
   // Game mode lock check against the first incompatible build
@@ -930,11 +951,12 @@ async function handleDropBuildsOnComp(buildIds, compId) {
   const oldStates = builds.map((b) => ({
     id: b.id,
     folderId: b.folderId || null,
-    compId: b.compId || null,
+    compIds: [...(b.compIds || [])],
   }));
 
   for (const build of builds) {
-    await window.desktopApi.saveBuild({ ...build, compId, folderId: null });
+    const newCompIds = [...new Set([...(build.compIds || []), compId])];
+    await window.desktopApi.saveBuild({ ...build, compIds: newCompIds });
   }
   if (comp) {
     let currentBuildIds = Array.isArray(comp.buildIds) ? [...comp.buildIds] : [];
@@ -952,7 +974,7 @@ async function handleDropBuildsOnComp(buildIds, compId) {
   pushUndo({ type: "move-to-comp", undo: async () => {
     for (const old of oldStates) {
       const current = state.builds.find((b) => b.id === old.id);
-      if (current) await window.desktopApi.saveBuild({ ...current, compId: old.compId, folderId: old.folderId });
+      if (current) await window.desktopApi.saveBuild({ ...current, compIds: old.compIds, folderId: old.folderId });
     }
     const c = state.comps?.find((c) => c.id === compId);
     if (c) {
@@ -974,10 +996,11 @@ async function handleRemoveBuildFromComp(buildId, compId) {
   const oldCompBuildIds = comp ? [...(comp.buildIds || [])] : [];
   const oldCompPartyLines = comp ? JSON.parse(JSON.stringify(comp.partyLines || [])) : [];
   const oldGameMode = comp?.gameMode ?? null;
-  // Clear compId on the build — it moves back to root
+  // Remove this comp from the build's compIds
   const build = state.builds.find((b) => b.id === buildId);
   if (build) {
-    await window.desktopApi.saveBuild({ ...build, compId: null });
+    const newCompIds = (build.compIds || []).filter((id) => id !== compId);
+    await window.desktopApi.saveBuild({ ...build, compIds: newCompIds });
   }
   // Also clean up comp's buildIds and party line slots
   if (comp) {
@@ -993,7 +1016,10 @@ async function handleRemoveBuildFromComp(buildId, compId) {
   state.comps = await window.desktopApi.listComps();
   pushUndo({ type: "remove-from-comp", undo: async () => {
     const current = state.builds.find((b) => b.id === buildId);
-    if (current) await window.desktopApi.saveBuild({ ...current, compId });
+    if (current) {
+      const restoredCompIds = [...new Set([...(current.compIds || []), compId])];
+      await window.desktopApi.saveBuild({ ...current, compIds: restoredCompIds });
+    }
     // Restore comp's buildIds and partyLines
     const c = state.comps?.find((c) => c.id === compId);
     if (c) await window.desktopApi.saveComp({ ...c, buildIds: oldCompBuildIds, partyLines: oldCompPartyLines, gameMode: oldGameMode });
@@ -1012,6 +1038,7 @@ async function handleDeleteComps(ids) {
     await window.desktopApi.deleteComp(id);
   }
   state.comps = await window.desktopApi.listComps();
+  state.builds = await window.desktopApi.listBuilds();
   clearSelection();
   renderLibrary();
 }

--- a/src/renderer/modules/mini-build-card.js
+++ b/src/renderer/modules/mini-build-card.js
@@ -105,7 +105,7 @@ function getWeaponSets(build) {
  * @returns {string} HTML string
  */
 export function renderMiniBuildCard(build, upgradeCatalog, options = {}) {
-  const { showActions = true, showMode = true, linkUrl = null, chatLink = null } = options;
+  const { showActions = true, showMode = true, linkUrl = null, chatLink = null, linkBadge = null } = options;
 
   const icon = getSpecIcon(build);
   const pClass = profClass(build.profession);
@@ -215,10 +215,18 @@ export function renderMiniBuildCard(build, upgradeCatalog, options = {}) {
       ? `<a href="${escapeHtml(linkUrl)}" target="_blank" rel="noopener" class="mini-card__name" title="Open build">${name} <span class="mini-card__name-arrow">&#8599;</span></a>`
       : `<span class="mini-card__name">${name}</span>`;
 
+  // Link badge — shows this build is a reference, not owned by the comp
+  const linkBadgeHtml = linkBadge
+    ? `<span class="mini-card__link-badge" title="${escapeHtml(linkBadge.tooltip)}">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+        ${escapeHtml(linkBadge.label)}
+      </span>`
+    : "";
+
   // Remove button — absolute top-right
   const removeHtml = showActions
     ? `<button type="button" class="mini-card__btn-remove" data-action="pool-remove"
-              data-build-id="${escapeHtml(build.id)}" title="Remove from comp">&times;</button>`
+              data-build-id="${escapeHtml(build.id)}" title="Unlink from comp">&times;</button>`
     : "";
 
   // Copy build code button (SPA comp view)
@@ -236,6 +244,7 @@ export function renderMiniBuildCard(build, upgradeCatalog, options = {}) {
       <div class="mini-card__info">
         <div class="mini-card__header">
           ${titleHtml}
+          ${linkBadgeHtml}
           ${tagPills}
           ${role}
           <div class="mini-card__pills">

--- a/src/renderer/modules/render-pages.js
+++ b/src/renderer/modules/render-pages.js
@@ -325,6 +325,7 @@ export function renderEditor() {
   _callbacks.renderSkills();
   _callbacks.renderEquipmentPanel();
   _callbacks.renderNotesPanel();
+  _callbacks.renderCompsPanel();
   _callbacks.renderDetailPanel();
 }
 

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -3,7 +3,7 @@
 // Application-level orchestration (init, wireEvents, setProfession, etc.) lives here.
 
 import { state, createEmptyEditor } from "./modules/state.js";
-import { delay, wireTagInput } from "./modules/utils.js";
+import { delay, wireTagInput, escapeHtml } from "./modules/utils.js";
 import { injectSkeleton } from "./modules/skeleton.js";
 
 let _lastGameMode = "pve";
@@ -51,6 +51,9 @@ import { initSettingsModal, initSettingsCallbacks } from "./modules/settings-mod
 import { initLibrary, renderLibrary, handleLibraryKeydown } from "./modules/library/library.js";
 import { clearUndo as clearLibraryUndo } from "./modules/library/undo.js";
 import { initComps, loadComps, renderComps } from "./modules/comps/comps.js";
+import { getProfessionSvg } from "./modules/profession-icons.js";
+import { getEliteSpecName, profClass } from "./modules/build-helpers.js";
+import { renderMiniBuildCard } from "./modules/mini-build-card.js";
 
 // ── DOM element cache ────────────────────────────────────────────────────────
 
@@ -74,6 +77,7 @@ const el = {
   tagsInput:         q("#tagsInput"),
   equipmentPanel:    q("#equipmentPanel"),
   notesPanel:        q("#notesPanel"),
+  compsPanel:        q("#compsPanel"),
   newBuildBtn:       q("#newBuildBtn"),
   saveBuildBtn:      q("#saveBuildBtn"),
   saveDot:           q("#saveDot"),
@@ -176,6 +180,7 @@ initRenderPagesCallbacks({
   renderSkills,
   renderEquipmentPanel,
   renderNotesPanel,
+  renderCompsPanel,
   renderDetailPanel,
   serializeEditorToBuild,
   parseBuildImportPayload,
@@ -401,8 +406,19 @@ async function startNewBuild(profession, { skipDirtyCheck = false } = {}) {
 
 async function saveCurrentBuild() {
   try {
+    const activeCompId = state.editor.activeCompId;
     const saved = await window.desktopApi.saveBuild(serializeEditorToBuild());
     state.editor.id = saved.id;
+    // If this build was created inside a comp, ensure the comp's buildIds includes it
+    if (activeCompId) {
+      const comp = state.comps?.find((c) => c.id === activeCompId);
+      if (comp && !(comp.buildIds || []).includes(saved.id)) {
+        const newGameMode = comp.gameMode || saved.gameMode || null;
+        await window.desktopApi.saveComp({ ...comp, gameMode: newGameMode, buildIds: [...(comp.buildIds || []), saved.id] });
+        state.comps = await window.desktopApi.listComps();
+      }
+      state.editor.activeCompId = "";
+    }
     await reloadBuilds();
     const savedBuild = state.builds.find((entry) => entry.id === saved.id);
     if (savedBuild) await loadBuildIntoEditor(savedBuild, { captureBaseline: true });
@@ -632,6 +648,139 @@ function navigateToPage(page) {
       document.querySelectorAll(".spec-card__body").forEach((body) => drawSpecConnector(body));
     });
   }
+}
+
+// ── Comps panel (editor tab) ─────────────────────────────────────────────────
+
+const PROF_COLORS = {
+  guardian: "#6ea8ff", warrior: "#ff9944", necromancer: "#4dca7a",
+  engineer: "#cc8844", ranger: "#77cc55", thief: "#cc6677",
+  mesmer: "#b07acc", elementalist: "#dd5555", revenant: "#aa6655",
+};
+
+function _compTabProfIcons(comp) {
+  const specs = [];
+  const seen = new Set();
+  for (const line of (comp.partyLines || [])) {
+    for (const slotBuildId of (line.slots || [])) {
+      if (!slotBuildId) continue;
+      const build = state.builds.find((b) => b.id === slotBuildId);
+      if (!build) continue;
+      const specName = getEliteSpecName(build) || build.profession;
+      if (!specName || seen.has(specName)) continue;
+      seen.add(specName);
+      specs.push({ specName, profession: build.profession });
+      if (specs.length >= 5) break;
+    }
+    if (specs.length >= 5) break;
+  }
+  if (specs.length === 0) return "";
+  return specs.map(({ specName, profession }) => {
+    const svg = getProfessionSvg(specName) || getProfessionSvg(profession) || "";
+    const color = PROF_COLORS[(profession || "").toLowerCase()] || "#888";
+    return `<span class="comp-list-row__prof-icon ${profClass(profession)}" style="background:${color}" title="${escapeHtml(specName)}">${svg}</span>`;
+  }).join("");
+}
+
+function _compTabPartySummary(comp) {
+  const lines = comp.partyLines || [];
+  const parties = lines.length;
+  const slots = lines.reduce((sum, l) => sum + (l.capacity || 0), 0);
+  return `${parties} ${parties === 1 ? "party" : "parties"} &middot; ${slots} ${slots === 1 ? "slot" : "slots"}`;
+}
+
+function renderCompsPanel() {
+  const panel = el.compsPanel;
+  if (!panel) return;
+
+  const compIds = state.editor.compIds || [];
+  const comps = (state.comps || []).filter((c) => compIds.includes(c.id));
+  if (comps.length === 0) {
+    panel.innerHTML = `<div class="comps-tab__empty">
+      <span class="comps-tab__empty-icon"><svg width="32" height="32" viewBox="0 0 16 16" fill="currentColor" opacity="0.3"><rect x="1" y="1" width="6" height="6" rx="1"/><rect x="9" y="1" width="6" height="6" rx="1"/><rect x="1" y="9" width="6" height="6" rx="1"/><rect x="9" y="9" width="6" height="6" rx="1"/></svg></span>
+      <span class="comps-tab__empty-text">This build is not linked to any comps.</span>
+    </div>`;
+    return;
+  }
+
+  const cards = comps.map((c) => {
+    const name = escapeHtml(c.name || "Untitled Comp");
+    const gmBadge = c.gameMode === "pve"
+      ? `<span class="comp-badge comp-badge--sm comp-badge--pve">PvE</span>`
+      : c.gameMode === "wvw"
+        ? `<span class="comp-badge comp-badge--sm comp-badge--wvw">WvW</span>`
+        : "";
+    const profIcons = _compTabProfIcons(c);
+    const summary = _compTabPartySummary(c);
+
+    const allBuildIds = new Set(c.buildIds || []);
+    for (const line of (c.partyLines || [])) {
+      for (const sid of (line.slots || [])) {
+        if (sid) allBuildIds.add(sid);
+      }
+    }
+    const buildCount = allBuildIds.size;
+
+    return `<div class="comps-tab__card" data-comp-id="${escapeHtml(c.id)}">
+      <div class="comps-tab__card-header">
+        <span class="comps-tab__card-name">${name}</span>
+        ${gmBadge}
+        <span class="comps-tab__card-spacer"></span>
+        <span class="comps-tab__card-open" title="Open comp">&#8599;</span>
+      </div>
+      <div class="comps-tab__card-meta">
+        <div class="comp-list-row__prof-icons">${profIcons}</div>
+        ${profIcons ? `<span class="comp-list-row__pipe">|</span>` : ""}
+        <span class="comp-list-row__summary">${summary}</span>
+      </div>
+      <button type="button" class="comps-tab__toggle" data-comp-toggle="${escapeHtml(c.id)}">
+        <svg class="comps-tab__toggle-chevron" width="12" height="12" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 0 1 .02-1.06L11.168 10 7.23 6.29a.75.75 0 1 1 1.04-1.08l4.5 4.25a.75.75 0 0 1 0 1.08l-4.5 4.25a.75.75 0 0 1-1.06-.02Z" clip-rule="evenodd"/></svg>
+        <span>${buildCount} build${buildCount !== 1 ? "s" : ""}</span>
+      </button>
+      <div class="comps-tab__card-builds comps-tab__card-builds--collapsed" data-comp-builds="${escapeHtml(c.id)}"></div>
+    </div>`;
+  }).join("");
+
+  panel.innerHTML = `<div class="comps-tab">
+    <div class="comps-tab__header">Linked Comps <span class="comps-tab__badge">${comps.length}</span></div>
+    <div class="comps-tab__list">${cards}</div>
+  </div>`;
+
+  panel.querySelectorAll(".comps-tab__card-header").forEach((header) => {
+    header.addEventListener("click", () => {
+      const compId = header.closest("[data-comp-id]").dataset.compId;
+      const comp = (state.comps || []).find((c) => c.id === compId);
+      if (!comp) return;
+      state.activeComp = comp;
+      state.compPage = "detail";
+      navigateToPage("comps");
+    });
+  });
+
+  panel.querySelectorAll(".comps-tab__toggle").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const compId = btn.dataset.compToggle;
+      const buildsEl = panel.querySelector(`[data-comp-builds="${compId}"]`);
+      if (!buildsEl) return;
+      const isCollapsed = buildsEl.classList.toggle("comps-tab__card-builds--collapsed");
+      btn.classList.toggle("comps-tab__toggle--open", !isCollapsed);
+      if (!isCollapsed && !buildsEl.dataset.rendered) {
+        const comp = (state.comps || []).find((c) => c.id === compId);
+        if (!comp) return;
+        const allIds = new Set(comp.buildIds || []);
+        for (const line of (comp.partyLines || [])) {
+          for (const sid of (line.slots || [])) { if (sid) allIds.add(sid); }
+        }
+        const html = [...allIds].map((bid) => {
+          const b = state.builds.find((x) => x.id === bid);
+          if (!b) return "";
+          return `<div class="comps-tab__build">${renderMiniBuildCard(b, state.upgradeCatalog, { showActions: false })}</div>`;
+        }).filter(Boolean).join("");
+        buildsEl.innerHTML = html || `<span class="comps-tab__card-empty">No builds</span>`;
+        buildsEl.dataset.rendered = "1";
+      }
+    });
+  });
 }
 
 // ── Event wiring ─────────────────────────────────────────────────────────────
@@ -1025,6 +1174,9 @@ function wireEvents() {
         requestAnimationFrame(() => {
           document.querySelectorAll(".spec-card__body").forEach((body) => drawSpecConnector(body));
         });
+      }
+      if (tab === "comps") {
+        renderCompsPanel();
       }
     });
   });

--- a/src/renderer/styles/comps.css
+++ b/src/renderer/styles/comps.css
@@ -1410,6 +1410,16 @@
   min-width: 0;
 }
 
+.comp-picker-row__comp-count {
+  font-size: 10px;
+  color: var(--text-dim);
+  background: var(--bg-tertiary, rgba(255, 255, 255, 0.08));
+  padding: 1px 6px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 .comp-picker-row__prof {
   font-size: 11px;
   color: var(--text-dim);
@@ -2161,4 +2171,162 @@
 .party-cov__src-target--self {
   background: #4a4a2a;
   color: #dd8;
+}
+
+/* ── Comps Tab (editor subtab) ────────────────────────────────────────────── */
+
+.comps-tab {
+  max-width: 640px;
+}
+
+.comps-tab__header {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-light);
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.comps-tab__badge {
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--hover-subtle);
+  color: var(--text-dim);
+  padding: 1px 7px;
+  border-radius: 8px;
+}
+
+.comps-tab__list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* ── Comp card ────────────────────────────────────────────────────────────── */
+
+.comps-tab__card {
+  background: var(--panel-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line-soft);
+  overflow: hidden;
+}
+
+.comps-tab__card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  cursor: pointer;
+  transition: background 0.12s;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.comps-tab__card-header:hover {
+  background: var(--panel);
+}
+
+.comps-tab__card-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--gold);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.comps-tab__card-spacer {
+  flex: 1;
+}
+
+.comps-tab__card-open {
+  font-size: 13px;
+  color: var(--text-dim);
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.comps-tab__card-header:hover .comps-tab__card-open {
+  opacity: 1;
+}
+
+.comps-tab__card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  padding: 6px 14px;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+/* ── Toggle button ────────────────────────────────────────────────────────── */
+
+.comps-tab__toggle {
+  all: unset;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  font-size: 12px;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: color 0.12s;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.comps-tab__toggle:hover {
+  color: var(--text-light);
+}
+
+.comps-tab__toggle-chevron {
+  transition: transform 0.15s;
+}
+
+.comps-tab__toggle--open .comps-tab__toggle-chevron {
+  transform: rotate(90deg);
+}
+
+/* ── Collapsible build list ───────────────────────────────────────────────── */
+
+.comps-tab__card-builds {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0 0 4px;
+}
+
+.comps-tab__card-builds--collapsed {
+  display: none;
+}
+
+.comps-tab__build {
+  padding: 2px 8px;
+}
+
+.comps-tab__build .mini-card {
+  background: transparent;
+  cursor: default;
+}
+
+.comps-tab__card-empty {
+  font-size: 12px;
+  color: var(--text-dim);
+  padding: 12px 14px;
+}
+
+/* ── Empty state ──────────────────────────────────────────────────────────── */
+
+.comps-tab__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 40px 20px;
+  color: var(--text-dim);
+}
+
+.comps-tab__empty-text {
+  font-size: 13px;
 }

--- a/src/renderer/styles/mini-build-card.css
+++ b/src/renderer/styles/mini-build-card.css
@@ -422,6 +422,26 @@ a.mini-card__name:hover .mini-card__name-arrow {
   background: rgba(197, 72, 95, 0.12);
 }
 
+/* ── Link badge (comp reference indicator) ────────────────────────────────── */
+
+.mini-card__link-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  color: var(--text-dim);
+  background: var(--bg-tertiary, rgba(255, 255, 255, 0.06));
+  padding: 1px 6px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.mini-card__link-badge svg {
+  opacity: 0.7;
+}
+
 /* ── Missing variant ───────────────────────────────────────────────────────── */
 
 .mini-card--missing {

--- a/tests/e2e/helpers/builds.js
+++ b/tests/e2e/helpers/builds.js
@@ -29,7 +29,7 @@ function makeTestBuild(overrides = {}) {
     notes: "",
     images: {},
     folderId: null,
-    compId: null,
+    compIds: [],
     pinned: false,
     sortOrder: 0,
     selectedLegends: ["", ""],

--- a/tests/e2e/specs/compositions.spec.js
+++ b/tests/e2e/specs/compositions.spec.js
@@ -72,12 +72,12 @@ test.describe("Compositions — Party Line Drag-and-Drop", () => {
   });
 
   // Mark builds as belonging to the comp
-  buildA.compId = comp.id;
-  buildB.compId = comp.id;
-  buildC.compId = comp.id;
-  buildD.compId = comp.id;
-  buildE.compId = comp.id;
-  buildF.compId = comp.id;
+  buildA.compIds = [comp.id];
+  buildB.compIds = [comp.id];
+  buildC.compIds = [comp.id];
+  buildD.compIds = [comp.id];
+  buildE.compIds = [comp.id];
+  buildF.compIds = [comp.id];
 
   test.beforeAll(async () => {
     cleanDataDir();
@@ -197,7 +197,7 @@ test.describe("Compositions — Full Party Line Behavior", () => {
     ],
   });
 
-  builds.forEach((b) => { b.compId = comp.id; });
+  builds.forEach((b) => { b.compIds = [comp.id]; });
 
   test.beforeAll(async () => {
     cleanDataDir();
@@ -343,10 +343,10 @@ test.describe("Compositions — Boon Coverage", () => {
     ],
   });
 
-  buildWithElite.compId = comp.id;
-  buildWithoutElite.compId = comp.id;
-  serializedBuild.compId = comp.id;
-  editorBuild.compId = comp.id;
+  buildWithElite.compIds = [comp.id];
+  buildWithoutElite.compIds = [comp.id];
+  serializedBuild.compIds = [comp.id];
+  editorBuild.compIds = [comp.id];
 
   test.beforeAll(async () => {
     cleanDataDir();

--- a/tests/e2e/specs/party-coverage.spec.js
+++ b/tests/e2e/specs/party-coverage.spec.js
@@ -124,10 +124,10 @@ const comp = makeTestComp({
   ],
 });
 
-guardianBuild.compId = comp.id;
-elementalistBuild.compId = comp.id;
-warriorBuild.compId = comp.id;
-necromancerBuild.compId = comp.id;
+guardianBuild.compIds = [comp.id];
+elementalistBuild.compIds = [comp.id];
+warriorBuild.compIds = [comp.id];
+necromancerBuild.compIds = [comp.id];
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 

--- a/tests/e2e/specs/regressions.spec.js
+++ b/tests/e2e/specs/regressions.spec.js
@@ -207,7 +207,7 @@ test.describe("Boon coverage collapsed by default", () => {
     buildIds: [build.id],
     partyLines: [{ id: lineId, capacity: 5, slots: [build.id] }],
   });
-  build.compId = comp.id;
+  build.compIds = [comp.id];
 
   test.beforeAll(async () => {
     cleanDataDir();
@@ -406,12 +406,12 @@ test.describe("Comp regressions — drag-and-drop", () => {
     ],
   });
 
-  buildA.compId = comp.id;
-  buildB.compId = comp.id;
-  buildC.compId = comp.id;
-  buildD.compId = comp.id;
-  buildE.compId = comp.id;
-  buildF.compId = comp.id;
+  buildA.compIds = [comp.id];
+  buildB.compIds = [comp.id];
+  buildC.compIds = [comp.id];
+  buildD.compIds = [comp.id];
+  buildE.compIds = [comp.id];
+  buildF.compIds = [comp.id];
 
   test.beforeAll(async () => {
     cleanDataDir();

--- a/tests/unit/buildStore.test.js
+++ b/tests/unit/buildStore.test.js
@@ -868,17 +868,139 @@ describe("BuildStore — move builds", () => {
     expect(builds.find((b) => b.id === b2.id).folderId).toBe("folder-xyz");
   });
 
-  test("clearCompFromBuilds sets compId to null for matching builds", async () => {
+  test("clearCompFromBuilds removes matching compId from compIds arrays", async () => {
     const b1 = await store.upsertBuild(
-      makeBuild({ title: "B1", compId: "comp-abc" }),
+      makeBuild({ title: "B1", compIds: ["comp-abc", "comp-def"] }),
     );
     const b2 = await store.upsertBuild(
-      makeBuild({ title: "B2", compId: "comp-xyz" }),
+      makeBuild({ title: "B2", compIds: ["comp-xyz"] }),
     );
     await store.clearCompFromBuilds(["comp-abc"]);
     const builds = await store.listBuilds();
-    expect(builds.find((b) => b.id === b1.id).compId).toBe(null);
-    expect(builds.find((b) => b.id === b2.id).compId).toBe("comp-xyz");
+    expect(builds.find((b) => b.id === b1.id).compIds).toEqual(["comp-def"]);
+    expect(builds.find((b) => b.id === b2.id).compIds).toEqual(["comp-xyz"]);
+  });
+});
+
+describe("BuildStore — compIds (multi-comp membership)", () => {
+  let store, dir;
+  beforeEach(async () => ({ store, dir } = await makeTempStore()));
+  afterEach(async () => cleanupDir(dir));
+
+  test("compIds defaults to empty array", async () => {
+    const build = await store.upsertBuild(makeBuild());
+    expect(build.compIds).toEqual([]);
+  });
+
+  test("persists compIds array", async () => {
+    const build = await store.upsertBuild(
+      makeBuild({ compIds: ["comp-a", "comp-b"] }),
+    );
+    expect(build.compIds).toEqual(["comp-a", "comp-b"]);
+    const builds = await store.listBuilds();
+    expect(builds[0].compIds).toEqual(["comp-a", "comp-b"]);
+  });
+
+  test("migrates legacy compId string to compIds array", async () => {
+    const build = await store.upsertBuild(
+      makeBuild({ compId: "comp-legacy" }),
+    );
+    expect(build.compIds).toEqual(["comp-legacy"]);
+    expect(build.compId).toBeUndefined();
+  });
+
+  test("compIds survives update round-trip", async () => {
+    const created = await store.upsertBuild(
+      makeBuild({ compIds: ["comp-a", "comp-b"] }),
+    );
+    const updated = await store.upsertBuild({ ...created, title: "Renamed" });
+    expect(updated.compIds).toEqual(["comp-a", "comp-b"]);
+  });
+
+  test("migrateCompIdToCompIds rewrites legacy compId on disk", async () => {
+    // Write raw JSON with legacy compId field
+    const buildsPath = path.join(dir, "builds.json");
+    await fs.writeFile(buildsPath, JSON.stringify([
+      { id: "b1", title: "Legacy", compId: "comp-old", profession: "Warrior" },
+      { id: "b2", title: "Already migrated", compIds: ["comp-new"], profession: "Guardian" },
+      { id: "b3", title: "No comp", profession: "Thief" },
+    ]));
+
+    await store.migrateCompIdToCompIds();
+
+    // Read raw JSON to verify disk was rewritten
+    const raw = JSON.parse(await fs.readFile(buildsPath, "utf8"));
+    expect(raw[0].compIds).toEqual(["comp-old"]);
+    expect(raw[0].compId).toBeUndefined();
+    expect(raw[1].compIds).toEqual(["comp-new"]);
+    expect(raw[2].compIds).toBeUndefined();
+  });
+
+  test("clearCompFromBuilds removes comp from all builds' compIds", async () => {
+    await store.upsertBuild(
+      makeBuild({ title: "B1", compIds: ["comp-a", "comp-b"] }),
+    );
+    await store.upsertBuild(
+      makeBuild({ title: "B2", compIds: ["comp-a"] }),
+    );
+    await store.upsertBuild(
+      makeBuild({ title: "B3", compIds: ["comp-c"] }),
+    );
+    await store.clearCompFromBuilds(["comp-a"]);
+    const builds = await store.listBuilds();
+    expect(builds.find((b) => b.title === "B1").compIds).toEqual(["comp-b"]);
+    expect(builds.find((b) => b.title === "B2").compIds).toEqual([]);
+    expect(builds.find((b) => b.title === "B3").compIds).toEqual(["comp-c"]);
+  });
+
+  test("normalizeCompIds handles null/undefined/missing gracefully", async () => {
+    const b1 = await store.upsertBuild(makeBuild({ compIds: null }));
+    expect(b1.compIds).toEqual([]);
+
+    const b2 = await store.upsertBuild(makeBuild({ compIds: undefined }));
+    expect(b2.compIds).toEqual([]);
+
+    const b3 = await store.upsertBuild(makeBuild({}));
+    expect(b3.compIds).toEqual([]);
+  });
+
+  test("normalizeCompIds filters out non-string and empty values", async () => {
+    const b = await store.upsertBuild(
+      makeBuild({ compIds: ["comp-a", "", null, 123, "comp-b", undefined] }),
+    );
+    expect(b.compIds).toEqual(["comp-a", "comp-b"]);
+  });
+
+  test("clearCompFromBuilds is a no-op when comp ID does not match any build", async () => {
+    const b1 = await store.upsertBuild(
+      makeBuild({ compIds: ["comp-a"] }),
+    );
+    await store.clearCompFromBuilds(["comp-nonexistent"]);
+    const builds = await store.listBuilds();
+    expect(builds.find((b) => b.id === b1.id).compIds).toEqual(["comp-a"]);
+  });
+
+  test("clearCompFromBuilds handles multiple comp IDs at once", async () => {
+    await store.upsertBuild(makeBuild({ title: "B1", compIds: ["comp-a", "comp-b", "comp-c"] }));
+    await store.clearCompFromBuilds(["comp-a", "comp-c"]);
+    const builds = await store.listBuilds();
+    expect(builds[0].compIds).toEqual(["comp-b"]);
+  });
+
+  test("migrateCompIdToCompIds is idempotent (safe to run twice)", async () => {
+    const raw = [
+      { id: "b1", title: "Legacy", compId: "comp-old", profession: "Warrior" },
+    ];
+    await require("node:fs/promises").writeFile(
+      path.join(dir, "builds.json"), JSON.stringify(raw),
+    );
+    await store.migrateCompIdToCompIds();
+    await store.migrateCompIdToCompIds();
+    const data = JSON.parse(await require("node:fs/promises").readFile(
+      path.join(dir, "builds.json"), "utf-8",
+    ));
+    expect(data[0].compIds).toEqual(["comp-old"]);
+    expect(data[0].compId).toBeUndefined();
   });
 });
 

--- a/tests/unit/renderer/columns-view-comp-dblclick.test.js
+++ b/tests/unit/renderer/columns-view-comp-dblclick.test.js
@@ -65,9 +65,9 @@ describe("Columns view — comp double-click", () => {
     initContent({ onOpenComp });
 
     // Set up state: one comp with one build
-    state.comps = [{ id: "comp-1", name: "Test Comp", folderId: null, sortOrder: 0 }];
+    state.comps = [{ id: "comp-1", name: "Test Comp", folderId: null, sortOrder: 0, buildIds: ["build-1"] }];
     state.builds = [
-      { id: "build-1", title: "Build A", compId: "comp-1", profession: "Guardian" },
+      { id: "build-1", title: "Build A", compIds: ["comp-1"], profession: "Guardian" },
     ];
     state.folders = [];
     state.libraryPrefs = { viewMode: "columns" };

--- a/tests/unit/renderer/serialize-build.test.js
+++ b/tests/unit/renderer/serialize-build.test.js
@@ -9,52 +9,65 @@ beforeEach(() => {
   state.activeCatalog = null;
 });
 
-describe("serializeEditorToBuild — folderId / compId", () => {
+describe("serializeEditorToBuild — folderId / compIds", () => {
   test("includes folderId when set on the editor", () => {
     state.editor.folderId = "folder-abc";
     const result = serializeEditorToBuild();
     expect(result.folderId).toBe("folder-abc");
   });
 
-  test("includes compId when set on the editor", () => {
-    state.editor.compId = "comp-xyz";
+  test("includes compIds when set on the editor", () => {
+    state.editor.compIds = ["comp-xyz", "comp-abc"];
     const result = serializeEditorToBuild();
-    expect(result.compId).toBe("comp-xyz");
+    expect(result.compIds).toEqual(["comp-xyz", "comp-abc"]);
   });
 
-  test("omits folderId and compId when not set", () => {
+  test("includes activeCompId in compIds when set", () => {
+    state.editor.activeCompId = "comp-new";
+    const result = serializeEditorToBuild();
+    expect(result.compIds).toEqual(["comp-new"]);
+  });
+
+  test("activeCompId merges with existing compIds without duplicates", () => {
+    state.editor.compIds = ["comp-a"];
+    state.editor.activeCompId = "comp-a";
+    const result = serializeEditorToBuild();
+    expect(result.compIds).toEqual(["comp-a"]);
+  });
+
+  test("omits folderId and compIds when not set", () => {
     const result = serializeEditorToBuild();
     expect(result.folderId).toBeUndefined();
-    expect(result.compId).toBeUndefined();
+    expect(result.compIds).toBeUndefined();
   });
 });
 
-describe("loadBuildIntoEditor — preserves compId / folderId", () => {
-  test("round-trip: compId and folderId survive load → serialize", async () => {
+describe("loadBuildIntoEditor — preserves compIds / folderId", () => {
+  test("round-trip: compIds and folderId survive load → serialize", async () => {
     const build = {
       id: "build-1",
       title: "My Build",
       profession: "Warrior",
-      compId: "comp-abc",
+      compIds: ["comp-abc"],
       folderId: "folder-def",
     };
     await loadBuildIntoEditor(build, { captureBaseline: false });
     const result = serializeEditorToBuild();
-    expect(result.compId).toBe("comp-abc");
+    expect(result.compIds).toEqual(["comp-abc"]);
     expect(result.folderId).toBe("folder-def");
   });
 
-  test("round-trip: renaming does not lose compId", async () => {
+  test("round-trip: renaming does not lose compIds", async () => {
     const build = {
       id: "build-2",
       title: "Original Name",
       profession: "Warrior",
-      compId: "comp-xyz",
+      compIds: ["comp-xyz"],
     };
     await loadBuildIntoEditor(build, { captureBaseline: false });
     state.editor.title = "Renamed Build";
     const result = serializeEditorToBuild();
     expect(result.title).toBe("Renamed Build");
-    expect(result.compId).toBe("comp-xyz");
+    expect(result.compIds).toEqual(["comp-xyz"]);
   });
 });

--- a/tests/unit/renderer/smart-folder-filtering.test.js
+++ b/tests/unit/renderer/smart-folder-filtering.test.js
@@ -37,7 +37,7 @@ function makeBuild(overrides) {
     profession: overrides.profession || "Guardian",
     gameMode: overrides.gameMode || "pve",
     folderId: overrides.folderId || null,
-    compId: overrides.compId || null,
+    compIds: overrides.compIds || [],
     pinned: overrides.pinned || false,
     sortOrder: overrides.sortOrder || 0,
     tags: overrides.tags || [],
@@ -75,10 +75,10 @@ describe("getVisibleBuilds — smart-profession folder", () => {
 
   test("shows builds that are inside comps", () => {
     state.builds = [
-      makeBuild({ id: "g1", profession: "Guardian", compId: null }),
-      makeBuild({ id: "g2", profession: "Guardian", compId: "comp-1" }),
+      makeBuild({ id: "g1", profession: "Guardian" }),
+      makeBuild({ id: "g2", profession: "Guardian" }),
     ];
-    state.comps = [{ id: "comp-1", name: "Raid Comp" }];
+    state.comps = [{ id: "comp-1", name: "Raid Comp", buildIds: ["g2"] }];
     state.currentFolder = { type: "smart-profession", id: "Guardian" };
 
     const result = getVisibleBuilds();
@@ -124,10 +124,10 @@ describe("getVisibleBuilds — smart-gamemode folder", () => {
 
   test("shows builds that are inside comps", () => {
     state.builds = [
-      makeBuild({ id: "p1", gameMode: "wvw", compId: null }),
-      makeBuild({ id: "p2", gameMode: "wvw", compId: "comp-1" }),
+      makeBuild({ id: "p1", gameMode: "wvw" }),
+      makeBuild({ id: "p2", gameMode: "wvw" }),
     ];
-    state.comps = [{ id: "comp-1", name: "WvW Comp" }];
+    state.comps = [{ id: "comp-1", name: "WvW Comp", buildIds: ["p2"] }];
     state.currentFolder = { type: "smart-gamemode", id: "wvw" };
 
     const result = getVisibleBuilds();
@@ -148,24 +148,12 @@ describe("getVisibleBuilds — smart-gamemode folder", () => {
 });
 
 describe("getVisibleBuilds — all-builds folder", () => {
-  test("excludes builds inside comps", () => {
+  test("shows builds in comps alongside regular builds (comps are references, not containers)", () => {
     state.builds = [
-      makeBuild({ id: "b1", compId: null }),
-      makeBuild({ id: "b2", compId: "comp-1" }),
+      makeBuild({ id: "b1" }),
+      makeBuild({ id: "b2" }),
     ];
-    state.comps = [{ id: "comp-1", name: "Test Comp" }];
-    state.currentFolder = { type: "all" };
-
-    const result = getVisibleBuilds();
-    expect(result.map((b) => b.id)).toEqual(["b1"]);
-  });
-
-  test("shows builds with orphaned compId (comp no longer exists)", () => {
-    state.builds = [
-      makeBuild({ id: "b1", compId: null }),
-      makeBuild({ id: "b2", compId: "deleted-comp" }),
-    ];
-    state.comps = [];
+    state.comps = [{ id: "comp-1", name: "Test Comp", buildIds: ["b2"] }];
     state.currentFolder = { type: "all" };
 
     const result = getVisibleBuilds();


### PR DESCRIPTION
## Summary

- Replaces `build.compId` (single string) with `build.compIds` (array), enabling builds to be linked to multiple compositions simultaneously
- Comps are now references — builds stay in their original library folder/root location and are no longer hidden when linked to a comp
- Adds a **Comps tab** in the build editor showing all linked comps with collapsible build lists, profession icons, and party summaries
- Context menu shows **Unlink from Comp** (with submenu when in multiple comps) alongside Delete, working from both comp view and library view
- Delete confirmation warns which comps will be affected when deleting a build that's linked to comps
- Link badges on mini build cards indicate multi-comp membership
- Context menu now dismisses on scroll and mousedown (matching native OS behavior)
- One-time disk migration converts legacy `compId` fields to `compIds` arrays on app startup
- Duplicated builds do not inherit comp membership

## Files changed (23)

**Data model:** `buildStore.js` (normalizeCompIds, clearCompFromBuilds, migrateCompIdToCompIds), `index.js` (IPC handlers)

**UI:** `renderer.js` (Comps tab), `context-menu.js` (unlink/delete helpers), `comp-detail.js` (add modal, pool rendering), `mini-build-card.js` (link badges), `library.js` (delete warning, duplicate fix, paste/drop handlers), `folder-store.js` (visibility), `editor.js` (compIds state), `content.js` (build counts)

**Styles:** `comps.css` (comp tab cards), `mini-build-card.css` (link badge)

**Tests:** 5 new unit tests for normalizeCompIds edge cases, migration idempotency, clearCompFromBuilds batch operations. All existing tests updated for compIds arrays. 1505 tests passing.

Closes #173

## Test plan

- [ ] Create a build and add it to 2+ comps — verify it appears in both
- [ ] Open the build editor Comps tab — verify both comps listed with correct build counts
- [ ] Click a comp card header — verify it navigates to comp detail view
- [ ] Expand the build list in a comp card — verify all builds shown
- [ ] Right-click a build in the library that's in multiple comps — verify "Unlink from Comp (N)" submenu
- [ ] Right-click a build inside a comp view — verify "Unlink from Comp" shown
- [ ] Delete a build that's in comps — verify warning mentions affected comp names
- [ ] Duplicate a build in a comp — verify the copy is NOT linked to any comps
- [ ] Delete a comp — verify builds' compIds are cleaned up
- [ ] Import a .axicode file with builds that have compIds — verify correct behavior
- [ ] Scroll while context menu is open — verify it closes
- [ ] Click outside context menu — verify it closes on mousedown

🤖 Generated with [Claude Code](https://claude.com/claude-code)