### PR TITLE
fix: Immobilize not registering on Entangle (closes #207)

### DIFF
--- a/packages/gw2-data/src/wiki/parser.js
+++ b/packages/gw2-data/src/wiki/parser.js
@@ -63,7 +63,7 @@ const CONDITIONS = new Set([
   "bleeding",
   "blind", "blinded",
   "burning",
-  "chilled",
+  "chill", "chilled",
   "confusion",
   "cripple", "crippled",
   "fear",

--- a/packages/gw2-data/src/wiki/parser.js
+++ b/packages/gw2-data/src/wiki/parser.js
@@ -61,14 +61,14 @@ const BOONS = new Set([
 
 const CONDITIONS = new Set([
   "bleeding",
-  "blind",
+  "blind", "blinded",
   "burning",
   "chilled",
   "confusion",
-  "crippled",
+  "cripple", "crippled",
   "fear",
-  "immobilize",
-  "poison",
+  "immobilize", "immobilized",
+  "poison", "poisoned",
   "slow",
   "taunt",
   "torment",

--- a/tests/unit/wiki-parser-conditions.test.js
+++ b/tests/unit/wiki-parser-conditions.test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const { mapWikiFactToApiFact, parseAllTaggedFacts } = require("../../packages/gw2-data/src/wiki/parser");
+
+describe("wiki parser condition variants (issue #207)", () => {
+  test("'immobilized' produces Buff fact (Entangle wiki uses this form)", () => {
+    const fact = mapWikiFactToApiFact("immobilized", ["2"], { stacks: "5" }, false, true);
+    expect(fact).toEqual({
+      type: "Buff",
+      text: "Immobilized",
+      status: "Immobilized",
+      duration: 2,
+      apply_count: 5,
+    });
+  });
+
+  test("all condition name variants produce Buff facts", () => {
+    const variants = ["cripple", "blinded", "poisoned", "immobilized"];
+    for (const variant of variants) {
+      const fact = mapWikiFactToApiFact(variant, ["3"], {}, false, true);
+      expect(fact).not.toBeNull();
+      expect(fact.type).toBe("Buff");
+      expect(fact.status).toBeTruthy();
+    }
+  });
+
+  test("Entangle-style wikitext extracts Immobilized as Buff fact", () => {
+    const wikitext = [
+      "{{skill fact|bleeding|8|stacks=5}}",
+      "{{skill fact|immobilized|2|stacks=5}}",
+      "{{skill fact|targets|5}}",
+    ].join("\n");
+    const { facts } = parseAllTaggedFacts(wikitext);
+    const buffFacts = facts.filter((f) => f.type === "Buff");
+    expect(buffFacts).toHaveLength(2);
+    const immobFact = buffFacts.find((f) => f.status === "Immobilized");
+    expect(immobFact).toBeDefined();
+    expect(immobFact.duration).toBe(2);
+    expect(immobFact.apply_count).toBe(5);
+  });
+});

--- a/tests/unit/wiki-parser-conditions.test.js
+++ b/tests/unit/wiki-parser-conditions.test.js
@@ -15,7 +15,7 @@ describe("wiki parser condition variants (issue #207)", () => {
   });
 
   test("all condition name variants produce Buff facts", () => {
-    const variants = ["cripple", "blinded", "poisoned", "immobilized"];
+    const variants = ["chill", "cripple", "blinded", "poisoned", "immobilized"];
     for (const variant of variants) {
       const fact = mapWikiFactToApiFact(variant, ["3"], {}, false, true);
       expect(fact).not.toBeNull();


### PR DESCRIPTION
## Summary

The wiki parser's `CONDITIONS` set only included `"immobilize"` but the GW2 wiki uses `{{skill fact|immobilized|...}}` for Entangle's Immobilize fact. This caused the parser to fall through to the generic Number handler, producing `{type: "Number"}` instead of `{type: "Buff"}`. Since wiki-parsed facts replace API facts in the catalog build, the correct `Immobile` condition data was lost, and the boon/condition coverage panel never showed Immobilize for Entangle.

**Root cause fix:** Added all missing condition name variants (`immobilized`, `blinded`, `cripple`, `poisoned`) to the parser's `CONDITIONS` set so any wiki spelling is recognized correctly. This prevents the same class of bug for other skills that might use alternate condition forms.

Closes #207