### PR TITLE
fix: Attributes show wrong Crit Chance (closes #209)

### DIFF
--- a/packages/gw2-data/data/overrides.json
+++ b/packages/gw2-data/data/overrides.json
@@ -29,5 +29,17 @@
   "trait:1338": {
     "weaponConditional": { "weapons": ["greatsword", "spear"], "multiplier": 2 },
     "description": "Forceful Greatsword: double Power bonus while wielding greatsword or underwater spear"
+  },
+  "trait:1011": {
+    "ignoreCritChance": true,
+    "description": "Precise Strike: 100% crit chance applies to Opening Strike only, not passive"
+  },
+  "trait:1215": {
+    "ignoreCritChance": true,
+    "description": "Hidden Killer: 100% crit chance applies while stealthed only, not passive"
+  },
+  "trait:1336": {
+    "ignoreCritChance": true,
+    "description": "Burst Precision: 100% crit chance applies to Burst skills only, not passive"
   }
 }

--- a/packages/gw2-data/src/engine/modifiers.js
+++ b/packages/gw2-data/src/engine/modifiers.js
@@ -198,7 +198,8 @@ function collectModifiers(ctx, catalogs, overrides) {
     // 6. "Critical Chance Increase" Percent facts — critChance
     //    Fury traits: condition = "fury" (applied only when fury is assumed)
     //    Non-fury/non-berserk traits: condition = null (passive, always active)
-    {
+    //    Skip traits with ignoreCritChance (skill-specific crit like Opening Strike, stealth, bursts)
+    if (!override?.ignoreCritChance) {
       const critFacts = modeFacts.filter(
         (f) => f.type === "Percent" && f.text === "Critical Chance Increase" && f.percent
       );

--- a/packages/gw2-data/tests/engine/modifiers.test.js
+++ b/packages/gw2-data/tests/engine/modifiers.test.js
@@ -497,6 +497,29 @@ describe("collectModifiers()", () => {
     expect(mightMods[0]).toMatchObject({ power: 40, condition: null });
   });
 
+  it("ignores critChance for traits with ignoreCritChance override (issue #209)", () => {
+    // Traits like Precise Strike (1011), Hidden Killer (1215), and Burst Precision (1336)
+    // have percent:100 "Critical Chance Increase" facts that represent skill-specific bonuses,
+    // not passive crit chance increases. They must be excluded.
+    const traitId = 1011;
+    const trait = {
+      slot: "Minor",
+      description: "Opening Strike has an increased chance to critically strike.",
+      facts: [
+        { type: "Percent", text: "Critical Chance Increase", percent: 100 },
+      ],
+    };
+    const catalogs = makeCatalogs({ [traitId]: trait }, { 8: { minorTraits: [1011] } });
+    const ctx = makeCtx([{ specializationId: 8, majorChoices: {} }]);
+    const overrides = makeOverrides({
+      "trait:1011": { ignoreCritChance: true },
+    });
+
+    const mods = collectModifiers(ctx, catalogs, overrides);
+    const critMods = mods.filter((m) => m.type === "critChance");
+    expect(critMods).toHaveLength(0);
+  });
+
   it("collects passive critChance from non-fury traits (Pinnacle of Strength)", () => {
     const traitId = 1453;
     const trait = {

--- a/tests/unit/critChance.test.js
+++ b/tests/unit/critChance.test.js
@@ -61,3 +61,77 @@ describe("Critical Strike Chance formula (issue #193)", () => {
     expect(result.derived.critChance).toBeLessThan(6);
   });
 });
+
+describe("Skill-specific crit traits must not inflate crit chance (issue #209)", () => {
+  test("Precise Strike (trait 1011) does not add 100% crit chance", () => {
+    // Trait 1011 "Opening Strike has an increased chance to critically strike"
+    // The percent:100 fact means Opening Strike gets 100% crit, NOT a passive bonus
+    const catalogs = makeCatalogs();
+    catalogs.traitById = new Map([
+      [1011, {
+        id: 1011,
+        slot: "Minor",
+        description: "Opening Strike has an increased chance to critically strike.",
+        facts: [
+          { type: "Percent", text: "Critical Chance Increase", percent: 100 },
+        ],
+      }],
+    ]);
+    catalogs.specializationById = new Map([
+      [8, { minorTraits: [1011] }],
+    ]);
+
+    const ctx = makeCtx({
+      profession: "Ranger",
+      specializations: [{ specializationId: 8, majorChoices: {} }],
+    });
+
+    const result = computeAttributes(ctx, catalogs);
+    // Base crit is ~5%. With the bug, this would be 100%.
+    expect(result.derived.critChance).toBeLessThan(10);
+  });
+
+  test("Hidden Killer (trait 1215) does not add 100% crit chance", () => {
+    const catalogs = makeCatalogs();
+    catalogs.traitById = new Map([
+      [1215, {
+        id: 1215,
+        slot: "Major",
+        description: "Gain bonus critical-hit chance while stealthed.",
+        facts: [
+          { type: "Percent", text: "Critical Chance Increase", percent: 100 },
+        ],
+      }],
+    ]);
+
+    const ctx = makeCtx({
+      profession: "Thief",
+      specializations: [{ id: 35, majorChoices: { 3: 1215 } }],
+    });
+
+    const result = computeAttributes(ctx, catalogs);
+    expect(result.derived.critChance).toBeLessThan(10);
+  });
+
+  test("Burst Precision (trait 1336) does not add 100% crit chance", () => {
+    const catalogs = makeCatalogs();
+    catalogs.traitById = new Map([
+      [1336, {
+        id: 1336,
+        slot: "Major",
+        description: "Burst skills have an increased critical chance.",
+        facts: [
+          { type: "Percent", text: "Critical Chance Increase", percent: 100 },
+        ],
+      }],
+    ]);
+
+    const ctx = makeCtx({
+      profession: "Warrior",
+      specializations: [{ id: 36, majorChoices: { 3: 1336 } }],
+    });
+
+    const result = computeAttributes(ctx, catalogs);
+    expect(result.derived.critChance).toBeLessThan(10);
+  });
+});


### PR DESCRIPTION
## Summary
Three traits — Precise Strike (1011), Hidden Killer (1215), and Burst Precision (1336) — have `percent: 100` "Critical Chance Increase" facts that represent skill-specific bonuses (Opening Strike crit, stealth crit, Burst skill crit), not passive crit chance increases. The modifiers system incorrectly treated them as passive bonuses, inflating displayed crit chance to 100%.

**Fix:** Added `ignoreCritChance: true` overrides for all three traits, and updated the modifiers module to skip "Critical Chance Increase" facts when this override is set. This follows the existing override pattern (similar to `petStatOnly`, `mightOverride`, etc.).

**Tests:** Added 3 regression tests in `tests/unit/critChance.test.js` and 1 unit test in `packages/gw2-data/tests/engine/modifiers.test.js`.

Closes #209