### PR TITLE
feat: shared build library via GitHub organizations

### DIFF
--- a/src/main/folderStore.js
+++ b/src/main/folderStore.js
@@ -33,14 +33,6 @@ class FolderStore {
       throw new Error("Shared folders must be top-level");
     }
 
-    // Non-shared folders cannot nest under shared folders
-    if (parentId) {
-      const parentFolder = folders.find((f) => f.id === parentId);
-      if (parentFolder?.shared) {
-        throw new Error("Cannot nest folders under a shared folder");
-      }
-    }
-
     // Depth check
     if (parentId) {
       const depth = this.#getDepth(folders, parentId);

--- a/src/main/folderStore.js
+++ b/src/main/folderStore.js
@@ -24,6 +24,23 @@ class FolderStore {
     const parentId =
       typeof input.parentId === "string" ? input.parentId : null;
 
+    const shared = input.shared === true;
+    const orgName = typeof input.orgName === "string" ? input.orgName : undefined;
+    const lastSyncedAt = typeof input.lastSyncedAt === "string" ? input.lastSyncedAt : undefined;
+
+    // Shared folders must be top-level
+    if (shared && parentId) {
+      throw new Error("Shared folders must be top-level");
+    }
+
+    // Non-shared folders cannot nest under shared folders
+    if (parentId) {
+      const parentFolder = folders.find((f) => f.id === parentId);
+      if (parentFolder?.shared) {
+        throw new Error("Cannot nest folders under a shared folder");
+      }
+    }
+
     // Depth check
     if (parentId) {
       const depth = this.#getDepth(folders, parentId);
@@ -44,6 +61,9 @@ class FolderStore {
       if (input.sortOrder !== undefined) {
         existing.sortOrder = Number(input.sortOrder) || 0;
       }
+      if (input.shared !== undefined) existing.shared = Boolean(input.shared);
+      if (input.orgName !== undefined) existing.orgName = input.orgName;
+      if (input.lastSyncedAt !== undefined) existing.lastSyncedAt = input.lastSyncedAt;
       // Ensure updatedAt is strictly greater than the previous value
       const prevUpdatedAt = existing.updatedAt;
       existing.updatedAt =
@@ -55,7 +75,7 @@ class FolderStore {
     }
 
     const folder = {
-      id: crypto.randomUUID(),
+      id: input.id || crypto.randomUUID(),
       name,
       parentId,
       sortOrder:
@@ -63,6 +83,9 @@ class FolderStore {
       createdAt: now,
       updatedAt: now,
     };
+    if (shared) folder.shared = true;
+    if (orgName) folder.orgName = orgName;
+    if (lastSyncedAt) folder.lastSyncedAt = lastSyncedAt;
     folders.push(folder);
     await this.#writeJson(this.foldersPath, folders);
     return { ...folder };

--- a/src/main/githubApi.js
+++ b/src/main/githubApi.js
@@ -485,8 +485,101 @@ async function deleteFile(token, owner, filePath, branch = "main", message = "Re
   });
 }
 
+// ---------------------------------------------------------------------------
+// Shared Library API
+// ---------------------------------------------------------------------------
+
+const SHARED_REPO = "axibuilds-shared";
+
+async function ensureSharedRepo(token, org) {
+  try {
+    await apiFetch(`/repos/${org}/${SHARED_REPO}`, token);
+    await waitForRepo(token, org, SHARED_REPO);
+    return SHARED_REPO;
+  } catch (err) {
+    if (err.status !== 404) throw err;
+  }
+
+  await apiFetch(`/orgs/${org}/repos`, token, {
+    method: "POST",
+    body: JSON.stringify({
+      name: SHARED_REPO,
+      private: true,
+      auto_init: true,
+      description: "AxiForge Shared Library — collaborative GW2 builds",
+    }),
+  }).catch(async (err) => {
+    if (err.status === 422) {
+      await apiFetch(`/repos/${org}/${SHARED_REPO}`, token);
+      return;
+    }
+    throw err;
+  });
+
+  await waitForRepo(token, org, SHARED_REPO);
+  return SHARED_REPO;
+}
+
+async function getRepoTree(token, owner, repo, branch = "main") {
+  const headRef = await apiFetch(
+    `/repos/${owner}/${repo}/git/ref/heads/${encodeURIComponent(branch)}`,
+    token
+  );
+  const headSha = headRef?.object?.sha;
+  if (!headSha) throw new Error(`Could not resolve ${owner}/${repo}@${branch}.`);
+
+  const headCommit = await apiFetch(`/repos/${owner}/${repo}/git/commits/${headSha}`, token);
+  const baseTreeSha = headCommit?.tree?.sha;
+  if (!baseTreeSha) throw new Error("Could not resolve repository tree.");
+
+  const treeData = await apiFetch(
+    `/repos/${owner}/${repo}/git/trees/${baseTreeSha}?recursive=1`,
+    token
+  );
+  const tree = Array.isArray(treeData?.tree) ? treeData.tree : [];
+  return tree
+    .filter((entry) => entry?.type === "blob" && entry?.path && entry?.sha)
+    .map((entry) => ({ path: entry.path, sha: entry.sha }));
+}
+
+async function getFileContents(token, owner, repo, filePath, branch = "main") {
+  const encodedPath = filePath.split("/").map((s) => encodeURIComponent(s)).join("/");
+  const data = await apiFetch(
+    `/repos/${owner}/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(branch)}`,
+    token
+  );
+  const content = data?.encoding === "base64" && typeof data?.content === "string"
+    ? Buffer.from(data.content, "base64").toString("utf8")
+    : null;
+  return { content, sha: data?.sha || null };
+}
+
+async function putSharedFile(token, owner, repo, filePath, content, sha, branch = "main", message = "Update shared build") {
+  const encodedPath = filePath.split("/").map((s) => encodeURIComponent(s)).join("/");
+  const body = {
+    message,
+    content: Buffer.from(content, "utf8").toString("base64"),
+    branch,
+  };
+  if (sha) body.sha = sha;
+  const result = await apiFetch(`/repos/${owner}/${repo}/contents/${encodedPath}`, token, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  return { sha: result?.content?.sha || null };
+}
+
+async function deleteSharedFile(token, owner, repo, filePath, sha, branch = "main", message = "Remove shared build") {
+  const encodedPath = filePath.split("/").map((s) => encodeURIComponent(s)).join("/");
+  await apiFetch(`/repos/${owner}/${repo}/contents/${encodedPath}`, token, {
+    method: "DELETE",
+    body: JSON.stringify({ message, sha, branch }),
+  });
+}
+
 module.exports = {
   TARGET_REPO,
+  SHARED_REPO,
   getViewer,
   listTargets,
   ensureAxiForgeRepo,
@@ -498,4 +591,9 @@ module.exports = {
   triggerPagesWorkflow,
   publishSiteBundle,
   deleteFile,
+  ensureSharedRepo,
+  getRepoTree,
+  getFileContents,
+  putSharedFile,
+  deleteSharedFile,
 };

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -427,10 +427,36 @@ app.whenReady().then(async () => {
       builds.filter((b) => ids.includes(b.id) && b.folderId).map((b) => b.folderId)
     )];
     await store.moveBuilds(ids, folderId);
+
+    // Handle shared folder sync boundaries
+    const folders = await folderStore.listFolders();
+    const destFolder = folders.find((f) => f.id === folderId);
+    const movedBuilds = (await store.listBuilds()).filter((b) => ids.includes(b.id));
+
+    // Moving INTO a shared folder: push each build
+    if (destFolder?.shared) {
+      for (const build of movedBuilds) {
+        sharedLibrary.schedulePush("build", build);
+      }
+    }
+
+    // Moving OUT OF a shared folder: delete remotely
+    for (const srcId of sourceFolderIds) {
+      const srcFolder = folders.find((f) => f.id === srcId);
+      if (srcFolder?.shared && srcId !== folderId) {
+        for (const id of ids) {
+          sharedLibrary.deleteBuildRemote(srcId, id).catch((err) => {
+            console.error("Failed to delete remote build after move:", err.message);
+          });
+        }
+      }
+    }
+
     // Touch source and destination folders
     const touchIds = [...sourceFolderIds];
     if (folderId) touchIds.push(folderId);
     if (touchIds.length) await folderStore.touchFolders([...new Set(touchIds)]);
+    return true;
   });
   ipcMain.handle("builds:pin", (_e, ids, pinned) =>
     store.pinBuilds(ids, pinned),

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -470,6 +470,7 @@ app.whenReady().then(async () => {
     const destRootShared = await findRootSharedFolder(folderId);
 
     if (destRootShared) {
+      _e.sender.send("sync-status", { status: "syncing", folderId: destRootShared.id });
       for (const build of movedBuilds) {
         sharedLibrary.schedulePush("build", build);
       }
@@ -480,6 +481,7 @@ app.whenReady().then(async () => {
       const srcRootShared = await findRootSharedFolder(srcId);
       // Only delete remotely if moving OUT of a different shared hierarchy
       if (srcRootShared && srcRootShared.id !== destRootShared?.id) {
+        _e.sender.send("sync-status", { status: "syncing", folderId: srcRootShared.id });
         for (const id of ids) {
           sharedLibrary.deleteBuildRemote(srcId, id).catch((err) => {
             console.error("Failed to delete remote build after move:", err.message);

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -420,13 +420,31 @@ app.whenReady().then(async () => {
 
   // Folder CRUD
   ipcMain.handle("folders:list", () => folderStore.listFolders());
-  ipcMain.handle("folders:save", (_e, folder) =>
-    folderStore.upsertFolder(folder),
-  );
+  ipcMain.handle("folders:save", async (_e, folder) => {
+    const saved = await folderStore.upsertFolder(folder);
+    // If this folder lives inside a shared folder, sync the folder structure
+    if (saved.parentId) {
+      const rootShared = await findRootSharedFolder(saved.parentId);
+      if (rootShared) {
+        _e.sender.send("sync-status", { status: "syncing", folderId: rootShared.id });
+        sharedLibrary.schedulePushFolderMeta(rootShared.id);
+      }
+    }
+    return saved;
+  });
   ipcMain.handle("folders:delete", async (_e, id) => {
+    // Capture parent before deletion to determine shared ancestry
+    const allFolders = await folderStore.listFolders();
+    const target = allFolders.find((f) => f.id === id);
+    const rootShared = target?.parentId ? await findRootSharedFolder(target.parentId) : null;
+
     const deletedIds = await folderStore.deleteFolder(id);
     if (deletedIds.length) {
       await store.clearFolderFromBuilds(deletedIds);
+    }
+    if (rootShared) {
+      _e.sender.send("sync-status", { status: "syncing", folderId: rootShared.id });
+      sharedLibrary.schedulePushFolderMeta(rootShared.id);
     }
     return deletedIds;
   });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -239,7 +239,28 @@ app.whenReady().then(async () => {
   await initDiskCache(dataDir);
   initWikiClient(dataDir);
   await migrateCompGameModes(store, compStore);
-  const sharedLibrary = new SharedLibrary({ buildStore: store, compStore, folderStore, syncStore });
+
+  // Walk up parentId chain to find the closest ancestor with shared:true
+  async function findRootSharedFolder(folderId) {
+    if (!folderId) return null;
+    const folders = await folderStore.listFolders();
+    function walk(id) {
+      const f = folders.find((x) => x.id === id);
+      if (!f) return null;
+      if (f.shared) return f;
+      if (f.parentId) return walk(f.parentId);
+      return null;
+    }
+    return walk(folderId);
+  }
+
+  const sharedLibrary = new SharedLibrary({
+    buildStore: store, compStore, folderStore, syncStore,
+    emit: (channel, data) => {
+      const wins = BrowserWindow.getAllWindows();
+      if (wins.length) wins[0].webContents.send(channel, data);
+    },
+  });
   sharedLibrary.startPolling();
 
   // Restore last window position/size if valid
@@ -369,19 +390,17 @@ app.whenReady().then(async () => {
   ipcMain.handle("builds:list", async () => store.listBuilds());
   ipcMain.handle("builds:save", async (_e, build) => {
     const saved = await store.upsertBuild(build);
-    // Touch the folder this build belongs to
     if (saved.folderId) {
       await folderStore.touchFolders([saved.folderId]);
     }
-    // Trigger shared library push if in a shared folder
-    const folder = (await folderStore.listFolders()).find((f) => f.id === saved.folderId);
-    if (folder?.shared) {
+    const rootShared = await findRootSharedFolder(saved.folderId);
+    if (rootShared) {
+      _e.sender.send("sync-status", { status: "syncing", folderId: saved.folderId });
       sharedLibrary.schedulePush("build", saved);
     }
     return saved;
   });
   ipcMain.handle("builds:delete", async (_e, id) => {
-    // Check which folder this build is in before deleting
     const builds = await store.listBuilds();
     const build = builds.find((b) => b.id === id);
     const folderId = build?.folderId;
@@ -389,8 +408,8 @@ app.whenReady().then(async () => {
     await compStore.removeBuildFromComps(id);
     if (folderId) {
       await folderStore.touchFolders([folderId]);
-      const folder = (await folderStore.listFolders()).find((f) => f.id === folderId);
-      if (folder?.shared) {
+      const rootShared = await findRootSharedFolder(folderId);
+      if (rootShared) {
         sharedLibrary.deleteBuildRemote(folderId, id).catch((err) => {
           console.error("Shared library remote delete failed:", err.message);
         });
@@ -428,22 +447,21 @@ app.whenReady().then(async () => {
     )];
     await store.moveBuilds(ids, folderId);
 
-    // Handle shared folder sync boundaries
-    const folders = await folderStore.listFolders();
-    const destFolder = folders.find((f) => f.id === folderId);
+    // Handle shared folder sync — check full ancestor chain for both source and dest
     const movedBuilds = (await store.listBuilds()).filter((b) => ids.includes(b.id));
+    const destRootShared = await findRootSharedFolder(folderId);
 
-    // Moving INTO a shared folder: push each build
-    if (destFolder?.shared) {
+    if (destRootShared) {
       for (const build of movedBuilds) {
         sharedLibrary.schedulePush("build", build);
       }
     }
 
-    // Moving OUT OF a shared folder: delete remotely
     for (const srcId of sourceFolderIds) {
-      const srcFolder = folders.find((f) => f.id === srcId);
-      if (srcFolder?.shared && srcId !== folderId) {
+      if (srcId === folderId) continue;
+      const srcRootShared = await findRootSharedFolder(srcId);
+      // Only delete remotely if moving OUT of a different shared hierarchy
+      if (srcRootShared && srcRootShared.id !== destRootShared?.id) {
         for (const id of ids) {
           sharedLibrary.deleteBuildRemote(srcId, id).catch((err) => {
             console.error("Failed to delete remote build after move:", err.message);
@@ -469,10 +487,10 @@ app.whenReady().then(async () => {
   ipcMain.handle("comps:list", () => compStore.listComps());
   ipcMain.handle("comps:save", async (_e, comp) => {
     const saved = await compStore.upsertComp(comp);
-    // Trigger shared library push if in a shared folder
     if (saved.folderId) {
-      const folder = (await folderStore.listFolders()).find((f) => f.id === saved.folderId);
-      if (folder?.shared) {
+      const rootShared = await findRootSharedFolder(saved.folderId);
+      if (rootShared) {
+        _e.sender.send("sync-status", { status: "syncing", folderId: saved.folderId });
         sharedLibrary.schedulePush("comp", saved);
       }
     }
@@ -485,8 +503,8 @@ app.whenReady().then(async () => {
     await compStore.deleteComp(id);
     await store.clearCompFromBuilds([id]);
     if (folderId) {
-      const folder = (await folderStore.listFolders()).find((f) => f.id === folderId);
-      if (folder?.shared) {
+      const rootShared = await findRootSharedFolder(folderId);
+      if (rootShared) {
         sharedLibrary.deleteCompRemote(folderId, id).catch((err) => {
           console.error("Shared library remote comp delete failed:", err.message);
         });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -16,6 +16,8 @@ app.commandLine.appendSwitch("class", "AxiForge");
 const { BuildStore } = require("./buildStore");
 const { FolderStore } = require("./folderStore");
 const { CompStore } = require("./compStore");
+const { SyncStore } = require("./syncStore");
+const { SharedLibrary } = require("./sharedLibrary");
 const { beginGitHubDeviceAuth, completeGitHubDeviceAuth } = require("./githubAuth");
 const {
   TARGET_REPO,
@@ -55,6 +57,7 @@ const dataDir = path.join(app.getPath("userData"), "data");
 const store = new BuildStore(dataDir);
 const folderStore = new FolderStore(dataDir);
 const compStore = new CompStore(dataDir);
+const syncStore = new SyncStore(dataDir);
 
 // On Windows, the taskbar follows the "system" theme (SystemUsesLightTheme)
 // while nativeTheme.shouldUseDarkColors follows the "app" theme. These can
@@ -232,9 +235,12 @@ app.whenReady().then(async () => {
   await store.migrateCompIdToCompIds();
   await folderStore.init();
   await compStore.init();
+  await syncStore.init();
   await initDiskCache(dataDir);
   initWikiClient(dataDir);
   await migrateCompGameModes(store, compStore);
+  const sharedLibrary = new SharedLibrary({ buildStore: store, compStore, folderStore, syncStore });
+  sharedLibrary.startPolling();
 
   // Restore last window position/size if valid
   let savedBounds;
@@ -367,6 +373,11 @@ app.whenReady().then(async () => {
     if (saved.folderId) {
       await folderStore.touchFolders([saved.folderId]);
     }
+    // Trigger shared library push if in a shared folder
+    const folder = (await folderStore.listFolders()).find((f) => f.id === saved.folderId);
+    if (folder?.shared) {
+      sharedLibrary.schedulePush("build", saved);
+    }
     return saved;
   });
   ipcMain.handle("builds:delete", async (_e, id) => {
@@ -378,6 +389,12 @@ app.whenReady().then(async () => {
     await compStore.removeBuildFromComps(id);
     if (folderId) {
       await folderStore.touchFolders([folderId]);
+      const folder = (await folderStore.listFolders()).find((f) => f.id === folderId);
+      if (folder?.shared) {
+        sharedLibrary.deleteBuildRemote(folderId, id).catch((err) => {
+          console.error("Shared library remote delete failed:", err.message);
+        });
+      }
     }
     return true;
   });
@@ -424,10 +441,31 @@ app.whenReady().then(async () => {
 
   // Comp CRUD
   ipcMain.handle("comps:list", () => compStore.listComps());
-  ipcMain.handle("comps:save", (_e, comp) => compStore.upsertComp(comp));
+  ipcMain.handle("comps:save", async (_e, comp) => {
+    const saved = await compStore.upsertComp(comp);
+    // Trigger shared library push if in a shared folder
+    if (saved.folderId) {
+      const folder = (await folderStore.listFolders()).find((f) => f.id === saved.folderId);
+      if (folder?.shared) {
+        sharedLibrary.schedulePush("comp", saved);
+      }
+    }
+    return saved;
+  });
   ipcMain.handle("comps:delete", async (_e, id) => {
+    const comps = await compStore.listComps();
+    const comp = comps.find((c) => c.id === id);
+    const folderId = comp?.folderId;
     await compStore.deleteComp(id);
     await store.clearCompFromBuilds([id]);
+    if (folderId) {
+      const folder = (await folderStore.listFolders()).find((f) => f.id === folderId);
+      if (folder?.shared) {
+        sharedLibrary.deleteCompRemote(folderId, id).catch((err) => {
+          console.error("Shared library remote comp delete failed:", err.message);
+        });
+      }
+    }
   });
   ipcMain.handle("comps:reorder", (_e, updates) => compStore.reorderComps(updates));
   ipcMain.handle("comps:delete-batch", async (_e, ids) => {
@@ -1256,6 +1294,120 @@ app.whenReady().then(async () => {
 
   // .axicode file export/import
   registerAxicodeFileHandlers(win);
+
+  // ─── Shared Library ─────────────────────────────────────────────────────────
+  ipcMain.handle("shared-library:list-orgs", async () => {
+    const session = await getSession();
+    if (!session) return [];
+    const targets = await listTargets(session.token, session.viewer.login);
+    return targets.filter((t) => t.type === "org");
+  });
+
+  ipcMain.handle("shared-library:setup", async (_e, orgName) => {
+    const session = await getSession();
+    if (!session) throw new Error("Not logged in");
+    const { ensureSharedRepo } = require("./githubApi");
+    await ensureSharedRepo(session.token, orgName);
+    const auth = await getAuthRecord();
+    await store.saveAuth({
+      ...auth,
+      sharedLibrary: { orgName, repoName: "axibuilds-shared" },
+    });
+    return { orgName, repoName: "axibuilds-shared" };
+  });
+
+  ipcMain.handle("shared-library:share-folder", async (_e, folderId) => {
+    await sharedLibrary.shareFolder(folderId);
+    return true;
+  });
+
+  ipcMain.handle("shared-library:unshare-folder", async (_e, folderId) => {
+    await sharedLibrary.unshareFolder(folderId);
+    return true;
+  });
+
+  ipcMain.handle("shared-library:pull-folder", async (_e, folderId) => {
+    await sharedLibrary.pullFolder(folderId);
+    return true;
+  });
+
+  ipcMain.handle("shared-library:pull-all", async () => {
+    await sharedLibrary.pullAll();
+    return true;
+  });
+
+  ipcMain.handle("shared-library:connect", async () => {
+    const auth = await getAuthRecord();
+    if (!auth?.sharedLibrary?.orgName) throw new Error("No shared library configured");
+
+    const { getRepoTree, getFileContents } = require("./githubApi");
+    const tree = await getRepoTree(
+      auth.token, auth.sharedLibrary.orgName,
+      auth.sharedLibrary.repoName || "axibuilds-shared"
+    );
+
+    const folderMetas = [];
+    for (const entry of tree) {
+      const match = entry.path.match(/^folders\/([^/]+)\/meta\.json$/);
+      if (match) {
+        const { content } = await getFileContents(
+          auth.token, auth.sharedLibrary.orgName,
+          auth.sharedLibrary.repoName || "axibuilds-shared",
+          entry.path
+        );
+        if (content) folderMetas.push(JSON.parse(content));
+      }
+    }
+
+    // Create local folders for each remote folder (if they don't exist)
+    const localFolders = await folderStore.listFolders();
+    for (const meta of folderMetas) {
+      const existing = localFolders.find((f) => f.id === meta.id);
+      if (!existing) {
+        await folderStore.upsertFolder({
+          id: meta.id,
+          name: meta.name,
+          sortOrder: meta.sortOrder || 0,
+          shared: true,
+          orgName: auth.sharedLibrary.orgName,
+        });
+      } else if (!existing.shared) {
+        await folderStore.upsertFolder({
+          id: existing.id,
+          name: meta.name,
+          shared: true,
+          orgName: auth.sharedLibrary.orgName,
+        });
+      }
+    }
+
+    await sharedLibrary.pullAll();
+    return true;
+  });
+
+  ipcMain.handle("shared-library:disconnect", async () => {
+    sharedLibrary.stopPolling();
+    const auth = await getAuthRecord();
+    delete auth.sharedLibrary;
+    await store.saveAuth(auth);
+    // Unmark all shared folders
+    const folders = await folderStore.listFolders();
+    for (const f of folders.filter((f) => f.shared)) {
+      await folderStore.upsertFolder({ id: f.id, name: f.name, shared: false });
+    }
+    await syncStore.reset();
+    return true;
+  });
+
+  ipcMain.handle("shared-library:get-config", async () => {
+    const auth = await getAuthRecord();
+    return auth?.sharedLibrary || null;
+  });
+
+  ipcMain.handle("shared-library:force-push", async (_e, type, item) => {
+    if (type === "build") return sharedLibrary.pushBuild(item);
+    if (type === "comp") return sharedLibrary.pushComp(item);
+  });
 });
 
 app.on("window-all-closed", () => {

--- a/src/main/sharedLibrary.js
+++ b/src/main/sharedLibrary.js
@@ -6,13 +6,23 @@ function api() {
 }
 
 class SharedLibrary {
-  constructor({ buildStore, compStore, folderStore, syncStore }) {
+  constructor({ buildStore, compStore, folderStore, syncStore, emit }) {
     this.buildStore = buildStore;
     this.compStore = compStore;
     this.folderStore = folderStore;
     this.syncStore = syncStore;
+    this._emit = typeof emit === "function" ? emit : () => {};
     this._pushTimers = new Map(); // debounce timers per build/comp ID
     this._pollTimer = null;
+  }
+
+  // Walk up the parentId chain to find the closest folder with shared:true
+  _findRootShared(folderId, folders) {
+    const folder = folders.find((f) => f.id === folderId);
+    if (!folder) return null;
+    if (folder.shared) return folder;
+    if (folder.parentId) return this._findRootShared(folder.parentId, folders);
+    return null;
   }
 
   async #getAuth() {
@@ -115,11 +125,36 @@ class SharedLibrary {
       const data = JSON.parse(content);
       const key = relPath.replace(/\.json$/, "");
       if (relPath.startsWith("builds/")) {
-        data.folderId = folderId;
+        // Restore subfolder if the build was in one
+        const restoreFolderId = data.folderId || folderId;
+        if (restoreFolderId !== folderId) {
+          const allFolders = await this.folderStore.listFolders();
+          if (!allFolders.find((f) => f.id === restoreFolderId)) {
+            await this.folderStore.upsertFolder({
+              id: restoreFolderId,
+              name: data._syncSubFolderName || "Subfolder",
+              parentId: folderId,
+            });
+          }
+        }
+        delete data._syncSubFolderName;
+        data.folderId = restoreFolderId;
         await this.buildStore.upsertBuild(data);
         await this.syncStore.setSha(folderId, key, sha);
       } else if (relPath.startsWith("comps/")) {
-        data.folderId = folderId;
+        const restoreFolderId = data.folderId || folderId;
+        if (restoreFolderId !== folderId) {
+          const allFolders = await this.folderStore.listFolders();
+          if (!allFolders.find((f) => f.id === restoreFolderId)) {
+            await this.folderStore.upsertFolder({
+              id: restoreFolderId,
+              name: data._syncSubFolderName || "Subfolder",
+              parentId: folderId,
+            });
+          }
+        }
+        delete data._syncSubFolderName;
+        data.folderId = restoreFolderId;
         await this.compStore.upsertComp(data);
         await this.syncStore.setSha(folderId, key, sha);
       }
@@ -153,16 +188,23 @@ class SharedLibrary {
     if (!auth) return { conflict: false };
 
     const folders = await this.folderStore.listFolders();
-    const folder = folders.find((f) => f.id === build.folderId && f.shared);
-    if (!folder) return { conflict: false };
+    const rootShared = this._findRootShared(build.folderId, folders);
+    if (!rootShared) return { conflict: false };
 
     const key = `builds/${build.id}`;
-    const filePath = `folders/${build.folderId}/${key}.json`;
-    const shas = await this.syncStore.getShas(build.folderId);
+    const filePath = `folders/${rootShared.id}/${key}.json`;
+    const shas = await this.syncStore.getShas(rootShared.id);
     const currentSha = shas[key] || null;
 
-    // Strip folderId from the stored JSON (it's implied by folder path)
-    const { folderId, compId, pinned, sortOrder, ...buildData } = build;
+    // Strip local-only fields; preserve folderId if in a subfolder so pull can restore it
+    const { compId, pinned, sortOrder, ...buildData } = build;
+    if (build.folderId === rootShared.id) {
+      delete buildData.folderId; // implied by folder path
+    } else {
+      // Include subfolder name so the other side can auto-create it
+      const subFolder = folders.find((f) => f.id === build.folderId);
+      if (subFolder) buildData._syncSubFolderName = subFolder.name;
+    }
     const content = JSON.stringify(buildData, null, 2);
 
     try {
@@ -171,7 +213,7 @@ class SharedLibrary {
         filePath, content, currentSha, "main",
         `Update build: ${build.title || build.id}`
       );
-      await this.syncStore.setSha(build.folderId, key, result.sha);
+      await this.syncStore.setSha(rootShared.id, key, result.sha);
       return { conflict: false };
     } catch (err) {
       if (err.status === 409) {
@@ -186,15 +228,21 @@ class SharedLibrary {
     if (!auth) return { conflict: false };
 
     const folders = await this.folderStore.listFolders();
-    const folder = folders.find((f) => f.id === comp.folderId && f.shared);
-    if (!folder) return { conflict: false };
+    const rootShared = this._findRootShared(comp.folderId, folders);
+    if (!rootShared) return { conflict: false };
 
     const key = `comps/${comp.id}`;
-    const filePath = `folders/${comp.folderId}/${key}.json`;
-    const shas = await this.syncStore.getShas(comp.folderId);
+    const filePath = `folders/${rootShared.id}/${key}.json`;
+    const shas = await this.syncStore.getShas(rootShared.id);
     const currentSha = shas[key] || null;
 
-    const { folderId, ...compData } = comp;
+    const { ...compData } = comp;
+    if (comp.folderId === rootShared.id) {
+      delete compData.folderId;
+    } else {
+      const subFolder = folders.find((f) => f.id === comp.folderId);
+      if (subFolder) compData._syncSubFolderName = subFolder.name;
+    }
     const content = JSON.stringify(compData, null, 2);
 
     try {
@@ -203,7 +251,7 @@ class SharedLibrary {
         filePath, content, currentSha, "main",
         `Update comp: ${comp.name || comp.id}`
       );
-      await this.syncStore.setSha(comp.folderId, key, result.sha);
+      await this.syncStore.setSha(rootShared.id, key, result.sha);
       return { conflict: false };
     } catch (err) {
       if (err.status === 409) {
@@ -217,16 +265,20 @@ class SharedLibrary {
     const auth = await this.#getAuth();
     if (!auth) return;
 
+    const folders = await this.folderStore.listFolders();
+    const rootShared = this._findRootShared(folderId, folders);
+    const rootId = rootShared?.id || folderId;
+
     const key = `builds/${buildId}`;
-    const filePath = `folders/${folderId}/${key}.json`;
-    const shas = await this.syncStore.getShas(folderId);
+    const filePath = `folders/${rootId}/${key}.json`;
+    const shas = await this.syncStore.getShas(rootId);
     const sha = shas[key];
     if (!sha) return;
 
     try {
       await api().deleteSharedFile(auth.token, auth.org, auth.repo, filePath, sha, "main",
         `Delete build: ${buildId}`);
-      await this.syncStore.removeSha(folderId, key);
+      await this.syncStore.removeSha(rootId, key);
     } catch (err) {
       if (err.status === 409) {
         return { conflict: true };
@@ -240,15 +292,19 @@ class SharedLibrary {
     if (!auth) return;
 
     const key = `comps/${compId}`;
-    const filePath = `folders/${folderId}/${key}.json`;
-    const shas = await this.syncStore.getShas(folderId);
+    const folders = await this.folderStore.listFolders();
+    const rootShared = this._findRootShared(folderId, folders);
+    const rootId = rootShared?.id || folderId;
+
+    const filePath = `folders/${rootId}/${key}.json`;
+    const shas = await this.syncStore.getShas(rootId);
     const sha = shas[key];
     if (!sha) return;
 
     try {
       await api().deleteSharedFile(auth.token, auth.org, auth.repo, filePath, sha, "main",
         `Delete comp: ${compId}`);
-      await this.syncStore.removeSha(folderId, key);
+      await this.syncStore.removeSha(rootId, key);
     } catch (err) {
       if (err.status === 409) {
         return { conflict: true };
@@ -284,15 +340,26 @@ class SharedLibrary {
     );
     await this.syncStore.setSha(folderId, "meta", metaResult.sha);
 
-    // Push all builds in this folder
+    // Push all builds in this folder and any subfolders
+    const allFolders = await this.folderStore.listFolders();
+    const folderTree = new Set([folderId]);
+    // collect all descendant folder IDs
+    const addChildren = (id) => {
+      for (const f of allFolders.filter((f) => f.parentId === id)) {
+        folderTree.add(f.id);
+        addChildren(f.id);
+      }
+    };
+    addChildren(folderId);
+
     const builds = await this.buildStore.listBuilds();
-    for (const build of builds.filter((b) => b.folderId === folderId)) {
+    for (const build of builds.filter((b) => folderTree.has(b.folderId))) {
       await this.pushBuild(build);
     }
 
-    // Push all comps in this folder
+    // Push all comps in this folder and subfolders
     const comps = await this.compStore.listComps();
-    for (const comp of comps.filter((c) => c.folderId === folderId)) {
+    for (const comp of comps.filter((c) => folderTree.has(c.folderId))) {
       await this.pushComp(comp);
     }
 
@@ -349,13 +416,20 @@ class SharedLibrary {
     this._pushTimers.set(key, setTimeout(async () => {
       this._pushTimers.delete(key);
       try {
+        let result;
         if (type === "build") {
-          await this.pushBuild(item);
+          result = await this.pushBuild(item);
         } else if (type === "comp") {
-          await this.pushComp(item);
+          result = await this.pushComp(item);
+        }
+        if (result?.conflict) {
+          this._emit("sync-conflict", { type, id: item.id, title: item.title || item.name, folderId: item.folderId });
+        } else {
+          this._emit("sync-status", { status: "synced", folderId: item.folderId });
         }
       } catch (err) {
         console.error(`Shared library push failed for ${key}:`, err.message);
+        this._emit("sync-status", { status: "error", folderId: item.folderId });
       }
     }, delayMs));
   }

--- a/src/main/sharedLibrary.js
+++ b/src/main/sharedLibrary.js
@@ -1,0 +1,364 @@
+"use strict";
+
+// Load at call time (not destructured at module load) so tests can mock the module.
+function api() {
+  return require("./githubApi");
+}
+
+class SharedLibrary {
+  constructor({ buildStore, compStore, folderStore, syncStore }) {
+    this.buildStore = buildStore;
+    this.compStore = compStore;
+    this.folderStore = folderStore;
+    this.syncStore = syncStore;
+    this._pushTimers = new Map(); // debounce timers per build/comp ID
+    this._pollTimer = null;
+  }
+
+  async #getAuth() {
+    const auth = await this.buildStore.getAuth();
+    if (!auth?.token || !auth?.sharedLibrary?.orgName) return null;
+    return {
+      token: auth.token,
+      org: auth.sharedLibrary.orgName,
+      repo: auth.sharedLibrary.repoName || "axibuilds-shared",
+    };
+  }
+
+  // ─── Pull ───────────────────────────────────────────────────────────────────
+
+  async pullFolder(folderId) {
+    const auth = await this.#getAuth();
+    if (!auth) return;
+    const tree = await api().getRepoTree(auth.token, auth.org, auth.repo);
+    await this.#pullFolderWithTree(folderId, tree, auth);
+  }
+
+  async pullAll() {
+    const auth = await this.#getAuth();
+    if (!auth) return;
+
+    const folders = await this.folderStore.listFolders();
+    const sharedFolders = folders.filter((f) => f.shared);
+    if (!sharedFolders.length) return;
+
+    // Fetch tree once for the entire repo (1 API call per poll)
+    let tree;
+    try {
+      tree = await api().getRepoTree(auth.token, auth.org, auth.repo);
+    } catch (err) {
+      // Transient error: retry once after 5 seconds
+      if (err.status >= 500 && err.status < 600) {
+        await new Promise((r) => setTimeout(r, 5000));
+        try {
+          tree = await api().getRepoTree(auth.token, auth.org, auth.repo);
+        } catch {
+          console.error("Shared library poll failed after retry:", err.message);
+          return;
+        }
+      } else {
+        console.error("Shared library poll error:", err.message);
+        return;
+      }
+    }
+
+    for (const folder of sharedFolders) {
+      try {
+        await this.#pullFolderWithTree(folder.id, tree, auth);
+      } catch (err) {
+        console.error(`Shared library pull failed for folder ${folder.id}:`, err.message);
+      }
+    }
+  }
+
+  // Internal: pull using a pre-fetched tree (avoids duplicate API calls in pullAll)
+  async #pullFolderWithTree(folderId, tree, auth) {
+    const folders = await this.folderStore.listFolders();
+    const folder = folders.find((f) => f.id === folderId && f.shared);
+    if (!folder) return;
+
+    const prefix = `folders/${folderId}/`;
+    const remoteFiles = tree.filter((f) => f.path.startsWith(prefix));
+    const localShas = await this.syncStore.getShas(folderId);
+
+    const changed = [];
+    const remotePaths = new Set();
+    for (const file of remoteFiles) {
+      const relPath = file.path.slice(prefix.length);
+      if (relPath === "meta.json") {
+        const metaSha = localShas["meta"];
+        if (metaSha !== file.sha) {
+          const { content: metaContent } = await api().getFileContents(auth.token, auth.org, auth.repo, file.path);
+          if (metaContent) {
+            const meta = JSON.parse(metaContent);
+            await this.folderStore.upsertFolder({
+              id: folderId, name: meta.name, sortOrder: meta.sortOrder,
+              shared: true, orgName: folder.orgName,
+            });
+            await this.syncStore.setSha(folderId, "meta", file.sha);
+          }
+        }
+        continue;
+      }
+      remotePaths.add(relPath);
+      const key = relPath.replace(/\.json$/, "");
+      const localSha = localShas[key];
+      if (localSha !== file.sha) {
+        changed.push({ relPath, sha: file.sha });
+      }
+    }
+
+    for (const { relPath, sha } of changed) {
+      const fullPath = `${prefix}${relPath}`;
+      const { content } = await api().getFileContents(auth.token, auth.org, auth.repo, fullPath);
+      if (!content) continue;
+      const data = JSON.parse(content);
+      const key = relPath.replace(/\.json$/, "");
+      if (relPath.startsWith("builds/")) {
+        data.folderId = folderId;
+        await this.buildStore.upsertBuild(data);
+        await this.syncStore.setSha(folderId, key, sha);
+      } else if (relPath.startsWith("comps/")) {
+        data.folderId = folderId;
+        await this.compStore.upsertComp(data);
+        await this.syncStore.setSha(folderId, key, sha);
+      }
+    }
+
+    for (const [key, _sha] of Object.entries(localShas)) {
+      const relPathWithExt = `${key}.json`;
+      if (!remotePaths.has(relPathWithExt) && key !== "meta") {
+        if (key.startsWith("builds/")) {
+          const buildId = key.replace("builds/", "");
+          await this.buildStore.deleteBuild(buildId);
+          await this.compStore.removeBuildFromComps(buildId);
+        } else if (key.startsWith("comps/")) {
+          const compId = key.replace("comps/", "");
+          await this.compStore.deleteComp(compId);
+        }
+        await this.syncStore.removeSha(folderId, key);
+      }
+    }
+
+    await this.folderStore.upsertFolder({
+      id: folderId, name: folder.name, shared: true,
+      orgName: folder.orgName, lastSyncedAt: new Date().toISOString(),
+    });
+  }
+
+  // ─── Push ───────────────────────────────────────────────────────────────────
+
+  async pushBuild(build) {
+    const auth = await this.#getAuth();
+    if (!auth) return { conflict: false };
+
+    const folders = await this.folderStore.listFolders();
+    const folder = folders.find((f) => f.id === build.folderId && f.shared);
+    if (!folder) return { conflict: false };
+
+    const key = `builds/${build.id}`;
+    const filePath = `folders/${build.folderId}/${key}.json`;
+    const shas = await this.syncStore.getShas(build.folderId);
+    const currentSha = shas[key] || null;
+
+    // Strip folderId from the stored JSON (it's implied by folder path)
+    const { folderId, compId, pinned, sortOrder, ...buildData } = build;
+    const content = JSON.stringify(buildData, null, 2);
+
+    try {
+      const result = await api().putSharedFile(
+        auth.token, auth.org, auth.repo,
+        filePath, content, currentSha, "main",
+        `Update build: ${build.title || build.id}`
+      );
+      await this.syncStore.setSha(build.folderId, key, result.sha);
+      return { conflict: false };
+    } catch (err) {
+      if (err.status === 409) {
+        return { conflict: true };
+      }
+      throw err;
+    }
+  }
+
+  async pushComp(comp) {
+    const auth = await this.#getAuth();
+    if (!auth) return { conflict: false };
+
+    const folders = await this.folderStore.listFolders();
+    const folder = folders.find((f) => f.id === comp.folderId && f.shared);
+    if (!folder) return { conflict: false };
+
+    const key = `comps/${comp.id}`;
+    const filePath = `folders/${comp.folderId}/${key}.json`;
+    const shas = await this.syncStore.getShas(comp.folderId);
+    const currentSha = shas[key] || null;
+
+    const { folderId, ...compData } = comp;
+    const content = JSON.stringify(compData, null, 2);
+
+    try {
+      const result = await api().putSharedFile(
+        auth.token, auth.org, auth.repo,
+        filePath, content, currentSha, "main",
+        `Update comp: ${comp.name || comp.id}`
+      );
+      await this.syncStore.setSha(comp.folderId, key, result.sha);
+      return { conflict: false };
+    } catch (err) {
+      if (err.status === 409) {
+        return { conflict: true };
+      }
+      throw err;
+    }
+  }
+
+  async deleteBuildRemote(folderId, buildId) {
+    const auth = await this.#getAuth();
+    if (!auth) return;
+
+    const key = `builds/${buildId}`;
+    const filePath = `folders/${folderId}/${key}.json`;
+    const shas = await this.syncStore.getShas(folderId);
+    const sha = shas[key];
+    if (!sha) return;
+
+    try {
+      await api().deleteSharedFile(auth.token, auth.org, auth.repo, filePath, sha, "main",
+        `Delete build: ${buildId}`);
+      await this.syncStore.removeSha(folderId, key);
+    } catch (err) {
+      if (err.status === 409) {
+        return { conflict: true };
+      }
+      throw err;
+    }
+  }
+
+  async deleteCompRemote(folderId, compId) {
+    const auth = await this.#getAuth();
+    if (!auth) return;
+
+    const key = `comps/${compId}`;
+    const filePath = `folders/${folderId}/${key}.json`;
+    const shas = await this.syncStore.getShas(folderId);
+    const sha = shas[key];
+    if (!sha) return;
+
+    try {
+      await api().deleteSharedFile(auth.token, auth.org, auth.repo, filePath, sha, "main",
+        `Delete comp: ${compId}`);
+      await this.syncStore.removeSha(folderId, key);
+    } catch (err) {
+      if (err.status === 409) {
+        return { conflict: true };
+      }
+      throw err;
+    }
+  }
+
+  // ─── Share / unshare folder ─────────────────────────────────────────────────
+
+  async shareFolder(folderId) {
+    const auth = await this.#getAuth();
+    if (!auth) throw new Error("Not authenticated or no shared library configured");
+
+    await api().ensureSharedRepo(auth.token, auth.org);
+
+    const folder = (await this.folderStore.listFolders()).find((f) => f.id === folderId);
+    if (!folder) throw new Error("Folder not found");
+
+    // Create meta.json
+    const metaContent = JSON.stringify({
+      id: folder.id,
+      name: folder.name,
+      sortOrder: folder.sortOrder || 0,
+      createdAt: folder.createdAt,
+      updatedAt: folder.updatedAt,
+    }, null, 2);
+
+    const metaResult = await api().putSharedFile(
+      auth.token, auth.org, auth.repo,
+      `folders/${folderId}/meta.json`, metaContent, null, "main",
+      `Share folder: ${folder.name}`
+    );
+    await this.syncStore.setSha(folderId, "meta", metaResult.sha);
+
+    // Push all builds in this folder
+    const builds = await this.buildStore.listBuilds();
+    for (const build of builds.filter((b) => b.folderId === folderId)) {
+      await this.pushBuild(build);
+    }
+
+    // Push all comps in this folder
+    const comps = await this.compStore.listComps();
+    for (const comp of comps.filter((c) => c.folderId === folderId)) {
+      await this.pushComp(comp);
+    }
+
+    // Mark folder as shared locally
+    await this.folderStore.upsertFolder({
+      id: folderId,
+      name: folder.name,
+      shared: true,
+      orgName: auth.org,
+      lastSyncedAt: new Date().toISOString(),
+    });
+  }
+
+  async unshareFolder(folderId) {
+    const folders = await this.folderStore.listFolders();
+    const folder = folders.find((f) => f.id === folderId);
+    if (!folder) return;
+
+    await this.folderStore.upsertFolder({
+      id: folderId,
+      name: folder.name,
+      shared: false,
+      orgName: undefined,
+      lastSyncedAt: undefined,
+    });
+    await this.syncStore.removeFolder(folderId);
+  }
+
+  // ─── Background poll ───────────────────────────────────────────────────────
+
+  startPolling(intervalMs = 5 * 60 * 1000) {
+    this.stopPolling();
+    this._pollTimer = setInterval(() => {
+      this.pullAll().catch((err) => {
+        console.error("Shared library poll error:", err.message);
+      });
+    }, intervalMs);
+  }
+
+  stopPolling() {
+    if (this._pollTimer) {
+      clearInterval(this._pollTimer);
+      this._pollTimer = null;
+    }
+  }
+
+  // ─── Debounced push ────────────────────────────────────────────────────────
+
+  schedulePush(type, item, delayMs = 2000) {
+    const key = `${type}:${item.id}`;
+    if (this._pushTimers.has(key)) {
+      clearTimeout(this._pushTimers.get(key));
+    }
+    this._pushTimers.set(key, setTimeout(async () => {
+      this._pushTimers.delete(key);
+      try {
+        if (type === "build") {
+          await this.pushBuild(item);
+        } else if (type === "comp") {
+          await this.pushComp(item);
+        }
+      } catch (err) {
+        console.error(`Shared library push failed for ${key}:`, err.message);
+      }
+    }, delayMs));
+  }
+}
+
+module.exports = { SharedLibrary };

--- a/src/main/sharedLibrary.js
+++ b/src/main/sharedLibrary.js
@@ -105,6 +105,19 @@ class SharedLibrary {
               id: folderId, name: meta.name, sortOrder: meta.sortOrder,
               shared: true, orgName: folder.orgName,
             });
+            // Restore any subfolders listed in meta that don't exist locally
+            if (Array.isArray(meta.subfolders)) {
+              const allFolders = await this.folderStore.listFolders();
+              for (const sf of meta.subfolders) {
+                if (!allFolders.find((f) => f.id === sf.id)) {
+                  await this.folderStore.upsertFolder({
+                    id: sf.id,
+                    name: sf.name,
+                    parentId: sf.parentId || folderId,
+                  });
+                }
+              }
+            }
             await this.syncStore.setSha(folderId, "meta", file.sha);
           }
         }
@@ -313,6 +326,82 @@ class SharedLibrary {
     }
   }
 
+  // ─── Folder meta push ──────────────────────────────────────────────────────
+
+  // Collect all direct and indirect children of rootId from allFolders array.
+  _collectDescendantFolders(rootId, allFolders) {
+    const result = [];
+    const queue = allFolders.filter((f) => f.parentId === rootId);
+    while (queue.length) {
+      const f = queue.shift();
+      result.push(f);
+      queue.push(...allFolders.filter((x) => x.parentId === f.id));
+    }
+    return result;
+  }
+
+  // Build the meta.json payload for a root shared folder (includes subfolders list).
+  async #buildMetaPayload(folderId, folder, allFolders) {
+    const subfolders = this._collectDescendantFolders(folderId, allFolders);
+    return JSON.stringify({
+      id: folder.id,
+      name: folder.name,
+      sortOrder: folder.sortOrder || 0,
+      createdAt: folder.createdAt,
+      updatedAt: folder.updatedAt,
+      subfolders: subfolders.map((sf) => ({
+        id: sf.id, name: sf.name, parentId: sf.parentId,
+      })),
+    }, null, 2);
+  }
+
+  // Push updated meta.json (folder name + subfolder list) for a root shared folder.
+  async pushFolderMeta(rootFolderId) {
+    const auth = await this.#getAuth();
+    if (!auth) return { conflict: false };
+
+    const allFolders = await this.folderStore.listFolders();
+    const folder = allFolders.find((f) => f.id === rootFolderId && f.shared);
+    if (!folder) return { conflict: false };
+
+    const metaContent = await this.#buildMetaPayload(rootFolderId, folder, allFolders);
+    const shas = await this.syncStore.getShas(rootFolderId);
+    const currentSha = shas["meta"] || null;
+
+    try {
+      const result = await api().putSharedFile(
+        auth.token, auth.org, auth.repo,
+        `folders/${rootFolderId}/meta.json`, metaContent, currentSha, "main",
+        `Update folder structure: ${folder.name}`
+      );
+      await this.syncStore.setSha(rootFolderId, "meta", result.sha);
+      return { conflict: false };
+    } catch (err) {
+      if (err.status === 409) return { conflict: true };
+      throw err;
+    }
+  }
+
+  // Debounced version — use from index.js when a subfolder is created/renamed/deleted.
+  schedulePushFolderMeta(rootFolderId, delayMs = 2000) {
+    const key = `meta:${rootFolderId}`;
+    if (this._pushTimers.has(key)) clearTimeout(this._pushTimers.get(key));
+    this._pushTimers.set(key, setTimeout(async () => {
+      this._pushTimers.delete(key);
+      try {
+        const result = await this.pushFolderMeta(rootFolderId);
+        if (result?.conflict) {
+          this._emit("sync-conflict", { type: "folder", id: rootFolderId, folderId: rootFolderId });
+        } else {
+          this._emit("sync-status", { status: "synced", folderId: rootFolderId });
+        }
+      } catch (err) {
+        console.error(`Shared library folder meta push failed for ${rootFolderId}:`, err.message);
+        this._emit("sync-status", { status: "error", folderId: rootFolderId });
+      }
+    }, delayMs));
+  }
+
   // ─── Share / unshare folder ─────────────────────────────────────────────────
 
   async shareFolder(folderId) {
@@ -321,17 +410,12 @@ class SharedLibrary {
 
     await api().ensureSharedRepo(auth.token, auth.org);
 
-    const folder = (await this.folderStore.listFolders()).find((f) => f.id === folderId);
+    const allFolders = await this.folderStore.listFolders();
+    const folder = allFolders.find((f) => f.id === folderId);
     if (!folder) throw new Error("Folder not found");
 
-    // Create meta.json
-    const metaContent = JSON.stringify({
-      id: folder.id,
-      name: folder.name,
-      sortOrder: folder.sortOrder || 0,
-      createdAt: folder.createdAt,
-      updatedAt: folder.updatedAt,
-    }, null, 2);
+    // Create meta.json (includes subfolder list)
+    const metaContent = await this.#buildMetaPayload(folderId, folder, allFolders);
 
     const metaResult = await api().putSharedFile(
       auth.token, auth.org, auth.repo,
@@ -341,9 +425,8 @@ class SharedLibrary {
     await this.syncStore.setSha(folderId, "meta", metaResult.sha);
 
     // Push all builds in this folder and any subfolders
-    const allFolders = await this.folderStore.listFolders();
     const folderTree = new Set([folderId]);
-    // collect all descendant folder IDs
+    // collect all descendant folder IDs (reuse allFolders already loaded above)
     const addChildren = (id) => {
       for (const f of allFolders.filter((f) => f.parentId === id)) {
         folderTree.add(f.id);

--- a/src/main/syncStore.js
+++ b/src/main/syncStore.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs/promises");
+
+class SyncStore {
+  constructor(baseDir) {
+    this.syncPath = path.join(baseDir, "syncState.json");
+  }
+
+  async init() {
+    try {
+      await fs.access(this.syncPath);
+    } catch {
+      await fs.writeFile(this.syncPath, "{}", "utf-8");
+    }
+  }
+
+  async getState() {
+    const raw = await fs.readFile(this.syncPath, "utf-8");
+    return JSON.parse(raw);
+  }
+
+  async #write(state) {
+    await fs.writeFile(this.syncPath, JSON.stringify(state, null, 2), "utf-8");
+  }
+
+  async getShas(folderId) {
+    const state = await this.getState();
+    return state[folderId]?.remoteShas || {};
+  }
+
+  async setShas(folderId, shas) {
+    const state = await this.getState();
+    if (!state[folderId]) state[folderId] = {};
+    state[folderId].remoteShas = { ...shas };
+    await this.#write(state);
+  }
+
+  async setSha(folderId, filePath, sha) {
+    const state = await this.getState();
+    if (!state[folderId]) state[folderId] = {};
+    if (!state[folderId].remoteShas) state[folderId].remoteShas = {};
+    state[folderId].remoteShas[filePath] = sha;
+    await this.#write(state);
+  }
+
+  async removeSha(folderId, filePath) {
+    const state = await this.getState();
+    if (state[folderId]?.remoteShas) {
+      delete state[folderId].remoteShas[filePath];
+      await this.#write(state);
+    }
+  }
+
+  async removeFolder(folderId) {
+    const state = await this.getState();
+    delete state[folderId];
+    await this.#write(state);
+  }
+
+  async reset() {
+    await fs.writeFile(this.syncPath, "{}", "utf-8");
+  }
+}
+
+module.exports = { SyncStore };

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -108,4 +108,23 @@ contextBridge.exposeInMainWorld("desktopApi", {
     ipcRenderer.removeAllListeners("publish-progress");
     ipcRenderer.on("publish-progress", (_e, step) => cb(step));
   },
+  // Shared Library
+  listOrgs: () => ipcRenderer.invoke("shared-library:list-orgs"),
+  setupSharedLibrary: (orgName) => ipcRenderer.invoke("shared-library:setup", orgName),
+  shareFolder: (folderId) => ipcRenderer.invoke("shared-library:share-folder", folderId),
+  unshareFolder: (folderId) => ipcRenderer.invoke("shared-library:unshare-folder", folderId),
+  pullFolder: (folderId) => ipcRenderer.invoke("shared-library:pull-folder", folderId),
+  pullAllShared: () => ipcRenderer.invoke("shared-library:pull-all"),
+  connectSharedLibrary: () => ipcRenderer.invoke("shared-library:connect"),
+  disconnectSharedLibrary: () => ipcRenderer.invoke("shared-library:disconnect"),
+  getSharedLibraryConfig: () => ipcRenderer.invoke("shared-library:get-config"),
+  forcePush: (type, item) => ipcRenderer.invoke("shared-library:force-push", type, item),
+  onSyncConflict: (cb) => {
+    ipcRenderer.removeAllListeners("sync-conflict");
+    ipcRenderer.on("sync-conflict", (_e, data) => cb(data));
+  },
+  onSyncStatus: (cb) => {
+    ipcRenderer.removeAllListeners("sync-status");
+    ipcRenderer.on("sync-status", (_e, status) => cb(status));
+  },
 });

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -72,6 +72,7 @@
           <button class="subnav__item" data-subtab="comps" type="button"><svg class="subnav__icon" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="1" width="6" height="6" rx="1"/><rect x="9" y="1" width="6" height="6" rx="1"/><rect x="1" y="9" width="6" height="6" rx="1"/><rect x="9" y="9" width="6" height="6" rx="1"/></svg> Comps</button>
           <div class="subnav__actions">
             <span id="saveStatus" class="subnav__save-status"></span>
+            <span id="syncStatus" class="subnav__sync-status"></span>
             <button id="saveBuildBtn" class="btn btn-secondary subnav__save-btn" type="button">
               <span id="saveDot" class="subnav__save-dot hidden"></span>
               Save

--- a/src/renderer/modules/comps/comp-detail.js
+++ b/src/renderer/modules/comps/comp-detail.js
@@ -707,9 +707,12 @@ function openAddBuildModal(comp) {
 
   // Available builds: those not already in this comp
   const currentBuildIds = new Set(comp.buildIds || []);
+  const compFolder = comp.folderId ? state.folders?.find((f) => f.id === comp.folderId) : null;
   const available = state.builds.filter((b) => {
     if (currentBuildIds.has(b.id)) return false;
     if (comp.gameMode && b.gameMode !== comp.gameMode) return false;
+    // For shared comps, only show builds from the same folder
+    if (compFolder?.shared && b.folderId !== comp.folderId) return false;
     return true;
   });
 

--- a/src/renderer/modules/library/content.js
+++ b/src/renderer/modules/library/content.js
@@ -176,6 +176,21 @@ function folderPathText(build) {
   return chain.join(" / ");
 }
 
+const _contentSyncSpinner = `<svg class="sync-spin" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 2a10 10 0 0 1 10 10"/></svg>`;
+const _contentSyncCheck = `<svg width="11" height="11" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd"/></svg>`;
+
+function contentSyncIndicatorHtml(folderId) {
+  const status = state.folderSyncStatus?.[folderId];
+  if (!status) return "";
+  if (status === "syncing") {
+    return `<span class="lib-content-sync-indicator lib-content-sync-indicator--syncing" title="Syncing\u2026">${_contentSyncSpinner}</span>`;
+  }
+  if (status === "synced") {
+    return `<span class="lib-content-sync-indicator lib-content-sync-indicator--synced" title="Synced">${_contentSyncCheck}</span>`;
+  }
+  return "";
+}
+
 /** Return HTML for the folder path breadcrumb shown in combined views. */
 function folderPathHtml(build) {
   if (!isCombinedView()) return "";
@@ -201,7 +216,7 @@ function renderListView(container) {
       (f) => `
         <div class="lib-list-row lib-list-row--folder" data-folder-id="${escapeHtml(f.id)}">
           <span class="lib-list-row__icon lib-list-row__icon--folder">${folderIcon}</span>
-          <span class="lib-list-row__title">${escapeHtml(f.name)}${f.shared ? `<span class="lib-shared-badge" title="Shared with ${escapeHtml(f.orgName || "org")}">${shareIcon}</span>` : ""}</span>
+          <span class="lib-list-row__title">${escapeHtml(f.name)}${f.shared ? `<span class="lib-shared-badge" title="Shared with ${escapeHtml(f.orgName || "org")}">${shareIcon}</span>` : ""}${contentSyncIndicatorHtml(f.id)}</span>
         </div>
       `
     )
@@ -300,7 +315,7 @@ function renderTableView(container) {
         <div class="lib-tv__row lib-tv__row--folder">
           <span class="lib-tv__action" data-toggle-table-folder="${escapeHtml(folder.id)}">${chevron}</span>
           <span class="lib-tv__icon"><span class="lib-table__folder-icon">${folderIcon}</span></span>
-          <span class="lib-tv__name">${escapeHtml(folder.name)}${folder.shared ? `<span class="lib-shared-badge" title="Shared with ${escapeHtml(folder.orgName || "org")}">${shareIcon}</span>` : ""}</span>
+          <span class="lib-tv__name">${escapeHtml(folder.name)}${folder.shared ? `<span class="lib-shared-badge" title="Shared with ${escapeHtml(folder.orgName || "org")}">${shareIcon}</span>` : ""}${contentSyncIndicatorHtml(folder.id)}</span>
           <span class="lib-tv__profession"></span>
           <span class="lib-tv__spec"></span>
           <span class="lib-tv__mode"></span>
@@ -427,7 +442,7 @@ function renderGridView(container) {
       (f) => `
         <div class="lib-grid-card lib-grid-card--folder" data-folder-id="${escapeHtml(f.id)}">
           <div class="lib-grid-card__folder-icon">${folderIcon}${f.shared ? `<span class="lib-shared-badge lib-shared-badge--grid" title="Shared with ${escapeHtml(f.orgName || "org")}">${shareIcon}</span>` : ""}</div>
-          <div class="lib-grid-card__title">${escapeHtml(f.name)}</div>
+          <div class="lib-grid-card__title">${escapeHtml(f.name)}${contentSyncIndicatorHtml(f.id)}</div>
         </div>
       `
     )
@@ -492,7 +507,7 @@ function renderIconView(container) {
       (f) => `
         <div class="lib-icon-item lib-icon-item--folder" data-folder-id="${escapeHtml(f.id)}">
           <div class="lib-icon-item__icon lib-icon-item__icon--folder">${folderIcon}${f.shared ? `<span class="lib-shared-badge lib-shared-badge--icon" title="Shared with ${escapeHtml(f.orgName || "org")}">${shareIcon}</span>` : ""}</div>
-          <div class="lib-icon-item__label">${escapeHtml(f.name)}</div>
+          <div class="lib-icon-item__label">${escapeHtml(f.name)}${contentSyncIndicatorHtml(f.id)}</div>
         </div>
       `
     )
@@ -579,7 +594,7 @@ function renderColumnsView(container) {
           <div class="lib-col__item lib-col__item--folder ${isSelected ? "lib-col__item--selected" : ""}"
                data-folder-id="${escapeHtml(f.id)}" data-col-index="${colIndex}">
             <span class="lib-col__icon lib-col__icon--folder">${folderIcon}</span>
-            <span class="lib-col__name">${escapeHtml(f.name)}${f.shared ? `<span class="lib-shared-badge" title="Shared with ${escapeHtml(f.orgName || "org")}">${shareIcon}</span>` : ""}</span>
+            <span class="lib-col__name">${escapeHtml(f.name)}${f.shared ? `<span class="lib-shared-badge" title="Shared with ${escapeHtml(f.orgName || "org")}">${shareIcon}</span>` : ""}${contentSyncIndicatorHtml(f.id)}</span>
             <span class="lib-col__chevron">${chevronRightIcon}</span>
           </div>
         `);

--- a/src/renderer/modules/library/content.js
+++ b/src/renderer/modules/library/content.js
@@ -15,6 +15,7 @@ import {
   chevronDownIcon,
   chevronRightIcon,
   compIcon,
+  shareIcon,
 } from "./heroicons.js";
 
 let _callbacks = {};
@@ -200,7 +201,7 @@ function renderListView(container) {
       (f) => `
         <div class="lib-list-row lib-list-row--folder" data-folder-id="${escapeHtml(f.id)}">
           <span class="lib-list-row__icon lib-list-row__icon--folder">${folderIcon}</span>
-          <span class="lib-list-row__title">${escapeHtml(f.name)}</span>
+          <span class="lib-list-row__title">${escapeHtml(f.name)}${f.shared ? `<span class="lib-shared-badge" title="Shared with ${escapeHtml(f.orgName || "org")}">${shareIcon}</span>` : ""}</span>
         </div>
       `
     )
@@ -299,7 +300,7 @@ function renderTableView(container) {
         <div class="lib-tv__row lib-tv__row--folder">
           <span class="lib-tv__action" data-toggle-table-folder="${escapeHtml(folder.id)}">${chevron}</span>
           <span class="lib-tv__icon"><span class="lib-table__folder-icon">${folderIcon}</span></span>
-          <span class="lib-tv__name">${escapeHtml(folder.name)}</span>
+          <span class="lib-tv__name">${escapeHtml(folder.name)}${folder.shared ? `<span class="lib-shared-badge" title="Shared with ${escapeHtml(folder.orgName || "org")}">${shareIcon}</span>` : ""}</span>
           <span class="lib-tv__profession"></span>
           <span class="lib-tv__spec"></span>
           <span class="lib-tv__mode"></span>
@@ -425,7 +426,7 @@ function renderGridView(container) {
     .map(
       (f) => `
         <div class="lib-grid-card lib-grid-card--folder" data-folder-id="${escapeHtml(f.id)}">
-          <div class="lib-grid-card__folder-icon">${folderIcon}</div>
+          <div class="lib-grid-card__folder-icon">${folderIcon}${f.shared ? `<span class="lib-shared-badge lib-shared-badge--grid" title="Shared with ${escapeHtml(f.orgName || "org")}">${shareIcon}</span>` : ""}</div>
           <div class="lib-grid-card__title">${escapeHtml(f.name)}</div>
         </div>
       `
@@ -490,7 +491,7 @@ function renderIconView(container) {
     .map(
       (f) => `
         <div class="lib-icon-item lib-icon-item--folder" data-folder-id="${escapeHtml(f.id)}">
-          <div class="lib-icon-item__icon lib-icon-item__icon--folder">${folderIcon}</div>
+          <div class="lib-icon-item__icon lib-icon-item__icon--folder">${folderIcon}${f.shared ? `<span class="lib-shared-badge lib-shared-badge--icon" title="Shared with ${escapeHtml(f.orgName || "org")}">${shareIcon}</span>` : ""}</div>
           <div class="lib-icon-item__label">${escapeHtml(f.name)}</div>
         </div>
       `
@@ -578,7 +579,7 @@ function renderColumnsView(container) {
           <div class="lib-col__item lib-col__item--folder ${isSelected ? "lib-col__item--selected" : ""}"
                data-folder-id="${escapeHtml(f.id)}" data-col-index="${colIndex}">
             <span class="lib-col__icon lib-col__icon--folder">${folderIcon}</span>
-            <span class="lib-col__name">${escapeHtml(f.name)}</span>
+            <span class="lib-col__name">${escapeHtml(f.name)}${f.shared ? `<span class="lib-shared-badge" title="Shared with ${escapeHtml(f.orgName || "org")}">${shareIcon}</span>` : ""}</span>
             <span class="lib-col__chevron">${chevronRightIcon}</span>
           </div>
         `);

--- a/src/renderer/modules/library/context-menu.js
+++ b/src/renderer/modules/library/context-menu.js
@@ -5,6 +5,7 @@
 import { escapeHtml } from "../utils.js";
 import { state } from "../state.js";
 import { isSelected, getSelection, isCompSelected, getCompSelection } from "./selection.js";
+import { shareFolder, unshareFolder, pullFolder } from "./folder-store.js";
 import {
   playIcon,
   pencilIcon,
@@ -30,6 +31,7 @@ import {
   axiforgeIcon,
   compPlusIcon,
   squaresIcon,
+  shareIcon,
 } from "./heroicons.js";
 
 let _callbacks = {};
@@ -198,6 +200,9 @@ function showMultiCompSelectMenu(x, y, ids) {
 }
 
 function showFolderMenu(x, y, folderId, folder) {
+  const isShared = folder?.shared;
+  const hasSharedLibrary = !!state.sharedLibraryConfig;
+
   const items = [
     _item(folderOpenIcon, "Open Folder", null, () => _callbacks.onOpenFolder?.(folderId)),
     _item(pencilIcon, "Rename", "F2", () => _callbacks.onRenameFolder?.(folderId)),
@@ -215,6 +220,25 @@ function showFolderMenu(x, y, folderId, folder) {
     _sep(),
     _item(clipboardIcon, "Paste", "Ctrl+V", () => _callbacks.onPasteJson?.(folderId)),
     _sep(),
+    ...(isShared ? [
+      _item(shareIcon, "Sync Now", null, async () => {
+        await pullFolder(folderId);
+        _callbacks.onRefresh?.();
+      }),
+      _item(trashIcon, "Unshare Folder", null, async () => {
+        if (confirm(`Stop sharing "${folder?.name || folderId}"? Your local copies will be kept.`)) {
+          await unshareFolder(folderId);
+          _callbacks.onRefresh?.();
+        }
+      }, true),
+    ] : hasSharedLibrary ? [
+      _item(shareIcon, "Share to Org", null, async () => {
+        if (confirm(`Share "${folder?.name || folderId}" to your org? All builds in this folder will be visible to org members.`)) {
+          await shareFolder(folderId);
+          _callbacks.onRefresh?.();
+        }
+      }),
+    ] : []),
     _item(trashIcon, "Delete Folder", null, () => _callbacks.onDeleteFolder?.(folderId), true),
   ];
   _showMenu(x, y, items);

--- a/src/renderer/modules/library/context-menu.js
+++ b/src/renderer/modules/library/context-menu.js
@@ -4,6 +4,7 @@
 
 import { escapeHtml } from "../utils.js";
 import { state } from "../state.js";
+import { showConfirmModal } from "../confirm-modal.js";
 import { isSelected, getSelection, isCompSelected, getCompSelection } from "./selection.js";
 import { shareFolder, unshareFolder, pullFolder } from "./folder-store.js";
 import {
@@ -226,14 +227,26 @@ function showFolderMenu(x, y, folderId, folder) {
         _callbacks.onRefresh?.();
       }),
       _item(trashIcon, "Unshare Folder", null, async () => {
-        if (confirm(`Stop sharing "${folder?.name || folderId}"? Your local copies will be kept.`)) {
+        const confirmed = await showConfirmModal({
+          title: "Unshare Folder",
+          body: `Stop sharing <strong>${escapeHtml(folder?.name || folderId)}</strong>? Your local copies will be kept.`,
+          confirmLabel: "Unshare",
+          cancelLabel: "Cancel",
+        });
+        if (confirmed) {
           await unshareFolder(folderId);
           _callbacks.onRefresh?.();
         }
       }, true),
     ] : hasSharedLibrary ? [
       _item(shareIcon, "Share to Org", null, async () => {
-        if (confirm(`Share "${folder?.name || folderId}" to your org? All builds in this folder will be visible to org members.`)) {
+        const confirmed = await showConfirmModal({
+          title: "Share to Org",
+          body: `Share <strong>${escapeHtml(folder?.name || folderId)}</strong> to your org? All builds in this folder will be visible to org members.`,
+          confirmLabel: "Share",
+          cancelLabel: "Cancel",
+        });
+        if (confirmed) {
           await shareFolder(folderId);
           _callbacks.onRefresh?.();
         }

--- a/src/renderer/modules/library/folder-store.js
+++ b/src/renderer/modules/library/folder-store.js
@@ -44,6 +44,27 @@ export async function reorderBuilds(updates) {
   state.builds = await window.desktopApi.listBuilds();
 }
 
+/** Share a folder to the org shared library. */
+export async function shareFolder(folderId) {
+  await window.desktopApi.shareFolder(folderId);
+  await loadFolders();
+  state.builds = await window.desktopApi.listBuilds();
+}
+
+/** Remove a folder from the org shared library. */
+export async function unshareFolder(folderId) {
+  await window.desktopApi.unshareFolder(folderId);
+  await loadFolders();
+}
+
+/** Pull the latest from remote for a shared folder. */
+export async function pullFolder(folderId) {
+  await window.desktopApi.pullFolder(folderId);
+  await loadFolders();
+  state.builds = await window.desktopApi.listBuilds();
+  state.comps = await window.desktopApi.listComps();
+}
+
 export async function reorderComps(updates) {
   await window.desktopApi.reorderComps(updates);
   state.comps = await window.desktopApi.listComps();

--- a/src/renderer/modules/library/heroicons.js
+++ b/src/renderer/modules/library/heroicons.js
@@ -81,3 +81,6 @@ export const compIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20
 
 // Grid + plus overlay — used for "New Comp" context menu item
 export const compPlusIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4.25 2A2.25 2.25 0 0 0 2 4.25v2.5A2.25 2.25 0 0 0 4.25 9h2.5A2.25 2.25 0 0 0 9 6.75v-2.5A2.25 2.25 0 0 0 6.75 2h-2.5Zm0 9A2.25 2.25 0 0 0 2 13.25v2.5A2.25 2.25 0 0 0 4.25 18h2.5A2.25 2.25 0 0 0 9 15.75v-2.5A2.25 2.25 0 0 0 6.75 11h-2.5Zm9-9A2.25 2.25 0 0 0 11 4.25v2.5A2.25 2.25 0 0 0 13.25 9h2.5A2.25 2.25 0 0 0 18 6.75v-2.5A2.25 2.25 0 0 0 15.75 2h-2.5Z" clip-rule="evenodd"/><path d="M14.5 11a.75.75 0 0 1 .75.75v1.75h1.75a.75.75 0 0 1 0 1.5h-1.75v1.75a.75.75 0 0 1-1.5 0V15h-1.75a.75.75 0 0 1 0-1.5h1.75v-1.75a.75.75 0 0 1 .75-.75Z"/></svg>`;
+
+// Share / network node icon — used for shared folder badge
+export const shareIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="12" height="12"><path d="M13 4.5a2.5 2.5 0 1 1 .702 1.737L6.97 9.604a2.518 2.518 0 0 1 0 .792l6.733 3.367a2.5 2.5 0 1 1-.671 1.341l-6.733-3.367a2.5 2.5 0 1 1 0-3.474l6.733-3.367A2.52 2.52 0 0 1 13 4.5Z"/></svg>`;

--- a/src/renderer/modules/library/library.js
+++ b/src/renderer/modules/library/library.js
@@ -70,6 +70,7 @@ export async function initLibrary(appCallbacks) {
   initContent(shared);
   initContextMenu(shared);
   initDragDrop(shared);
+
 }
 
 /**
@@ -439,7 +440,7 @@ async function handleCutJson(idOrIds) {
 
 let _toastEl = null;
 let _toastTimer = null;
-function showToast(message, type = "success") {
+export function showToast(message, type = "success") {
   if (!_toastEl) {
     _toastEl = document.createElement("div");
     _toastEl.className = "lib-toast";

--- a/src/renderer/modules/library/library.js
+++ b/src/renderer/modules/library/library.js
@@ -58,6 +58,7 @@ export async function initLibrary(appCallbacks) {
   try {
     await loadFolders();
     await loadPrefs();
+    state.sharedLibraryConfig = await window.desktopApi.getSharedLibraryConfig().catch(() => null);
   } catch (err) {
     console.warn("[library] init data load failed:", err);
   }

--- a/src/renderer/modules/library/library.js
+++ b/src/renderer/modules/library/library.js
@@ -1111,6 +1111,19 @@ async function handleEditTags(idOrIds) {
 function handleOpenFolder(folderId) {
   state.currentFolder = { type: "custom", id: folderId };
   renderLibrary();
+
+  // Pull latest from remote when navigating to a shared folder
+  const folderObj = state.folders.find((f) => f.id === folderId);
+  if (folderObj?.shared) {
+    window.desktopApi.pullFolder(folderId).then(async () => {
+      state.builds = await window.desktopApi.listBuilds();
+      state.comps = await window.desktopApi.listComps();
+      state.folders = await window.desktopApi.listFolders();
+      renderLibrary();
+    }).catch(() => {
+      // Silently fail — will sync on next poll
+    });
+  }
 }
 
 async function handleMoveFolder(folderId, newParentId) {

--- a/src/renderer/modules/library/sidebar.js
+++ b/src/renderer/modules/library/sidebar.js
@@ -12,6 +12,7 @@ import {
   chevronDoubleLeftIcon,
   chevronDoubleRightIcon,
   compIcon,
+  shareIcon,
 } from "./heroicons.js";
 
 let _callbacks = {};
@@ -172,9 +173,24 @@ function renderMyFolders(expanded) {
     .filter((f) => f.parentId === null)
     .sort((a, b) => a.sortOrder - b.sortOrder);
 
-  const items = topLevel.map((f) => renderFolderItem(f, expanded, 0)).join("");
+  const sharedFolders = topLevel.filter((f) => f.shared);
+  const personalFolders = topLevel.filter((f) => !f.shared);
 
-  return `
+  const sharedItems = sharedFolders.map((f) => renderFolderItem(f, expanded, 0)).join("");
+  const personalItems = personalFolders.map((f) => renderFolderItem(f, expanded, 0)).join("");
+
+  let html = "";
+
+  if (sharedFolders.length > 0) {
+    html += `
+      <div class="lib-sidebar__section">
+        <div class="lib-sidebar__section-label">Shared Folders</div>
+        ${sharedItems}
+      </div>
+    `;
+  }
+
+  html += `
     <div class="lib-sidebar__section">
       <div class="lib-sidebar__section-header">
         <div class="lib-sidebar__section-label">My Folders</div>
@@ -182,9 +198,11 @@ function renderMyFolders(expanded) {
           ${folderPlusIcon}
         </button>
       </div>
-      ${items || `<div class="lib-sidebar__empty">No folders yet</div>`}
+      ${personalItems || `<div class="lib-sidebar__empty">No folders yet</div>`}
     </div>
   `;
+
+  return html;
 }
 
 function renderFolderItem(folder, expanded, depth) {
@@ -216,6 +234,7 @@ function renderFolderItem(folder, expanded, depth) {
         }
         <span class="lib-nav-item__icon">${isExpanded ? folderOpenIcon : folderIcon}</span>
         <span class="lib-nav-item__label">${escapeHtml(folder.name)}</span>
+        ${folder.shared ? `<span class="lib-nav-item__shared-badge" title="Shared with ${escapeHtml(folder.orgName || 'org')}">${shareIcon}</span>` : ""}
         <span class="lib-nav-item__count">${count}</span>
       </button>
       ${hasChildren && isExpanded ? `<div class="lib-nav-group">${childItems}</div>` : ""}

--- a/src/renderer/modules/library/sidebar.js
+++ b/src/renderer/modules/library/sidebar.js
@@ -235,11 +235,27 @@ function renderFolderItem(folder, expanded, depth) {
         <span class="lib-nav-item__icon">${isExpanded ? folderOpenIcon : folderIcon}</span>
         <span class="lib-nav-item__label">${escapeHtml(folder.name)}</span>
         ${folder.shared ? `<span class="lib-nav-item__shared-badge" title="Shared with ${escapeHtml(folder.orgName || 'org')}">${shareIcon}</span>` : ""}
+        ${_renderSyncIndicator(folder.id)}
         <span class="lib-nav-item__count">${count}</span>
       </button>
       ${hasChildren && isExpanded ? `<div class="lib-nav-group">${childItems}</div>` : ""}
     </div>
   `;
+}
+
+const _sidebarSyncSpinner = `<svg class="sync-spin" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 2a10 10 0 0 1 10 10"/></svg>`;
+const _sidebarSyncCheck = `<svg width="11" height="11" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd"/></svg>`;
+
+function _renderSyncIndicator(folderId) {
+  const syncStatus = state.folderSyncStatus?.[folderId];
+  if (!syncStatus) return "";
+  if (syncStatus === "syncing") {
+    return `<span class="lib-nav-item__sync-indicator lib-nav-item__sync-indicator--syncing" title="Syncing\u2026">${_sidebarSyncSpinner}</span>`;
+  }
+  if (syncStatus === "synced") {
+    return `<span class="lib-nav-item__sync-indicator lib-nav-item__sync-indicator--synced" title="Synced">${_sidebarSyncCheck}</span>`;
+  }
+  return "";
 }
 
 function gameModeLabel(id) {

--- a/src/renderer/modules/render-pages.js
+++ b/src/renderer/modules/render-pages.js
@@ -509,6 +509,17 @@ export function renderEditorForm() {
 // ---------------------------------------------------------------------------
 // renderEditorMeta
 // ---------------------------------------------------------------------------
+
+function _findRootSharedFolderInState(folderId) {
+  let current = state.folders.find((f) => f.id === folderId);
+  while (current) {
+    if (current.shared) return current;
+    if (!current.parentId) return null;
+    current = state.folders.find((f) => f.id === current.parentId);
+  }
+  return null;
+}
+
 export function renderEditorMeta() {
   if (state.editorDirty) {
     _el.saveDot.classList.remove("hidden");
@@ -528,6 +539,26 @@ export function renderEditorMeta() {
     }
     _el.saveStatus.classList.toggle("subnav__save-status--draft", isDraft);
     _el.saveStatus.classList.toggle("subnav__save-status--saved", !isDraft);
+  }
+
+  // Sync status for shared-folder builds
+  if (_el.syncStatus) {
+    const folderId = state.editor?.folderId;
+    const rootShared = folderId ? _findRootSharedFolderInState(folderId) : null;
+    const syncStatus = rootShared ? (state.folderSyncStatus[rootShared.id] || null) : null;
+    if (syncStatus === "syncing") {
+      _el.syncStatus.className = "subnav__sync-status subnav__sync-status--syncing";
+      _el.syncStatus.textContent = "Syncing\u2026";
+    } else if (syncStatus === "synced") {
+      _el.syncStatus.className = "subnav__sync-status subnav__sync-status--synced";
+      _el.syncStatus.textContent = "\u2713 Synced";
+    } else if (syncStatus === "error") {
+      _el.syncStatus.className = "subnav__sync-status subnav__sync-status--error";
+      _el.syncStatus.textContent = "Sync failed";
+    } else {
+      _el.syncStatus.className = "subnav__sync-status";
+      _el.syncStatus.textContent = "";
+    }
   }
 
   // Published link button (inside share dropdown)

--- a/src/renderer/modules/render-pages.js
+++ b/src/renderer/modules/render-pages.js
@@ -547,17 +547,16 @@ export function renderEditorMeta() {
     const rootShared = folderId ? _findRootSharedFolderInState(folderId) : null;
     const syncStatus = rootShared ? (state.folderSyncStatus[rootShared.id] || null) : null;
     if (syncStatus === "syncing") {
-      _el.syncStatus.className = "subnav__sync-status subnav__sync-status--syncing";
       _el.syncStatus.textContent = "Syncing\u2026";
+      _el.syncStatus.className = "subnav__sync-status subnav__sync-status--syncing subnav__sync-status--active";
     } else if (syncStatus === "synced") {
-      _el.syncStatus.className = "subnav__sync-status subnav__sync-status--synced";
       _el.syncStatus.textContent = "\u2713 Synced";
+      _el.syncStatus.className = "subnav__sync-status subnav__sync-status--synced subnav__sync-status--active";
     } else if (syncStatus === "error") {
-      _el.syncStatus.className = "subnav__sync-status subnav__sync-status--error";
       _el.syncStatus.textContent = "Sync failed";
+      _el.syncStatus.className = "subnav__sync-status subnav__sync-status--error subnav__sync-status--active";
     } else {
-      _el.syncStatus.className = "subnav__sync-status";
-      _el.syncStatus.textContent = "";
+      _el.syncStatus.classList.remove("subnav__sync-status--active");
     }
   }
 

--- a/src/renderer/modules/settings-modal.js
+++ b/src/renderer/modules/settings-modal.js
@@ -114,6 +114,27 @@ export function initSettingsModal() {
             <span class="settings-modal__cache-status" id="sm-cache-status"></span>
           </div>
         </div>
+        <div class="settings-modal__section" id="sm-shared-library-section">
+          <h4 class="settings-modal__section-title">
+            <svg class="settings-modal__section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+            Shared Library
+          </h4>
+          <span class="settings-modal__error" id="sm-shared-status"></span>
+          <div id="sm-shared-setup">
+            <label class="settings-modal__label" for="sm-org-select">Organization</label>
+            <select class="settings-modal__select" id="sm-org-select">
+              <option value="">Select an organization...</option>
+            </select>
+            <button class="settings-modal__btn settings-modal__btn--secondary" id="sm-shared-connect" type="button">Connect</button>
+          </div>
+          <div id="sm-shared-connected" class="settings-modal__shared-connected--hidden">
+            <div class="settings-modal__shared-info">
+              <span class="settings-modal__shared-org" id="sm-shared-org-name"></span>
+              <span class="settings-modal__shared-repo"> / axibuilds-shared</span>
+            </div>
+            <button class="settings-modal__btn settings-modal__btn--danger" id="sm-shared-disconnect" type="button">Disconnect</button>
+          </div>
+        </div>
       </div>
       <div class="settings-modal__actions">
         <button class="settings-modal__btn settings-modal__btn--save" id="sm-save">Save</button>
@@ -141,12 +162,21 @@ export function initSettingsModal() {
     save:              document.getElementById("sm-save"),
     clearCache:        document.getElementById("sm-clear-cache"),
     cacheStatus:       document.getElementById("sm-cache-status"),
+    sharedStatus:      document.getElementById("sm-shared-status"),
+    sharedSetup:       document.getElementById("sm-shared-setup"),
+    sharedConnected:   document.getElementById("sm-shared-connected"),
+    orgSelect:         document.getElementById("sm-org-select"),
+    sharedConnect:     document.getElementById("sm-shared-connect"),
+    sharedDisconnect:  document.getElementById("sm-shared-disconnect"),
+    sharedOrgName:     document.getElementById("sm-shared-org-name"),
   };
   _el.themedBuilds = _overlay.querySelector("#sm-themed-builds");
 
   _el.close.addEventListener("click", _close);
   _el.save.addEventListener("click", _save);
   _el.clearCache.addEventListener("click", _clearCache);
+  _el.sharedConnect.addEventListener("click", _connectSharedLibrary);
+  _el.sharedDisconnect.addEventListener("click", _disconnectSharedLibrary);
 
   // Toggle thread ID input visibility for comp webhook
   _el.threadMode.addEventListener("change", (e) => {
@@ -207,6 +237,9 @@ export async function openSettingsModal() {
 
   // Populate publishing section
   _renderPublishing();
+
+  // Populate shared library section
+  _loadSharedLibraryState();
 
   _overlay.classList.remove("settings-modal-overlay--hidden");
   _escHandler = (e) => { if (e.key === "Escape") _close(); };
@@ -564,4 +597,57 @@ function _close() {
     document.removeEventListener("keydown", _escHandler);
     _escHandler = null;
   }
+}
+
+// ─── Shared Library section ──────────────────────────────────────────────────
+
+async function _loadSharedLibraryState() {
+  if (!_el.sharedSetup) return;
+  _el.sharedStatus.textContent = "";
+  const config = await window.desktopApi.getSharedLibraryConfig();
+  if (config?.orgName) {
+    _el.sharedSetup.style.display = "none";
+    _el.sharedConnected.classList.remove("settings-modal__shared-connected--hidden");
+    _el.sharedOrgName.textContent = config.orgName;
+  } else {
+    _el.sharedConnected.classList.add("settings-modal__shared-connected--hidden");
+    _el.sharedSetup.style.display = "";
+    const session = await window.desktopApi.getSession();
+    if (session) {
+      const orgs = await window.desktopApi.listOrgs();
+      _el.orgSelect.innerHTML = '<option value="">Select an organization...</option>';
+      for (const org of orgs) {
+        const opt = document.createElement("option");
+        opt.value = org.login;
+        opt.textContent = org.login;
+        _el.orgSelect.appendChild(opt);
+      }
+    } else {
+      _el.sharedStatus.textContent = "Log in to GitHub first to set up sharing.";
+    }
+  }
+}
+
+async function _connectSharedLibrary() {
+  const org = _el.orgSelect.value;
+  if (!org) return;
+  _el.sharedConnect.disabled = true;
+  _el.sharedConnect.textContent = "Connecting...";
+  _el.sharedStatus.textContent = "";
+  try {
+    await window.desktopApi.setupSharedLibrary(org);
+    await window.desktopApi.connectSharedLibrary();
+    await _loadSharedLibraryState();
+  } catch (err) {
+    _el.sharedStatus.textContent = `Error: ${err.message}`;
+  } finally {
+    _el.sharedConnect.disabled = false;
+    _el.sharedConnect.textContent = "Connect";
+  }
+}
+
+async function _disconnectSharedLibrary() {
+  if (!confirm("Disconnect from shared library? Your local copies will be kept.")) return;
+  await window.desktopApi.disconnectSharedLibrary();
+  await _loadSharedLibraryState();
 }

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -50,6 +50,7 @@ export const state = {
     boonCoverageCollapsed: false,
   },
   sharedLibraryConfig: null,  // { orgName, repoName } or null
+  folderSyncStatus: {},  // map of folderId → "syncing"|"synced"|"error"
   skillSearch: "",
   catalogCache: new Map(),
   activeCatalog: null,

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -49,6 +49,7 @@ export const state = {
     viewMode: "expanded",
     boonCoverageCollapsed: false,
   },
+  sharedLibraryConfig: null,  // { orgName, repoName } or null
   skillSearch: "",
   catalogCache: new Map(),
   activeCatalog: null,

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -78,8 +78,8 @@ const _syncCheckSvg = `<svg width="12" height="12" viewBox="0 0 20 20" fill="cur
 
 // Apply or remove a sync indicator on all sidebar/content folder elements for folderId.
 function _updateFolderSyncIndicators(folderId, status) {
-  const selector = `[data-navigate-folder="${CSS.escape(folderId)}"]`;
-  document.querySelectorAll(selector).forEach((navEl) => {
+  // Sidebar nav items
+  document.querySelectorAll(`[data-navigate-folder="${CSS.escape(folderId)}"]`).forEach((navEl) => {
     let badge = navEl.querySelector(".lib-nav-item__sync-indicator");
     if (!status) {
       badge?.remove();
@@ -88,7 +88,6 @@ function _updateFolderSyncIndicators(folderId, status) {
     if (!badge) {
       badge = document.createElement("span");
       badge.className = "lib-nav-item__sync-indicator";
-      // Insert just before the count badge (last child), or append
       const countEl = navEl.querySelector(".lib-nav-item__count");
       if (countEl) {
         navEl.insertBefore(badge, countEl);
@@ -99,6 +98,26 @@ function _updateFolderSyncIndicators(folderId, status) {
     badge.className = `lib-nav-item__sync-indicator lib-nav-item__sync-indicator--${status}`;
     badge.innerHTML = status === "syncing" ? _syncSpinnerSvg : status === "synced" ? _syncCheckSvg : "";
     badge.title = status === "syncing" ? "Syncing to shared library…" : status === "synced" ? "Synced" : "Sync error";
+  });
+
+  // Content area folder cards (list/table/grid/icon/columns views)
+  document.querySelectorAll(`[data-folder-id="${CSS.escape(folderId)}"]`).forEach((cardEl) => {
+    let badge = cardEl.querySelector(".lib-content-sync-indicator");
+    if (!status) {
+      badge?.remove();
+      return;
+    }
+    if (!badge) {
+      badge = document.createElement("span");
+      // Find the best anchor: a name/title/label span, or fall back to the card itself
+      const nameEl =
+        cardEl.querySelector(".lib-list-row__title, .lib-tv__name, .lib-grid-card__title, .lib-icon-item__label, .lib-col__name") ||
+        cardEl;
+      nameEl.appendChild(badge);
+    }
+    badge.className = `lib-content-sync-indicator lib-content-sync-indicator--${status}`;
+    badge.innerHTML = status === "syncing" ? _syncSpinnerSvg : status === "synced" ? _syncCheckSvg : "";
+    badge.title = status === "syncing" ? "Syncing…" : status === "synced" ? "Synced" : "Sync error";
   });
 }
 

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -47,7 +47,7 @@ import { initDetailModal, openDetailModal } from "./modules/detail-modal.js";
 import { initConfirmModal } from "./modules/confirm-modal.js";
 import { initImportConflictModal } from "./modules/import-conflict-modal.js";
 import { initSettingsModal, initSettingsCallbacks } from "./modules/settings-modal.js";
-import { initLibrary, renderLibrary, handleLibraryKeydown } from "./modules/library/library.js";
+import { initLibrary, renderLibrary, handleLibraryKeydown, showToast } from "./modules/library/library.js";
 import { clearUndo as clearLibraryUndo } from "./modules/library/undo.js";
 import { initComps, loadComps, renderComps } from "./modules/comps/comps.js";
 import { getProfessionSvg } from "./modules/profession-icons.js";
@@ -58,6 +58,49 @@ import { PROFESSION_THEMES } from "./modules/constants.js";
 let _lastGameMode = "pve";
 let _stashedTheme = null;
 let _themedBuildsEnabled = false;
+
+// ── Sync-status helpers ──────────────────────────────────────────────────────
+
+// Walk up the parentId chain in state.folders to find the nearest folder with shared:true.
+function _findRootSharedFolderInState(folderId) {
+  let current = state.folders.find((f) => f.id === folderId);
+  while (current) {
+    if (current.shared) return current;
+    if (!current.parentId) return null;
+    current = state.folders.find((f) => f.id === current.parentId);
+  }
+  return null;
+}
+
+// Inline SVGs for sync indicators (no external imports needed)
+const _syncSpinnerSvg = `<svg class="sync-spin" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 2a10 10 0 0 1 10 10"/></svg>`;
+const _syncCheckSvg = `<svg width="12" height="12" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd"/></svg>`;
+
+// Apply or remove a sync indicator on all sidebar/content folder elements for folderId.
+function _updateFolderSyncIndicators(folderId, status) {
+  const selector = `[data-navigate-folder="${CSS.escape(folderId)}"]`;
+  document.querySelectorAll(selector).forEach((navEl) => {
+    let badge = navEl.querySelector(".lib-nav-item__sync-indicator");
+    if (!status) {
+      badge?.remove();
+      return;
+    }
+    if (!badge) {
+      badge = document.createElement("span");
+      badge.className = "lib-nav-item__sync-indicator";
+      // Insert just before the count badge (last child), or append
+      const countEl = navEl.querySelector(".lib-nav-item__count");
+      if (countEl) {
+        navEl.insertBefore(badge, countEl);
+      } else {
+        navEl.appendChild(badge);
+      }
+    }
+    badge.className = `lib-nav-item__sync-indicator lib-nav-item__sync-indicator--${status}`;
+    badge.innerHTML = status === "syncing" ? _syncSpinnerSvg : status === "synced" ? _syncCheckSvg : "";
+    badge.title = status === "syncing" ? "Syncing to shared library…" : status === "synced" ? "Synced" : "Sync error";
+  });
+}
 
 // ── DOM element cache ────────────────────────────────────────────────────────
 
@@ -86,6 +129,7 @@ const el = {
   saveBuildBtn:      q("#saveBuildBtn"),
   saveDot:           q("#saveDot"),
   saveStatus:        q("#saveStatus"),
+  syncStatus:        q("#syncStatus"),
   editorSharePubLink: document.querySelector("#editorShareDropdown [data-action='copy-published-link']"),
   duplicateBuildBtn: q("#duplicateBuildBtn"),
   copyBuildBtn:      q("#copyBuildBtn"),
@@ -384,6 +428,37 @@ async function init() {
     importBuildJsonFromClipboard,
     render,
   });
+  // ── Global sync-status / conflict handlers ───────────────────────────────
+  // Registered once here (after initLibrary) so preload's removeAllListeners
+  // doesn't clobber a handler added in library.js.
+  window.desktopApi.onSyncStatus?.((data) => {
+    if (!data || typeof data !== "object") return;
+    const { status, folderId } = data;
+    if (!folderId || !status) return;
+
+    // Resolve to root shared folder so we key by the folder visible in the sidebar
+    const rootShared = _findRootSharedFolderInState(folderId);
+    const trackId = rootShared?.id || folderId;
+    state.folderSyncStatus[trackId] = status;
+
+    renderEditorMeta();
+    _updateFolderSyncIndicators(trackId, status);
+
+    if (status === "synced") {
+      setTimeout(() => {
+        if (state.folderSyncStatus[trackId] === "synced") {
+          delete state.folderSyncStatus[trackId];
+          renderEditorMeta();
+          _updateFolderSyncIndicators(trackId, null);
+        }
+      }, 3000);
+    }
+  });
+
+  window.desktopApi.onSyncConflict?.((data) => {
+    showToast(`Sync conflict on \u201c${data?.title || "item"}\u201d \u2014 pull to refresh`, "warning");
+  });
+
   initComps({
     navigateToPage,
     loadBuildIntoEditor,

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -324,10 +324,17 @@ body:has(.app-layout) {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease,
+              color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
 }
 
-.subnav__sync-status:empty {
-  display: none;
+.subnav__sync-status--active {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 
 .subnav__sync-status--syncing {

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -313,6 +313,40 @@ body:has(.app-layout) {
   border-color: rgba(var(--accent-rgb), 0.3);
 }
 
+.subnav__sync-status {
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+  padding: 3px 8px;
+  border-radius: 20px;
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.subnav__sync-status:empty {
+  display: none;
+}
+
+.subnav__sync-status--syncing {
+  color: var(--text-dim);
+  border-color: var(--border);
+}
+
+.subnav__sync-status--synced {
+  color: #4caf50;
+  border-color: rgba(76, 175, 80, 0.35);
+  background: rgba(76, 175, 80, 0.08);
+}
+
+.subnav__sync-status--error {
+  color: #e57373;
+  border-color: rgba(229, 115, 115, 0.35);
+  background: rgba(229, 115, 115, 0.08);
+}
+
 .subnav__save-btn {
   display: flex;
   align-items: center;

--- a/src/renderer/styles/library.css
+++ b/src/renderer/styles/library.css
@@ -1828,6 +1828,27 @@
   color: #4caf50;
 }
 
+/* ── Content area folder sync indicators ─────────────────────────────────── */
+
+.lib-content-sync-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  vertical-align: middle;
+  margin-left: 4px;
+}
+
+.lib-content-sync-indicator--syncing {
+  color: var(--text-dim);
+}
+
+.lib-content-sync-indicator--synced {
+  color: #4caf50;
+}
+
 /* Spinner animation for syncing state */
 @keyframes sync-spin {
   to { transform: rotate(360deg); }

--- a/src/renderer/styles/library.css
+++ b/src/renderer/styles/library.css
@@ -1767,3 +1767,73 @@
 .lib-grid-card:nth-child(7) { animation-delay: 240ms; }
 .lib-grid-card:nth-child(8) { animation-delay: 280ms; }
 .lib-grid-card:nth-child(n+9) { animation-delay: 320ms; }
+
+/* ── Shared folder badge ─────────────────────────────────────────────────── */
+
+.lib-shared-badge {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  margin-left: 6px;
+  color: var(--accent);
+  opacity: 0.75;
+  flex-shrink: 0;
+}
+
+.lib-shared-badge svg {
+  width: 11px;
+  height: 11px;
+}
+
+/* Grid/icon view: overlay badge on folder icon */
+.lib-grid-card__folder-icon,
+.lib-icon-item__icon--folder {
+  position: relative;
+}
+
+.lib-shared-badge--grid,
+.lib-shared-badge--icon {
+  position: absolute;
+  bottom: -2px;
+  right: -4px;
+  margin: 0;
+  background: var(--bg-2);
+  border-radius: 50%;
+  padding: 1px;
+  opacity: 1;
+}
+
+.lib-shared-badge--grid svg,
+.lib-shared-badge--icon svg {
+  width: 10px;
+  height: 10px;
+}
+
+/* ── Sidebar folder sync indicators ─────────────────────────────────────── */
+
+.lib-nav-item__sync-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+}
+
+.lib-nav-item__sync-indicator--syncing {
+  color: var(--text-dim);
+}
+
+.lib-nav-item__sync-indicator--synced {
+  color: #4caf50;
+}
+
+/* Spinner animation for syncing state */
+@keyframes sync-spin {
+  to { transform: rotate(360deg); }
+}
+
+.sync-spin {
+  animation: sync-spin 0.8s linear infinite;
+  transform-origin: center;
+}

--- a/src/renderer/styles/settings-modal.css
+++ b/src/renderer/styles/settings-modal.css
@@ -543,6 +543,112 @@
   color: var(--accent);
 }
 
+/* ── Select ──────────────────────────────────────────────────────────── */
+
+.settings-modal__select {
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 0.8rem;
+  padding: 8px 32px 8px 12px;
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-sm);
+  background: var(--input-bg);
+  color: var(--text);
+  outline: none;
+  font-family: inherit;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='%23888'%3E%3Cpath fill-rule='evenodd' d='M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06z' clip-rule='evenodd'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 16px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.settings-modal__select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.settings-modal__select option {
+  background: var(--bg-2);
+  color: var(--text);
+}
+
+/* ── Button variants ─────────────────────────────────────────────────── */
+
+.settings-modal__btn--secondary {
+  background: rgba(var(--accent-rgb), 0.08);
+  color: var(--accent);
+  border-color: rgba(var(--accent-rgb), 0.35);
+}
+
+.settings-modal__btn--secondary:hover {
+  background: rgba(var(--accent-rgb), 0.16);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.settings-modal__btn--danger {
+  background: rgba(197, 72, 95, 0.08);
+  color: var(--danger-text);
+  border-color: rgba(197, 72, 95, 0.3);
+}
+
+.settings-modal__btn--danger:hover {
+  background: rgba(197, 72, 95, 0.16);
+  border-color: var(--danger-text);
+  color: var(--danger-text);
+}
+
+/* ── Shared Library section ──────────────────────────────────────────── */
+
+.settings-modal__shared-connected--hidden {
+  display: none;
+}
+
+#sm-shared-setup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#sm-shared-setup .settings-modal__btn {
+  align-self: flex-start;
+}
+
+.settings-modal__shared-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+}
+
+.settings-modal__shared-org {
+  font-weight: 700;
+  color: var(--text);
+}
+
+.settings-modal__shared-repo {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+#sm-shared-connected {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#sm-shared-connected .settings-modal__btn {
+  align-self: flex-start;
+}
+
 /* ── Themed builds toggle ─────────────────────────────────────────────── */
 .settings-modal__toggle {
   display: flex;

--- a/tests/unit/folderStore.test.js
+++ b/tests/unit/folderStore.test.js
@@ -247,11 +247,11 @@ describe("FolderStore — shared folder fields", () => {
     ).rejects.toThrow("Shared folders must be top-level");
   });
 
-  test("non-shared folders cannot nest under shared folders", async () => {
+  test("non-shared folders can nest under shared folders", async () => {
     const shared = await store.upsertFolder({ name: "Shared", shared: true, orgName: "org" });
-    await expect(
-      store.upsertFolder({ name: "Child", parentId: shared.id })
-    ).rejects.toThrow("Cannot nest folders under a shared folder");
+    const child = await store.upsertFolder({ name: "Child", parentId: shared.id });
+    expect(child.parentId).toBe(shared.id);
+    expect(child.shared).toBeUndefined();
   });
 
   test("caller-specified id is preserved on create", async () => {

--- a/tests/unit/folderStore.test.js
+++ b/tests/unit/folderStore.test.js
@@ -215,3 +215,47 @@ describe("FolderStore — touchFolders", () => {
     // Should not throw
   });
 });
+
+describe("FolderStore — shared folder fields", () => {
+  let store, dir;
+  beforeEach(async () => ({ store, dir } = await makeTempStore()));
+  afterEach(async () => cleanupDir(dir));
+
+  test("upsertFolder preserves shared field on create", async () => {
+    const folder = await store.upsertFolder({ name: "Shared", shared: true, orgName: "test-org" });
+    expect(folder.shared).toBe(true);
+    expect(folder.orgName).toBe("test-org");
+  });
+
+  test("upsertFolder preserves shared fields on update", async () => {
+    const folder = await store.upsertFolder({ name: "Shared", shared: true, orgName: "test-org" });
+    const updated = await store.upsertFolder({ id: folder.id, name: "Renamed", shared: true, orgName: "test-org", lastSyncedAt: "2026-01-01T00:00:00Z" });
+    expect(updated.shared).toBe(true);
+    expect(updated.orgName).toBe("test-org");
+    expect(updated.lastSyncedAt).toBe("2026-01-01T00:00:00Z");
+  });
+
+  test("shared defaults to undefined when not provided", async () => {
+    const folder = await store.upsertFolder({ name: "Personal" });
+    expect(folder.shared).toBeUndefined();
+  });
+
+  test("shared folders cannot have a parentId", async () => {
+    const parent = await store.upsertFolder({ name: "Parent" });
+    await expect(
+      store.upsertFolder({ name: "Shared", shared: true, orgName: "org", parentId: parent.id })
+    ).rejects.toThrow("Shared folders must be top-level");
+  });
+
+  test("non-shared folders cannot nest under shared folders", async () => {
+    const shared = await store.upsertFolder({ name: "Shared", shared: true, orgName: "org" });
+    await expect(
+      store.upsertFolder({ name: "Child", parentId: shared.id })
+    ).rejects.toThrow("Cannot nest folders under a shared folder");
+  });
+
+  test("caller-specified id is preserved on create", async () => {
+    const folder = await store.upsertFolder({ id: "custom-id-123", name: "Remote", shared: true, orgName: "org" });
+    expect(folder.id).toBe("custom-id-123");
+  });
+});

--- a/tests/unit/githubApi.test.js
+++ b/tests/unit/githubApi.test.js
@@ -3,6 +3,7 @@
 const crypto = require("node:crypto");
 const {
   TARGET_REPO,
+  SHARED_REPO,
   getViewer,
   listTargets,
   ensureAxiForgeRepo,
@@ -11,6 +12,11 @@ const {
   ensurePagesWorkflow,
   publishSiteBundle,
   deleteFile,
+  ensureSharedRepo,
+  getRepoTree,
+  getFileContents,
+  putSharedFile,
+  deleteSharedFile,
 } = require("../../src/main/githubApi");
 
 const { createGithubMockFetch } = require("../helpers/mockFetch");
@@ -739,5 +745,99 @@ describe("deleteFile", () => {
   test("returns silently if file does not exist (404)", async () => {
     global.fetch = jest.fn(() => failRes(404));
     await deleteFile(FAKE_TOKEN, FAKE_OWNER, "site/builds/missing.enc", "main", "Remove");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shared Library API
+// ---------------------------------------------------------------------------
+
+describe("ensureSharedRepo", () => {
+  test("returns repo name if repo already exists", async () => {
+    global.fetch = jest.fn()
+      .mockReturnValueOnce(okRes({ name: "axibuilds-shared" }))  // GET repo
+      .mockReturnValueOnce(okRes({ name: "axibuilds-shared" })); // waitForRepo poll
+    const name = await ensureSharedRepo(FAKE_TOKEN, "test-org");
+    expect(name).toBe("axibuilds-shared");
+  });
+
+  test("creates private repo if 404", async () => {
+    global.fetch = jest.fn()
+      .mockReturnValueOnce(failRes(404))                         // GET repo → 404
+      .mockReturnValueOnce(okRes({ name: "axibuilds-shared" }))  // POST create
+      .mockReturnValueOnce(okRes({ name: "axibuilds-shared" })); // waitForRepo
+    const name = await ensureSharedRepo(FAKE_TOKEN, "test-org");
+    expect(name).toBe("axibuilds-shared");
+    // Verify POST was to org endpoint with private: true
+    const postCall = global.fetch.mock.calls[1];
+    expect(postCall[0]).toContain("/orgs/test-org/repos");
+    const body = JSON.parse(postCall[1].body);
+    expect(body.private).toBe(true);
+  });
+});
+
+describe("getRepoTree", () => {
+  test("returns flat file list with SHAs", async () => {
+    const tree = [
+      { path: "folders/f1/meta.json", sha: "aaa", type: "blob" },
+      { path: "folders/f1/builds/b1.json", sha: "bbb", type: "blob" },
+      { path: "folders/f1", sha: "ccc", type: "tree" },
+    ];
+    global.fetch = jest.fn()
+      .mockReturnValueOnce(okRes({ object: { sha: "head-sha" } }))  // ref
+      .mockReturnValueOnce(okRes({ tree: { sha: "tree-sha" } }))    // commit
+      .mockReturnValueOnce(okRes({ tree, truncated: false }));       // tree
+    const result = await getRepoTree(FAKE_TOKEN, "test-org", "axibuilds-shared");
+    // Should only include blobs, not tree entries
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ path: "folders/f1/meta.json", sha: "aaa" });
+  });
+});
+
+describe("putSharedFile", () => {
+  test("creates file when no SHA provided", async () => {
+    global.fetch = jest.fn()
+      .mockReturnValueOnce(okRes({ content: { sha: "new-sha" } }));  // PUT
+    const result = await putSharedFile(FAKE_TOKEN, "test-org", "axibuilds-shared", "folders/f1/builds/b1.json", '{"id":"b1"}', null);
+    expect(result.sha).toBe("new-sha");
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.sha).toBeUndefined();
+  });
+
+  test("updates file with SHA for optimistic locking", async () => {
+    global.fetch = jest.fn()
+      .mockReturnValueOnce(okRes({ content: { sha: "new-sha" } }));
+    await putSharedFile(FAKE_TOKEN, "test-org", "axibuilds-shared", "path.json", "{}", "old-sha");
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.sha).toBe("old-sha");
+  });
+
+  test("throws with status 409 on conflict", async () => {
+    global.fetch = jest.fn()
+      .mockReturnValueOnce(failRes(409, "Conflict"));
+    await expect(
+      putSharedFile(FAKE_TOKEN, "test-org", "axibuilds-shared", "path.json", "{}", "stale-sha")
+    ).rejects.toMatchObject({ status: 409 });
+  });
+});
+
+describe("deleteSharedFile", () => {
+  test("deletes file with SHA", async () => {
+    global.fetch = jest.fn()
+      .mockReturnValueOnce(okRes({}));
+    await deleteSharedFile(FAKE_TOKEN, "test-org", "axibuilds-shared", "path.json", "sha-123");
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.sha).toBe("sha-123");
+  });
+});
+
+describe("getFileContents", () => {
+  test("returns decoded file content", async () => {
+    const content = Buffer.from('{"id":"b1","title":"Test"}').toString("base64");
+    global.fetch = jest.fn()
+      .mockReturnValueOnce(okRes({ content, encoding: "base64", sha: "sha-abc" }));
+    const result = await getFileContents(FAKE_TOKEN, "test-org", "axibuilds-shared", "path.json");
+    expect(result.content).toBe('{"id":"b1","title":"Test"}');
+    expect(result.sha).toBe("sha-abc");
   });
 });

--- a/tests/unit/sharedLibrary.test.js
+++ b/tests/unit/sharedLibrary.test.js
@@ -1,0 +1,199 @@
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const { FolderStore } = require("../../src/main/folderStore");
+const { SyncStore } = require("../../src/main/syncStore");
+const { SharedLibrary } = require("../../src/main/sharedLibrary");
+
+// Mock githubApi module
+jest.mock("../../src/main/githubApi");
+const githubApi = require("../../src/main/githubApi");
+
+async function makeTempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "axiforge-sync-engine-"));
+}
+
+async function cleanupDir(dir) {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+// Helper: create a BuildStore-like object
+function mockBuildStore(builds = []) {
+  return {
+    listBuilds: jest.fn(async () => [...builds]),
+    upsertBuild: jest.fn(async (b) => ({ ...b, updatedAt: new Date().toISOString() })),
+    deleteBuild: jest.fn(async () => {}),
+    getAuth: jest.fn(async () => ({
+      token: "fake-token",
+      sharedLibrary: { orgName: "test-org", repoName: "axibuilds-shared" },
+    })),
+  };
+}
+
+function mockCompStore(comps = []) {
+  return {
+    listComps: jest.fn(async () => [...comps]),
+    upsertComp: jest.fn(async (c) => ({ ...c, updatedAt: new Date().toISOString() })),
+    deleteComp: jest.fn(async () => {}),
+    removeBuildFromComps: jest.fn(async () => {}),
+  };
+}
+
+describe("SharedLibrary — pullFolder", () => {
+  let dir, syncStore, folderStore;
+  beforeEach(async () => {
+    dir = await makeTempDir();
+    syncStore = new SyncStore(dir);
+    folderStore = new FolderStore(dir);
+    await syncStore.init();
+    await folderStore.init();
+  });
+  afterEach(async () => cleanupDir(dir));
+
+  test("pulls new builds from remote into local store", async () => {
+    const buildStore = mockBuildStore([]);
+    const compStore = mockCompStore([]);
+    const folder = await folderStore.upsertFolder({
+      name: "Shared", shared: true, orgName: "test-org",
+    });
+
+    // Remote has one build
+    githubApi.getRepoTree.mockResolvedValue([
+      { path: `folders/${folder.id}/meta.json`, sha: "meta-sha" },
+      { path: `folders/${folder.id}/builds/b1.json`, sha: "build-sha" },
+    ]);
+    githubApi.getFileContents.mockResolvedValue({
+      content: JSON.stringify({ id: "b1", title: "Remote Build", profession: "Warrior" }),
+      sha: "build-sha",
+    });
+
+    const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore });
+    await lib.pullFolder(folder.id);
+
+    expect(buildStore.upsertBuild).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "b1", title: "Remote Build", folderId: folder.id })
+    );
+    // SHA should be tracked
+    const shas = await syncStore.getShas(folder.id);
+    expect(shas[`builds/b1`]).toBe("build-sha");
+  });
+
+  test("skips unchanged files (matching SHA)", async () => {
+    const buildStore = mockBuildStore([]);
+    const compStore = mockCompStore([]);
+    const folder = await folderStore.upsertFolder({
+      name: "Shared", shared: true, orgName: "test-org",
+    });
+    await syncStore.setShas(folder.id, { "meta": "meta-sha", "builds/b1": "same-sha" });
+
+    githubApi.getRepoTree.mockResolvedValue([
+      { path: `folders/${folder.id}/meta.json`, sha: "meta-sha" },
+      { path: `folders/${folder.id}/builds/b1.json`, sha: "same-sha" },
+    ]);
+
+    const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore });
+    await lib.pullFolder(folder.id);
+
+    expect(githubApi.getFileContents).not.toHaveBeenCalled();
+    expect(buildStore.upsertBuild).not.toHaveBeenCalled();
+  });
+
+  test("removes locally tracked builds deleted on remote", async () => {
+    const buildStore = mockBuildStore([
+      { id: "b1", title: "Old", folderId: "f1" },
+    ]);
+    const compStore = mockCompStore([]);
+    const folder = await folderStore.upsertFolder({
+      id: "f1", name: "Shared", shared: true, orgName: "test-org",
+    });
+    await syncStore.setShas("f1", { "builds/b1": "old-sha" });
+
+    // Remote tree has no builds
+    githubApi.getRepoTree.mockResolvedValue([
+      { path: "folders/f1/meta.json", sha: "meta-sha" },
+    ]);
+
+    const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore });
+    await lib.pullFolder("f1");
+
+    expect(buildStore.deleteBuild).toHaveBeenCalledWith("b1");
+  });
+});
+
+describe("SharedLibrary — pushBuild", () => {
+  let dir, syncStore, folderStore;
+  beforeEach(async () => {
+    dir = await makeTempDir();
+    syncStore = new SyncStore(dir);
+    folderStore = new FolderStore(dir);
+    await syncStore.init();
+    await folderStore.init();
+  });
+  afterEach(async () => cleanupDir(dir));
+
+  test("creates new file when no SHA tracked", async () => {
+    const build = { id: "b1", title: "New Build", folderId: "f1" };
+    const buildStore = mockBuildStore([build]);
+    const compStore = mockCompStore([]);
+    await folderStore.upsertFolder({ id: "f1", name: "Shared", shared: true, orgName: "test-org" });
+
+    githubApi.putSharedFile.mockResolvedValue({ sha: "new-sha" });
+
+    const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore });
+    await lib.pushBuild(build);
+
+    expect(githubApi.putSharedFile).toHaveBeenCalledWith(
+      "fake-token", "test-org", "axibuilds-shared",
+      "folders/f1/builds/b1.json",
+      expect.any(String),  // JSON content
+      null,                // no SHA = create
+      "main",
+      expect.any(String),  // commit message
+    );
+    const shas = await syncStore.getShas("f1");
+    expect(shas["builds/b1"]).toBe("new-sha");
+  });
+
+  test("updates with SHA when tracked (optimistic locking)", async () => {
+    const build = { id: "b1", title: "Updated", folderId: "f1" };
+    const buildStore = mockBuildStore([build]);
+    const compStore = mockCompStore([]);
+    await folderStore.upsertFolder({ id: "f1", name: "Shared", shared: true, orgName: "test-org" });
+    await syncStore.setShas("f1", { "builds/b1": "existing-sha" });
+
+    githubApi.putSharedFile.mockResolvedValue({ sha: "updated-sha" });
+
+    const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore });
+    await lib.pushBuild(build);
+
+    expect(githubApi.putSharedFile).toHaveBeenCalledWith(
+      "fake-token", "test-org", "axibuilds-shared",
+      "folders/f1/builds/b1.json",
+      expect.any(String),
+      "existing-sha",     // existing SHA for optimistic lock
+      "main",
+      expect.any(String),
+    );
+    const shas = await syncStore.getShas("f1");
+    expect(shas["builds/b1"]).toBe("updated-sha");
+  });
+
+  test("returns conflict info on 409", async () => {
+    const build = { id: "b1", title: "Mine", folderId: "f1" };
+    const buildStore = mockBuildStore([build]);
+    const compStore = mockCompStore([]);
+    await folderStore.upsertFolder({ id: "f1", name: "Shared", shared: true, orgName: "test-org" });
+    await syncStore.setShas("f1", { "builds/b1": "stale-sha" });
+
+    const err = new Error("Conflict");
+    err.status = 409;
+    githubApi.putSharedFile.mockRejectedValue(err);
+
+    const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore });
+    const result = await lib.pushBuild(build);
+
+    expect(result.conflict).toBe(true);
+  });
+});

--- a/tests/unit/syncStore.test.js
+++ b/tests/unit/syncStore.test.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const { SyncStore } = require("../../src/main/syncStore");
+
+async function makeTempStore() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "axiforge-sync-"));
+  const store = new SyncStore(dir);
+  await store.init();
+  return { store, dir };
+}
+
+async function cleanupDir(dir) {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+describe("SyncStore — init", () => {
+  let store, dir;
+  beforeEach(async () => ({ store, dir } = await makeTempStore()));
+  afterEach(async () => cleanupDir(dir));
+
+  test("creates syncState.json with empty object if missing", async () => {
+    const content = await fs.readFile(path.join(dir, "syncState.json"), "utf-8");
+    expect(JSON.parse(content)).toEqual({});
+  });
+
+  test("preserves existing syncState.json", async () => {
+    const existing = { "folder-1": { remoteShas: { "meta": "abc" } } };
+    await fs.writeFile(path.join(dir, "syncState.json"), JSON.stringify(existing));
+    const store2 = new SyncStore(dir);
+    await store2.init();
+    const state = await store2.getState();
+    expect(state).toEqual(existing);
+  });
+});
+
+describe("SyncStore — getShas / setShas", () => {
+  let store, dir;
+  beforeEach(async () => ({ store, dir } = await makeTempStore()));
+  afterEach(async () => cleanupDir(dir));
+
+  test("getShas returns empty object for unknown folder", async () => {
+    expect(await store.getShas("unknown")).toEqual({});
+  });
+
+  test("setShas persists and retrieves SHA map", async () => {
+    const shas = { "builds/b1": "sha-111", "comps/c1": "sha-222" };
+    await store.setShas("folder-1", shas);
+    expect(await store.getShas("folder-1")).toEqual(shas);
+  });
+
+  test("setSha updates a single entry", async () => {
+    await store.setShas("folder-1", { "builds/b1": "sha-111" });
+    await store.setSha("folder-1", "builds/b2", "sha-222");
+    const shas = await store.getShas("folder-1");
+    expect(shas).toEqual({ "builds/b1": "sha-111", "builds/b2": "sha-222" });
+  });
+
+  test("removeSha deletes a single entry", async () => {
+    await store.setShas("folder-1", { "builds/b1": "sha-111", "builds/b2": "sha-222" });
+    await store.removeSha("folder-1", "builds/b1");
+    expect(await store.getShas("folder-1")).toEqual({ "builds/b2": "sha-222" });
+  });
+
+  test("removeFolder removes entire folder entry", async () => {
+    await store.setShas("folder-1", { "builds/b1": "sha-111" });
+    await store.removeFolder("folder-1");
+    expect(await store.getShas("folder-1")).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a shared library feature allowing teams to sync builds/comps across GitHub organization members via a private `axibuilds-shared` repo
- Implements full pull/push/conflict detection engine with background polling (5-min interval) and debounced push (2s after save)
- Extends folder UI with share/unshare/sync context menu actions, sidebar visual indicators, and settings modal configuration

## What's included

- `src/main/syncStore.js` — persists sync state (file SHAs) to `syncState.json`
- `src/main/sharedLibrary.js` — sync engine: pull, push, conflict detection, polling, debounced push
- `src/main/githubApi.js` — new API: `ensureSharedRepo`, `getRepoTree`, `getFileContents`, `putSharedFile`, `deleteSharedFile`
- `src/main/folderStore.js` — extended schema: `shared`, `orgName`, `lastSyncedAt`; nesting constraints enforced
- `src/main/index.js` — IPC handlers wired; save/delete ops trigger shared sync; build move enforces boundaries
- `src/preload/index.js` — 11 new shared library API methods + event listeners for conflict/status
- `src/renderer/modules/settings-modal.js` — Shared Library section: org picker, connect/disconnect UI
- `src/renderer/modules/library/sidebar.js` — Shared Folders / My Folders split with share badge
- `src/renderer/modules/library/context-menu.js` — share/unshare/sync menu items
- `src/renderer/modules/library/library.js` — pull on shared folder navigation
- `src/renderer/modules/comps/comp-detail.js` — comp build picker scoped to same folder for shared folders
- New tests: `syncStore.test.js`, `sharedLibrary.test.js`; extended `folderStore.test.js`, `githubApi.test.js`

## Test plan

- [ ] All 1550 tests pass (`npm test`)
- [ ] Connect shared library in Settings → select org → folder appears in "Shared Folders" sidebar section
- [ ] Save a build in a shared folder → push triggers within 2s
- [ ] Second org member opens app → background poll pulls the build
- [ ] Conflict scenario: two users edit same build → conflict notification fires
- [ ] Unshare folder → folder moves back to "My Folders", remote files remain
- [ ] Move a build out of a shared folder → blocked with error toast
- [ ] Comp in shared folder → build picker only shows same-folder builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)