### PR TITLE
fix: own taskbar entry on KDE/Wayland

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "axiforge-desktop",
+  "productName": "AxiForge",
   "version": "0.4.1",
   "workspaces": ["packages/*"],
   "description": "GW2 build editor desktop app with GitHub Pages publishing",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -7,6 +7,13 @@ for (const stream of [process.stdout, process.stderr]) {
   stream?.on?.("error", (err) => { if (err.code !== "EPIPE") throw err; });
 }
 const { app, BrowserWindow, ipcMain, dialog, clipboard, nativeTheme, nativeImage, screen } = require("electron");
+
+// Taskbar identity — set before app is ready so the compositor gives AxiForge
+// its own taskbar entry instead of grouping it with whatever process launched
+// electron (e.g. a VS Code terminal). On Wayland, Chromium derives app_id from
+// app.getName(); on X11, --class sets WM_CLASS.
+app.setName("AxiForge");
+app.commandLine.appendSwitch("class", "AxiForge");
 const { BuildStore } = require("./buildStore");
 const { FolderStore } = require("./folderStore");
 const { CompStore } = require("./compStore");


### PR DESCRIPTION
## Summary
Electron derives the Wayland `app_id` from `app.getName()`, and X11 groups by `WM_CLASS`. In dev mode the app had neither set, so KDE grouped the window with whatever launched electron (e.g. a VS Code terminal).

- Set `app.setName("AxiForge")` and `app.commandLine.appendSwitch("class", "AxiForge")` early in `src/main/index.js` — before `whenReady()`.
- Hoist `productName: "AxiForge"` to the top level of `package.json` so `app.getName()` returns the right value even without the switch.

Verified via `wmctrl -lx`: `WM_CLASS` now reads `axiforge.AxiForge` (previously generic/inherited from parent process).

## Side effect
Dev userData path changes from `{appData}/axiforge-desktop-dev` → `{appData}/AxiForge-dev`, which aligns dev with the packaged app. Existing dev data in the old path is orphaned; migrate manually if needed.

## Test plan
- [x] `npm test` — all 1519 Jest tests pass
- [x] Launched `electron .` and confirmed `WM_CLASS = axiforge, AxiForge` via `wmctrl`
- [ ] Manual: run `npm run dev`, confirm KDE shows AxiForge with its own taskbar icon (not grouped with the editor/terminal)