### PR TITLE
fix: publishing repo dropdown clipped by overflow due to animation transform (closes #221)

### DIFF
--- a/src/renderer/styles/settings-modal.css
+++ b/src/renderer/styles/settings-modal.css
@@ -117,7 +117,7 @@
 @keyframes sm-section-in {
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: none;
   }
 }
 

--- a/tests/unit/settingsModalDropdown.test.js
+++ b/tests/unit/settingsModalDropdown.test.js
@@ -1,0 +1,48 @@
+"use strict";
+
+/**
+ * Regression tests for the "publishing repo dropdown doesn't work" bug.
+ *
+ * Root cause: .settings-modal__section uses `animation-fill-mode: forwards`
+ * with a final keyframe of `transform: translateY(0)`. Any non-`none`
+ * transform value creates a new containing block for `position: fixed`
+ * descendants, so the custom-select menu (positioned fixed) is constrained
+ * to the section's bounds and gets clipped by .settings-modal's
+ * `overflow: hidden`.
+ *
+ * Fix: end the keyframe at `transform: none` so no containing block is
+ * created after the animation completes.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+describe("settings-modal dropdown CSS — no transform containing block", () => {
+  let css;
+
+  beforeAll(() => {
+    css = fs.readFileSync(
+      path.resolve(__dirname, "../../src/renderer/styles/settings-modal.css"),
+      "utf8"
+    );
+  });
+
+  test("sm-section-in keyframe to-state does not use transform: translateY(0)", () => {
+    // If the keyframe ends at translateY(0), it creates a containing block
+    // for position:fixed descendants, breaking the custom-select dropdown.
+    // The to-state must use `transform: none` (or omit transform entirely).
+    const keyframeBlock = css.match(/@keyframes\s+sm-section-in\s*\{[\s\S]*?\}/)?.[0] || "";
+    expect(keyframeBlock).toBeTruthy();
+
+    // Must NOT contain translateY(0) in the final state
+    const toBlock = keyframeBlock.match(/to\s*\{[\s\S]*?\}/)?.[0] || "";
+    expect(toBlock).not.toMatch(/transform\s*:\s*translateY\s*\(\s*0\s*(px)?\s*\)/);
+  });
+
+  test("sm-section-in keyframe to-state explicitly resets transform to none", () => {
+    const keyframeBlock = css.match(/@keyframes\s+sm-section-in\s*\{[\s\S]*?\}/)?.[0] || "";
+    const toBlock = keyframeBlock.match(/to\s*\{[\s\S]*?\}/)?.[0] || "";
+    // The to-state should set transform: none so no containing block persists
+    expect(toBlock).toMatch(/transform\s*:\s*none/);
+  });
+});


### PR DESCRIPTION
## Summary

The \"Repository owner\" dropdown in the Settings → Publishing section was non-functional. The root cause was a CSS animation fill-mode interaction:

- `.settings-modal__section` has `animation: sm-section-in 0.3s ease-out forwards`
- The final keyframe was `transform: translateY(0)` — visually a no-op, but **any non-`none` transform value creates a new containing block for `position: fixed` descendants** (CSS spec)
- The custom-select dropdown menu uses `position: fixed` when opened, positioning itself using `getBoundingClientRect()` (viewport-relative coords)
- With the section as containing block, those viewport-relative coords are interpreted relative to the section instead, placing the menu off-screen
- Additionally, `.settings-modal` has `overflow: hidden`, which clips the incorrectly-positioned fixed menu

**Fix:** Changed the `to` keyframe from `transform: translateY(0)` to `transform: none`. This preserves the identical slide-in visual effect while ensuring the section does not act as a containing block after animation completes, allowing the fixed-position dropdown menu to render and position correctly relative to the viewport.

Closes #221