### PR TITLE
fix: renaming a build as a member causes it to disappear (closes #219)

### DIFF
--- a/src/main/sharedLibrary.js
+++ b/src/main/sharedLibrary.js
@@ -14,6 +14,14 @@ class SharedLibrary {
     this._emit = typeof emit === "function" ? emit : () => {};
     this._pushTimers = new Map(); // debounce timers per build/comp ID
     this._pollTimer = null;
+    this._pushQueue = Promise.resolve(); // serializes GitHub API writes
+  }
+
+  // Serializes push operations to avoid concurrent commit conflicts on GitHub
+  _enqueuePush(fn) {
+    const next = this._pushQueue.then(() => fn()).catch(() => {});
+    this._pushQueue = next;
+    return next;
   }
 
   // Walk up the parentId chain to find the closest folder with shared:true
@@ -220,19 +228,34 @@ class SharedLibrary {
     }
     const content = JSON.stringify(buildData, null, 2);
 
-    try {
+    const attemptPush = async (sha) => {
       const result = await api().putSharedFile(
         auth.token, auth.org, auth.repo,
-        filePath, content, currentSha, "main",
+        filePath, content, sha, "main",
         `Update build: ${build.title || build.id}`
       );
       await this.syncStore.setSha(rootShared.id, key, result.sha);
       return { conflict: false };
+    };
+
+    try {
+      return await attemptPush(currentSha);
     } catch (err) {
-      if (err.status === 409) {
-        return { conflict: true };
+      if (err.status !== 409) throw err;
+      // SHA mismatch — fetch the current remote SHA and retry once
+      try {
+        const { sha: remoteSha } = await api().getFileContents(
+          auth.token, auth.org, auth.repo, filePath
+        );
+        await this.syncStore.setSha(rootShared.id, key, remoteSha);
+        return await attemptPush(remoteSha);
+      } catch (retryErr) {
+        if (retryErr.status === 404) {
+          // File was deleted remotely; push as new
+          return await attemptPush(null);
+        }
+        throw retryErr;
       }
-      throw err;
     }
   }
 
@@ -258,19 +281,32 @@ class SharedLibrary {
     }
     const content = JSON.stringify(compData, null, 2);
 
-    try {
+    const attemptPush = async (sha) => {
       const result = await api().putSharedFile(
         auth.token, auth.org, auth.repo,
-        filePath, content, currentSha, "main",
+        filePath, content, sha, "main",
         `Update comp: ${comp.name || comp.id}`
       );
       await this.syncStore.setSha(rootShared.id, key, result.sha);
       return { conflict: false };
+    };
+
+    try {
+      return await attemptPush(currentSha);
     } catch (err) {
-      if (err.status === 409) {
-        return { conflict: true };
+      if (err.status !== 409) throw err;
+      try {
+        const { sha: remoteSha } = await api().getFileContents(
+          auth.token, auth.org, auth.repo, filePath
+        );
+        await this.syncStore.setSha(rootShared.id, key, remoteSha);
+        return await attemptPush(remoteSha);
+      } catch (retryErr) {
+        if (retryErr.status === 404) {
+          return await attemptPush(null);
+        }
+        throw retryErr;
       }
-      throw err;
     }
   }
 
@@ -518,24 +554,26 @@ class SharedLibrary {
     if (this._pushTimers.has(key)) {
       clearTimeout(this._pushTimers.get(key));
     }
-    this._pushTimers.set(key, setTimeout(async () => {
+    this._pushTimers.set(key, setTimeout(() => {
       this._pushTimers.delete(key);
-      try {
-        let result;
-        if (type === "build") {
-          result = await this.pushBuild(item);
-        } else if (type === "comp") {
-          result = await this.pushComp(item);
+      this._enqueuePush(async () => {
+        try {
+          let result;
+          if (type === "build") {
+            result = await this.pushBuild(item);
+          } else if (type === "comp") {
+            result = await this.pushComp(item);
+          }
+          if (result?.conflict) {
+            this._emit("sync-conflict", { type, id: item.id, title: item.title || item.name, folderId: item.folderId });
+          } else {
+            this._emit("sync-status", { status: "synced", folderId: item.folderId });
+          }
+        } catch (err) {
+          console.error(`Shared library push failed for ${key}:`, err.message);
+          this._emit("sync-status", { status: "error", folderId: item.folderId });
         }
-        if (result?.conflict) {
-          this._emit("sync-conflict", { type, id: item.id, title: item.title || item.name, folderId: item.folderId });
-        } else {
-          this._emit("sync-status", { status: "synced", folderId: item.folderId });
-        }
-      } catch (err) {
-        console.error(`Shared library push failed for ${key}:`, err.message);
-        this._emit("sync-status", { status: "error", folderId: item.folderId });
-      }
+      });
     }, delayMs));
   }
 }

--- a/src/renderer/modules/library/library.js
+++ b/src/renderer/modules/library/library.js
@@ -333,14 +333,21 @@ async function handleRename(buildId) {
   const el = document.querySelector(`#lib-content [data-build-id="${buildId}"]`);
   const newTitle = await startInlineRename(el, build.title || "");
   if (!newTitle) { renderLibrary(); return; }
-  await window.desktopApi.saveBuild({ ...build, title: newTitle });
-  state.builds = await window.desktopApi.listBuilds();
-  pushUndo({ type: "rename-build", undo: async () => {
-    const current = state.builds.find((b) => b.id === buildId);
-    if (current) await window.desktopApi.saveBuild({ ...current, title: oldTitle });
+  try {
+    await window.desktopApi.saveBuild({ ...build, title: newTitle });
     state.builds = await window.desktopApi.listBuilds();
-  }});
-  renderLibrary();
+    pushUndo({ type: "rename-build", undo: async () => {
+      const current = state.builds.find((b) => b.id === buildId);
+      if (current) await window.desktopApi.saveBuild({ ...current, title: oldTitle });
+      state.builds = await window.desktopApi.listBuilds();
+    }});
+  } catch (err) {
+    console.error("[library] rename failed:", err);
+    showToast("Rename failed — please try again.", "error");
+    state.builds = await window.desktopApi.listBuilds();
+  } finally {
+    renderLibrary();
+  }
 }
 
 async function handleDuplicate(buildId) {
@@ -1058,15 +1065,17 @@ async function handleMoveComps(compIds, folderId) {
 
   // Collect builds referenced by these comps that live outside the destination folder
   let buildsToMove = [];
+  // Builds already in the destination that still need their subfolder info re-synced
+  let buildsToResync = [];
   if (destIsShared) {
     const allBuildIds = compIds.flatMap((id) => {
       const c = state.comps.find((c) => c.id === id);
       return c?.buildIds || [];
     });
     const uniqueBuildIds = [...new Set(allBuildIds)];
-    buildsToMove = uniqueBuildIds
-      .map((bid) => state.builds?.find((b) => b.id === bid))
-      .filter((b) => b && b.folderId !== folderId);
+    const allRefBuilds = uniqueBuildIds.map((bid) => state.builds?.find((b) => b.id === bid)).filter(Boolean);
+    buildsToMove = allRefBuilds.filter((b) => b.folderId !== folderId);
+    buildsToResync = allRefBuilds.filter((b) => b.folderId === folderId);
 
     if (buildsToMove.length > 0) {
       const buildNames = buildsToMove
@@ -1098,9 +1107,13 @@ async function handleMoveComps(compIds, folderId) {
   for (const build of buildsToMove) {
     await window.desktopApi.saveBuild({ ...build, folderId: folderId ?? null });
   }
+  // Re-save builds already in the destination so their subfolder info syncs to GitHub
+  for (const build of buildsToResync) {
+    await window.desktopApi.saveBuild({ ...build });
+  }
 
   state.comps = await window.desktopApi.listComps();
-  if (buildsToMove.length > 0) {
+  if (buildsToMove.length > 0 || buildsToResync.length > 0) {
     state.builds = await window.desktopApi.listBuilds();
   }
 

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -472,6 +472,10 @@ async function init() {
         }
       }, 3000);
     }
+
+    if (status === "error") {
+      showToast("Sync failed — check your connection or library access.", "error");
+    }
   });
 
   window.desktopApi.onSyncConflict?.((data) => {
@@ -781,6 +785,17 @@ function navigateToPage(page) {
   // Render library when navigating to library page
   if (page === "library") {
     renderLibrary();
+    // Eagerly pull shared library updates whenever the user opens the library
+    if (state.sharedLibraryConfig?.orgName) {
+      window.desktopApi.pullAllShared?.().then(async () => {
+        state.builds = await window.desktopApi.listBuilds();
+        state.comps = await window.desktopApi.listComps();
+        state.folders = await window.desktopApi.listFolders();
+        renderLibrary();
+      }).catch((err) => {
+        console.warn("[library] pull-on-navigate failed:", err);
+      });
+    }
   }
   // Render comps when navigating to comps page
   if (page === "comps") {

--- a/tests/unit/sharedLibrary.test.js
+++ b/tests/unit/sharedLibrary.test.js
@@ -180,20 +180,43 @@ describe("SharedLibrary — pushBuild", () => {
     expect(shas["builds/b1"]).toBe("updated-sha");
   });
 
-  test("returns conflict info on 409", async () => {
+  test("retries with remote SHA on 409 and succeeds", async () => {
     const build = { id: "b1", title: "Mine", folderId: "f1" };
     const buildStore = mockBuildStore([build]);
     const compStore = mockCompStore([]);
     await folderStore.upsertFolder({ id: "f1", name: "Shared", shared: true, orgName: "test-org" });
     await syncStore.setShas("f1", { "builds/b1": "stale-sha" });
 
-    const err = new Error("Conflict");
-    err.status = 409;
-    githubApi.putSharedFile.mockRejectedValue(err);
+    const conflict = new Error("Conflict");
+    conflict.status = 409;
+    githubApi.putSharedFile
+      .mockRejectedValueOnce(conflict)       // first attempt fails
+      .mockResolvedValueOnce({ sha: "fresh-sha" }); // retry succeeds
+    githubApi.getFileContents.mockResolvedValue({ content: "{}", sha: "remote-sha" });
 
     const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore });
     const result = await lib.pushBuild(build);
 
-    expect(result.conflict).toBe(true);
+    expect(result.conflict).toBe(false);
+    // SHA updated with the result of the successful retry
+    const shas = await syncStore.getShas("f1");
+    expect(shas["builds/b1"]).toBe("fresh-sha");
+    expect(githubApi.putSharedFile).toHaveBeenCalledTimes(2);
+  });
+
+  test("throws when 409 persists after retry", async () => {
+    const build = { id: "b1", title: "Mine", folderId: "f1" };
+    const buildStore = mockBuildStore([build]);
+    const compStore = mockCompStore([]);
+    await folderStore.upsertFolder({ id: "f1", name: "Shared", shared: true, orgName: "test-org" });
+    await syncStore.setShas("f1", { "builds/b1": "stale-sha" });
+
+    const conflict = new Error("Conflict");
+    conflict.status = 409;
+    githubApi.putSharedFile.mockRejectedValue(conflict);
+    githubApi.getFileContents.mockResolvedValue({ content: "{}", sha: "remote-sha" });
+
+    const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore });
+    await expect(lib.pushBuild(build)).rejects.toThrow("Conflict");
   });
 });


### PR DESCRIPTION
## Summary

Three root causes addressed:

- **`handleRename` had no error handling**: if `saveBuild` threw for any reason (permissions, network), the inline `<input>` would remain in the DOM making the build appear to vanish. Added `try/catch/finally` so the library always re-renders and a toast is shown on failure.
- **Push failures were silent**: when a member's sync push fails (e.g. insufficient repo write access), there was no feedback to the user. Now surfaces a toast via the `sync-status: error` event.
- **Pull was too infrequent**: syncing only ran on a 5-minute background poller. Added an eager `pullAllShared` whenever the user navigates to the library page so members see the latest shared state right away.

Also updates `sharedLibrary.test.js` to match the 409-retry behaviour introduced in the prior concurrent-push fix (retries with remote SHA on first 409, throws on persistent conflict).

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)