### PR TITLE
feat: Activate Signet (closes #210)

### DIFF
--- a/packages/gw2-data/src/engine/attributes.js
+++ b/packages/gw2-data/src/engine/attributes.js
@@ -360,9 +360,18 @@ function computeAttributes(ctx, catalogs) {
       ctx.skills.eliteId,
     ].filter(Boolean).map(Number);
 
+    // Signet passives can be toggled off per-signet (e.g., to simulate active use).
+    // Absent/null activeSignets means all passives apply (backward compatible).
+    const activeSignets = ctx.activeSignets;
+    const isPassiveActive = (id) => {
+      if (!activeSignets) return true;
+      const v = activeSignets instanceof Map ? activeSignets.get(id) : activeSignets[id];
+      return v !== false;
+    };
+
     for (const skillId of skillIds) {
       const buff = SIGNET_PASSIVE_BUFFS.get(skillId);
-      if (buff && buff.stat in signetStats) {
+      if (buff && buff.stat in signetStats && isPassiveActive(skillId)) {
         signetStats[buff.stat] += buff.value;
       }
     }

--- a/packages/gw2-data/tests/engine/attributes.test.js
+++ b/packages/gw2-data/tests/engine/attributes.test.js
@@ -319,6 +319,44 @@ describe("computeAttributes", () => {
     expect(result.signets.Power).toBe(180);
   });
 
+  test("signet passive applied when activeSignets entry is true", () => {
+    const ctx = makeCtx({
+      skills: { healId: null, utilityIds: [9093], eliteId: null },
+      activeSignets: { 9093: true },
+    });
+    const result = computeAttributes(ctx, makeCatalogs());
+    expect(result.signets.Power).toBe(180);
+  });
+
+  test("signet passive skipped when activeSignets entry is false", () => {
+    const ctx = makeCtx({
+      skills: { healId: null, utilityIds: [9093], eliteId: null },
+      activeSignets: { 9093: false },
+    });
+    const result = computeAttributes(ctx, makeCatalogs());
+    expect(result.signets.Power).toBe(0);
+  });
+
+  test("signet passive applied when activeSignets is null (backward compat)", () => {
+    const ctx = makeCtx({
+      skills: { healId: null, utilityIds: [9093], eliteId: null },
+      activeSignets: null,
+    });
+    const result = computeAttributes(ctx, makeCatalogs());
+    expect(result.signets.Power).toBe(180);
+  });
+
+  test("activeSignets toggle is per-signet", () => {
+    // Bane Signet (9093) = +180 Power; Signet of Stone (12500) = +180 Toughness
+    const ctx = makeCtx({
+      skills: { healId: null, utilityIds: [9093, 12500], eliteId: null },
+      activeSignets: { 9093: true, 12500: false },
+    });
+    const result = computeAttributes(ctx, makeCatalogs());
+    expect(result.signets.Power).toBe(180);
+    expect(result.signets.Toughness).toBe(0);
+  });
+
   test("Pinnacle of Strength adds +10 Power per Might stack (40 instead of 30)", () => {
     const catalogs = makeCatalogs({
       traitById: new Map([[1453, {

--- a/src/renderer/modules/engine-bridge.js
+++ b/src/renderer/modules/engine-bridge.js
@@ -39,7 +39,7 @@ function getOverrides() {
 /**
  * Transform renderer state.editor into the engine's build context shape.
  */
-export function buildEngineCtx(state, assumedBoons = null, sigilStacks = null) {
+export function buildEngineCtx(state, assumedBoons = null, sigilStacks = null, activeSignets = null) {
   const editor = state.editor || {};
   const equipment = editor.equipment || {};
   const isUnderwater = Boolean(editor.underwaterMode);
@@ -74,6 +74,7 @@ export function buildEngineCtx(state, assumedBoons = null, sigilStacks = null) {
     skills: isUnderwater ? (editor.underwaterSkills || {}) : (editor.skills || {}),
     assumedBoons,
     sigilStacks,
+    activeSignets,
     berserkActive,
   };
 }
@@ -101,8 +102,8 @@ export function buildEngineCatalogs(state) {
  * { base, equipment, food, runes, infusions, enrichment, utility, signets,
  *   traits, conversions, boons, sigils, total, derived }
  */
-export function computeStats(state, assumedBoons = null, sigilStacks = null) {
-  const ctx = buildEngineCtx(state, assumedBoons, sigilStacks);
+export function computeStats(state, assumedBoons = null, sigilStacks = null, activeSignets = null) {
+  const ctx = buildEngineCtx(state, assumedBoons, sigilStacks, activeSignets);
   const catalogs = buildEngineCatalogs(state);
   return computeAttributes(ctx, catalogs);
 }

--- a/src/renderer/modules/equipment.js
+++ b/src/renderer/modules/equipment.js
@@ -11,7 +11,7 @@ import {
 } from "./constants.js";
 import { escapeHtml } from "./utils.js";
 import { computeSlotStats, computeUpgradeModifiers, computeStatBreakdown } from "./stats.js";
-import { computeStats, computeBoons, computeFuryCritModifier, computePassiveCritModifier, computeFuryStatBonuses, computeMightPerStack, FURY_CRIT_CHANCE, FURY_CRIT_CHANCE_WVW, STACKING_SIGIL_DEFS } from "./engine-bridge.js";
+import { computeStats, computeBoons, computeFuryCritModifier, computePassiveCritModifier, computeFuryStatBonuses, computeMightPerStack, FURY_CRIT_CHANCE, FURY_CRIT_CHANCE_WVW, STACKING_SIGIL_DEFS, SIGNET_PASSIVE_BUFFS } from "./engine-bridge.js";
 import { bindHoverPreview, selectDetail } from "./detail-panel.js";
 import { getProfessionSvg } from "./profession-icons.js";
 import { getSlotSvg } from "./slot-icons.js";
@@ -45,6 +45,12 @@ export function resetAssumedBoons() {
 let _sigilStacks = {};
 export function getSigilStacks() { return _sigilStacks; }
 export function resetSigilStacks() { _sigilStacks = {}; }
+
+// Signet passive toggles — session-only, not persisted to builds.
+// { [skillId: number]: boolean }. Missing entry = passive active (default ON).
+let _activeSignets = {};
+export function getActiveSignets() { return _activeSignets; }
+export function resetActiveSignets() { _activeSignets = {}; }
 
 let _boonsExpanded = false;
 
@@ -1491,9 +1497,96 @@ export function renderEquipmentPanel() {
     boonsSection.append(sigilBar);
   }
 
+  // Signet passive toggles — show icons for equipped stat-granting signets.
+  // Default ON (passive active); toggle OFF simulates using the active (passive disabled).
+  const isUnderwaterSignets = Boolean(state.editor.underwaterMode);
+  const activeSkillSlots = isUnderwaterSignets
+    ? (state.editor.underwaterSkills || {})
+    : (state.editor.skills || {});
+  const equippedSignetIds = [
+    activeSkillSlots.healId,
+    ...(activeSkillSlots.utilityIds || []),
+    activeSkillSlots.eliteId,
+  ].filter(Boolean).map(Number).filter((id) => SIGNET_PASSIVE_BUFFS.has(id));
+
+  // Clean up toggle state for signets no longer equipped
+  for (const key of Object.keys(_activeSignets)) {
+    if (!equippedSignetIds.includes(Number(key))) delete _activeSignets[key];
+  }
+
+  if (equippedSignetIds.length > 0) {
+    const signetLabel = document.createElement("div");
+    signetLabel.className = "equip-boons__sigil-label";
+    signetLabel.textContent = "Signet Passives";
+    boonsSection.append(signetLabel);
+
+    const signetBar = document.createElement("div");
+    signetBar.className = "equip-boons__bar equip-boons__bar--sigils";
+
+    const STAT_LABELS = {
+      Power: "Power", Precision: "Precision", Toughness: "Toughness", Vitality: "Vitality",
+      Ferocity: "Ferocity", ConditionDamage: "Condition Damage", HealingPower: "Healing Power",
+      Concentration: "Concentration", Expertise: "Expertise",
+    };
+
+    for (const skillId of equippedSignetIds) {
+      const buff = SIGNET_PASSIVE_BUFFS.get(skillId);
+      const skillData = state.activeCatalog?.skillById?.get(skillId);
+      const name = skillData?.name || `Signet ${skillId}`;
+      const icon = skillData?.icon || "";
+      const isActive = _activeSignets[skillId] !== false;
+      const statLabel = STAT_LABELS[buff.stat] || buff.stat;
+
+      const item = document.createElement("div");
+      item.className = "equip-boons__item";
+
+      const iconWrap = document.createElement("div");
+      iconWrap.className = "equip-boons__icon equip-boons__icon--sigil" + (isActive ? " equip-boons__icon--on" : "");
+
+      if (icon) {
+        const img = document.createElement("img");
+        img.src = icon;
+        img.alt = name;
+        img.width = 28;
+        img.height = 28;
+        iconWrap.append(img);
+      }
+
+      // Tooltip
+      const tooltip = document.createElement("div");
+      tooltip.className = "equip-boons__tooltip";
+      tooltip.innerHTML = isActive
+        ? `<div class="equip-boons__tip-title">${escapeHtml(name)}</div>`
+          + `<div class="equip-boons__tip-effect">+${buff.value} ${statLabel}</div>`
+          + `<div class="equip-boons__tip-note">Passive active. Click to simulate using the active (disables passive).</div>`
+        : `<div class="equip-boons__tip-title">${escapeHtml(name)}</div>`
+          + `<div class="equip-boons__tip-note">Passive disabled (simulating active use). Click to re-enable +${buff.value} ${statLabel}.</div>`;
+      item.append(tooltip);
+
+      // Click handlers — click or right-click toggles
+      const toggle = () => {
+        _activeSignets[skillId] = !(_activeSignets[skillId] !== false);
+        _render();
+      };
+      iconWrap.addEventListener("click", toggle);
+      iconWrap.addEventListener("contextmenu", (e) => { e.preventDefault(); toggle(); });
+
+      item.append(iconWrap);
+
+      const label = document.createElement("div");
+      label.className = "equip-boons__label" + (isActive ? " equip-boons__label--on" : "");
+      label.textContent = name;
+      item.append(label);
+
+      signetBar.append(item);
+    }
+
+    boonsSection.append(signetBar);
+  }
+
   // Attributes
   const statsSection = makeSection("Attributes");
-  const statsResult = computeStats(state, _assumedBoons, _sigilStacks);
+  const statsResult = computeStats(state, _assumedBoons, _sigilStacks, _activeSignets);
   const computed = statsResult.total;
   const traitBonuses = statsResult.conversions;
   const professionName = state.editor.profession;
@@ -1543,7 +1636,7 @@ export function renderEquipmentPanel() {
     leftEl.innerHTML = `<span class="equip-stat-label">${row.stat}</span><span class="equip-stat-value${isBoosted ? " equip-stat-value--boosted" : ""}">${(row.value || 0).toLocaleString()}</span>`;
 
     bindHoverPreview(leftEl, "equip-stat", () => {
-      const breakdown = computeStatBreakdown(row.key, _assumedBoons, _sigilStacks);
+      const breakdown = computeStatBreakdown(row.key, _assumedBoons, _sigilStacks, _activeSignets);
       if (!breakdown.length) return null;
       // Consolidate duplicate sources (e.g. 18x identical infusions → one line)
       const grouped = new Map();

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -117,7 +117,7 @@ function getExcludedSlots() {
  * Returns an array of { source: string, value: number } entries.
  * This is a UI-only function for hover tooltips.
  */
-export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks = null) {
+export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks = null, activeSignets = null) {
   const entries = [];
   const BASE_STATS = new Set(["Power", "Precision", "Toughness", "Vitality"]);
   if (BASE_STATS.has(statKey)) entries.push({ source: "Base", value: 1000, category: "base" });
@@ -254,7 +254,7 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
     if (utilDef) {
       const MAP = { "Condition Damage": "ConditionDamage", "Healing Power": "HealingPower" };
       // Percentage conversions — use engine totals for source stats
-      const totals = computeStats(state, assumedBoons, sigilStacks).total;
+      const totals = computeStats(state, assumedBoons, sigilStacks, activeSignets).total;
       const convRe = /Gain (Condition Damage|Healing Power|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise) Equal to (\d+(?:\.\d+)?)% of Your (Condition Damage|Healing Power|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise)/g;
       let m;
       while ((m = convRe.exec(utilDef.buff)) !== null) {
@@ -289,9 +289,14 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
     ...(skills.utilityIds || []),
     skills.eliteId,
   ].filter(Boolean).map(Number);
+  const isSignetPassiveActive = (id) => {
+    if (!activeSignets) return true;
+    const v = activeSignets instanceof Map ? activeSignets.get(id) : activeSignets[id];
+    return v !== false;
+  };
   for (const skillId of signetSkillIds) {
     const buff = SIGNET_PASSIVE_BUFFS.get(skillId);
-    if (buff && buff.stat === statKey) {
+    if (buff && buff.stat === statKey && isSignetPassiveActive(skillId)) {
       const catalog = state.activeCatalog;
       const skillData = catalog?.skillById?.get(skillId);
       const name = skillData?.name || `Signet (${skillId})`;
@@ -320,7 +325,7 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
   }
 
   // Passive trait flat stat bonuses — per-trait breakdown from engine
-  const engineResult = computeStats(state, assumedBoons, sigilStacks);
+  const engineResult = computeStats(state, assumedBoons, sigilStacks, activeSignets);
   if (engineResult.traitDetails) {
     for (const detail of engineResult.traitDetails) {
       if (detail.target === statKey && detail.value) {

--- a/tests/e2e/specs/equipment.spec.js
+++ b/tests/e2e/specs/equipment.spec.js
@@ -1452,3 +1452,161 @@ test.describe("Assumed Boons — trait AttributeConversion", () => {
     await window.waitForTimeout(300);
   });
 });
+
+// ─── Section 6I: Signet Passives ────────────────────────────────────────────
+
+test.describe("Equipment — Signet Passives", () => {
+  let app, window;
+
+  test.beforeAll(async () => {
+    ({ app, window } = await launchApp());
+    await goToEditor(window);
+    await selectProfession(window, "Necromancer");
+
+    // Equip Signet of Spite (id 10622, +180 Power) in the first utility slot.
+    const utilGroup = window.locator(".skill-group--utilities");
+    await expect(utilGroup).toBeVisible({ timeout: 5000 });
+    const utilitySlot = utilGroup.locator(".skill-slot").nth(1);
+    await utilitySlot.locator(".skill-icon-large").click();
+
+    const cselectOpen = window.locator(".cselect--skill-slot.cselect--open");
+    await expect(cselectOpen).toBeVisible({ timeout: 5000 });
+    await cselectOpen
+      .locator('.cselect__option:has-text("Signet of Spite")')
+      .first()
+      .click();
+    await window.waitForTimeout(500);
+
+    // Switch to equipment tab and wait for render.
+    await switchTab(window, "equipment");
+    await window.waitForFunction(
+      () => {
+        const panel = document.querySelector("#equipmentPanel");
+        return panel && panel.querySelector(".equip-section") !== null;
+      },
+      null,
+      { timeout: 10_000 }
+    );
+  });
+
+  test.afterAll(async () => {
+    await closeApp(app);
+  });
+
+  // Helper: read a stat value by exact label from the Attributes section.
+  async function getStat(statLabel) {
+    const panel = window.locator("#equipmentPanel");
+    const statsSection = panel.locator(".equip-section").filter({ hasText: "Attributes" }).first();
+    const rows = statsSection.locator(".equip-stat-row");
+    const count = await rows.count();
+    for (let i = 0; i < count; i++) {
+      const label = (await rows.nth(i).locator(".equip-stat-label").first().textContent()).trim();
+      if (label === statLabel) {
+        const val = await rows.nth(i).locator(".equip-stat-value").first().textContent();
+        return parseInt(val.replace(/,/g, ""), 10);
+      }
+    }
+    return null;
+  }
+
+  // 33. Signet passive toggle: default ON, click disables (Power -180), re-enables (Power restored)
+  test("signet passive toggle: active by default, toggle off then on affects Power by 180", async () => {
+    const panel = window.locator("#equipmentPanel");
+    const boonsSection = panel.locator(".equip-boons");
+    await expect(boonsSection).toBeVisible();
+
+    // "Signet Passives" section label is rendered.
+    const signetLabel = boonsSection.locator(".equip-boons__sigil-label", {
+      hasText: "Signet Passives",
+    });
+    await expect(signetLabel).toBeVisible();
+
+    // Signet of Spite item appears in the signet bar.
+    const signetItem = boonsSection
+      .locator(".equip-boons__item")
+      .filter({ hasText: "Signet of Spite" })
+      .first();
+    await expect(signetItem).toBeVisible();
+
+    const signetIcon = signetItem.locator(".equip-boons__icon--sigil");
+
+    // Default: passive active (--on class present).
+    const onInitially = await signetIcon.evaluate((el) =>
+      el.classList.contains("equip-boons__icon--on")
+    );
+    expect(onInitially).toBe(true);
+
+    // Power reflects +180 from Signet of Spite.
+    const powerWithPassive = await getStat("Power");
+    expect(powerWithPassive).not.toBeNull();
+
+    // Click icon to disable the passive.
+    await signetIcon.click();
+    await window.waitForTimeout(300);
+
+    // Icon marked off; Power drops by exactly 180.
+    const iconAfterOff = boonsSection
+      .locator(".equip-boons__item")
+      .filter({ hasText: "Signet of Spite" })
+      .first()
+      .locator(".equip-boons__icon--sigil");
+    const offAfterClick = await iconAfterOff.evaluate((el) =>
+      !el.classList.contains("equip-boons__icon--on")
+    );
+    expect(offAfterClick).toBe(true);
+    const powerWithoutPassive = await getStat("Power");
+    expect(powerWithoutPassive).toBe(powerWithPassive - 180);
+
+    // Right-click re-enables the passive.
+    await iconAfterOff.click({ button: "right" });
+    await window.waitForTimeout(300);
+
+    const iconAfterOn = boonsSection
+      .locator(".equip-boons__item")
+      .filter({ hasText: "Signet of Spite" })
+      .first()
+      .locator(".equip-boons__icon--sigil");
+    const onAgain = await iconAfterOn.evaluate((el) =>
+      el.classList.contains("equip-boons__icon--on")
+    );
+    expect(onAgain).toBe(true);
+    const powerRestored = await getStat("Power");
+    expect(powerRestored).toBe(powerWithPassive);
+  });
+
+  // 34. Unequipping the signet hides the Signet Passives section
+  test("Signet Passives section disappears when no stat-granting signet is equipped", async () => {
+    // Go back to the build tab and clear the utility slot.
+    await switchTab(window, "build");
+    await window.waitForTimeout(300);
+
+    const utilGroup = window.locator(".skill-group--utilities");
+    const utilitySlot = utilGroup.locator(".skill-slot").nth(1);
+    await utilitySlot.locator(".skill-icon-large").click();
+
+    const cselectOpen = window.locator(".cselect--skill-slot.cselect--open");
+    await expect(cselectOpen).toBeVisible({ timeout: 5000 });
+    // Pick a non-stat-granting utility (Plague Signet has no stat passive in the buff map).
+    await cselectOpen
+      .locator('.cselect__option:has-text("Plague Signet")')
+      .first()
+      .click();
+    await window.waitForTimeout(500);
+
+    await switchTab(window, "equipment");
+    await window.waitForFunction(
+      () => {
+        const panel = document.querySelector("#equipmentPanel");
+        return panel && panel.querySelector(".equip-section") !== null;
+      },
+      null,
+      { timeout: 10_000 }
+    );
+
+    const boonsSection = window.locator("#equipmentPanel .equip-boons");
+    const signetLabel = boonsSection.locator(".equip-boons__sigil-label", {
+      hasText: "Signet Passives",
+    });
+    await expect(signetLabel).toHaveCount(0);
+  });
+});

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -912,4 +912,21 @@ describe("computeStatBreakdown — signet passive buffs", () => {
     const signetEntry = entries.find((e) => e.source.includes("Signet"));
     expect(signetEntry).toBeUndefined();
   });
+
+  test("signet passive excluded when activeSignets entry is false", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [14404, 0, 0], eliteId: 0 };
+    const entries = computeStatBreakdown("Power", null, null, { 14404: false });
+    const signetEntry = entries.find((e) => e.source.includes("Signet"));
+    expect(signetEntry).toBeUndefined();
+  });
+
+  test("signet passive included when activeSignets entry is true", () => {
+    state.editor = makeEditor({});
+    state.editor.skills = { healId: 0, utilityIds: [14404, 0, 0], eliteId: 0 };
+    const entries = computeStatBreakdown("Power", null, null, { 14404: true });
+    const signetEntry = entries.find((e) => e.source.includes("Signet"));
+    expect(signetEntry).toBeDefined();
+    expect(signetEntry.value).toBe(180);
+  });
 });


### PR DESCRIPTION
## Summary
Adds a **Signet Passives** toggle section in the Equipment tab so players can simulate using a signet's active (disabling the passive stat bonus) without unequipping it. Default state is ON (passive active — matches current behavior). Click or right-click toggles individual signets off/on; the Attributes panel and stat breakdown tooltips update in lockstep.

Covers all 13 stat-granting signets (Bane Signet, Signet of Might, Signet of Stone, Assassin's Signet, Signet of Spite, etc.). The section hides automatically when no stat-granting signet is equipped, and state is cleaned up when signets are unequipped.

The engine's `computeAttributes` pipeline now accepts `ctx.activeSignets` as a per-signet boolean map; passing `null` (existing callers) preserves prior all-passives-on behavior for full backward compatibility.

## Test plan
- [x] Unit: 4 new engine tests cover activeSignets=true/false/null and per-signet independence (`packages/gw2-data/tests/engine/attributes.test.js`)
- [x] Unit: 2 new stat-breakdown tests verify toggle propagates through `computeStatBreakdown` (`tests/unit/renderer/stats.test.js`)
- [x] Full suite: all 1519 Jest tests pass
- [x] E2E: Playwright spec added (`tests/e2e/specs/equipment.spec.js` Section 6I) — two tests covering the toggle-off/toggle-on flow (Power ±180) and section-hidden-when-unequipped. Note: the existing e2e `launchApp` helper has a pre-existing wait bug that prevents local execution of any e2e spec on this branch; the test structure follows the Section 6F boon-toggle pattern and will run once the helper is repaired.
- [ ] Manual: equip a stat-granting signet (e.g. Signet of Might), verify the Signet Passives section appears, click to toggle, verify Attributes drops by 180, verify tooltip text updates, verify state resets when signet is unequipped

Closes #210