### PR TITLE
feat: shared builds always publish to the org's axibuilds repo

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -61,6 +61,16 @@ const compStore = new CompStore(dataDir);
 const syncStore = new SyncStore(dataDir);
 const buildHistoryStore = new BuildHistoryStore(dataDir);
 
+// Walk up the folder parentId chain to find the root folder with shared:true.
+// Returns the shared folder object (with orgName) or null if the build is personal.
+function _findRootSharedFolder(folderId, folders) {
+  if (!folderId) return null;
+  const folder = folders.find((f) => f.id === folderId);
+  if (!folder) return null;
+  if (folder.shared) return folder;
+  return _findRootSharedFolder(folder.parentId, folders);
+}
+
 // On Windows, the taskbar follows the "system" theme (SystemUsesLightTheme)
 // while nativeTheme.shouldUseDarkColors follows the "app" theme. These can
 // differ when the user picks "Custom" under Personalisation → Colors.
@@ -777,13 +787,20 @@ app.whenReady().then(async () => {
 
     const auth = await getAuthRecord();
     const branch = auth?.onboarding?.branch || "main";
-    const owner = auth?.onboarding?.targetOwner || session.viewer.login;
+    const personalOwner = auth?.onboarding?.targetOwner || session.viewer.login;
 
     // Load the build
     progress("loading");
     const builds = await store.listBuilds();
     const build = builds.find((b) => b.id === buildId);
     if (!build) throw new Error("Build not found.");
+
+    // Shared builds always publish to the org's axibuilds repo, regardless of
+    // what the user has set as their personal publishing target.
+    const allFolders = await folderStore.listFolders();
+    const sharedRoot = _findRootSharedFolder(build.folderId, allFolders);
+    const owner = sharedRoot ? sharedRoot.orgName : personalOwner;
+    const ownerType = sharedRoot ? "org" : "user";
 
     // Auto-populate build name if empty or default
     if (!build.title?.trim() || build.title === "Untitled Build") {
@@ -803,7 +820,7 @@ app.whenReady().then(async () => {
 
     // Ensure repo and site infrastructure exist
     progress("repo");
-    await ensureAxiForgeRepo(session.token, owner, "user");
+    await ensureAxiForgeRepo(session.token, owner, ownerType);
     await ensurePagesWorkflow(session.token, owner, branch, TARGET_REPO);
     await ensurePages(session.token, owner, branch, TARGET_REPO);
 
@@ -916,20 +933,24 @@ app.whenReady().then(async () => {
       : await store.getSetting("appearance.theme");
     const pagesUrl = `https://${owner}.github.io/${TARGET_REPO}/?n=${encodeURIComponent(newSlug)}&b=${fileId}.${encKey}${themeParam ? `&t=${themeParam}` : ""}`;
 
-    await patchAuthRecord({
-      onboarding: {
-        repoReady: true,
-        forkReady: true,
-        repoName: TARGET_REPO,
-        pagesReady: false,
-        pagesBuildStatus: "queued",
-        pagesBuildUpdatedAt: new Date().toISOString(),
-        pagesBuildError: null,
-        pagesUrl: `https://${owner}.github.io/${TARGET_REPO}/`,
-        branch,
-        targetOwner: owner,
-      },
-    });
+    // Only update the personal auth record for personal builds — shared builds
+    // publish to the org's repo and must not overwrite the user's personal target.
+    if (!sharedRoot) {
+      await patchAuthRecord({
+        onboarding: {
+          repoReady: true,
+          forkReady: true,
+          repoName: TARGET_REPO,
+          pagesReady: false,
+          pagesBuildStatus: "queued",
+          pagesBuildUpdatedAt: new Date().toISOString(),
+          pagesBuildError: null,
+          pagesUrl: `https://${owner}.github.io/${TARGET_REPO}/`,
+          branch,
+          targetOwner: owner,
+        },
+      });
+    }
 
     return {
       pagesUrl,

--- a/src/renderer/modules/custom-select.js
+++ b/src/renderer/modules/custom-select.js
@@ -5,6 +5,34 @@ import { state } from "./state.js";
 let _bindHoverPreview = null;
 let _onError = (err) => console.error("[AxiForge cselect]", err);
 
+// Portal tracking: when a menu is moved to document.body to escape modal
+// overflow/stacking constraints, we remember where it came from so we can
+// restore it when the dropdown closes.
+const _portalledMenus = new WeakMap(); // root → { menu, originalParent }
+
+function _portalMenu(root, menu) {
+  _portalledMenus.set(root, { menu, parent: menu.parentNode });
+  menu.dataset.cselectPortal = "1"; // sentinel for outside-click handler
+  document.body.appendChild(menu);
+  menu.style.display = "block"; // .cselect__menu defaults display:none in CSS
+}
+
+function _restorePortaledMenu(root) {
+  const entry = _portalledMenus.get(root);
+  if (!entry) return null;
+  const { menu, parent } = entry;
+  delete menu.dataset.cselectPortal;
+  menu.style.display = "";
+  if (parent && menu.parentNode !== parent) parent.appendChild(menu);
+  _portalledMenus.delete(root);
+  return menu;
+}
+
+// Return the menu element whether it's inside root or portalled to body.
+function _getMenu(root) {
+  return _portalledMenus.get(root)?.menu ?? root.querySelector(".cselect__menu");
+}
+
 export function initCustomSelect({ bindHoverPreview, onError } = {}) {
   if (bindHoverPreview) _bindHoverPreview = bindHoverPreview;
   if (onError) _onError = onError;
@@ -238,18 +266,24 @@ export function toggleCustomSelect(root) {
   const currentlyOpen = state.openCustomSelect;
   if (currentlyOpen && currentlyOpen !== root) {
     currentlyOpen.classList.remove("cselect--open");
-    resetCustomSelectMenuPosition(currentlyOpen.querySelector(".cselect__menu"));
+    const prevMenu = _restorePortaledMenu(currentlyOpen) ?? currentlyOpen.querySelector(".cselect__menu");
+    resetCustomSelectMenuPosition(prevMenu);
   }
   const shouldOpen = !root.classList.contains("cselect--open");
   if (shouldOpen) {
     const menu = root.querySelector(".cselect__menu");
     const rect = getSelectAnchorRect(root);
     if (rect && menu) {
+      // Portal the menu to document.body so it escapes any ancestor overflow:hidden
+      // or stacking-context constraints (common when cselect is inside a modal).
+      _portalMenu(root, menu);
+
       const menuEstHeight = 300;
       const spaceBelow = window.innerHeight - rect.bottom;
       const spaceAbove = rect.top;
       const dropUp = spaceBelow < menuEstHeight + 8 && spaceAbove > spaceBelow;
       menu.style.position = "fixed";
+      menu.style.zIndex = "9999";
       const menuWidth = parseFloat(getComputedStyle(menu).minWidth) || 200;
       menu.style.left = `${Math.min(rect.left, window.innerWidth - menuWidth - 8)}px`;
       menu.style.right = "auto";
@@ -262,12 +296,13 @@ export function toggleCustomSelect(root) {
       }
     }
   } else {
-    resetCustomSelectMenuPosition(root.querySelector(".cselect__menu"));
+    const menu = _restorePortaledMenu(root) ?? root.querySelector(".cselect__menu");
+    resetCustomSelectMenuPosition(menu);
   }
   root.classList.toggle("cselect--open", shouldOpen);
   state.openCustomSelect = shouldOpen ? root : null;
   if (shouldOpen) {
-    const searchInput = root.querySelector(".cselect__search");
+    const searchInput = _getMenu(root)?.querySelector(".cselect__search");
     if (searchInput) searchInput.focus();
   }
 }
@@ -279,6 +314,7 @@ export function resetCustomSelectMenuPosition(menu) {
   menu.style.bottom = "";
   menu.style.left = "";
   menu.style.right = "";
+  menu.style.zIndex = "";
 }
 
 export function closeCustomSelect() {
@@ -286,7 +322,8 @@ export function closeCustomSelect() {
   if (!open) return;
   if (open.isConnected) {
     open.classList.remove("cselect--open");
-    resetCustomSelectMenuPosition(open.querySelector(".cselect__menu"));
+    const menu = _restorePortaledMenu(open) ?? open.querySelector(".cselect__menu");
+    resetCustomSelectMenuPosition(menu);
     const searchInput = open.querySelector(".cselect__search");
     if (searchInput) {
       searchInput.value = "";

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -1390,13 +1390,19 @@ function wireEvents() {
 
   document.addEventListener("pointerdown", (event) => {
     if (event.target.closest(".cselect")) return;
+    if (event.target.closest("[data-cselect-portal]")) return; // portalled menu
     closeCustomSelect();
   });
 
   document.addEventListener("scroll", (event) => {
     // Don't close when scrolling inside the open dropdown's own list
     const open = state.openCustomSelect;
-    if (open && event.target instanceof Node && open.contains(event.target)) return;
+    if (open && event.target instanceof Node) {
+      if (open.contains(event.target)) return;
+      // Also allow scrolling inside a portalled menu (which lives in document.body)
+      const portal = document.querySelector("[data-cselect-portal]");
+      if (portal?.contains(event.target)) return;
+    }
     closeCustomSelect();
   }, { capture: true, passive: true });
 

--- a/src/renderer/styles/settings-modal.css
+++ b/src/renderer/styles/settings-modal.css
@@ -117,7 +117,7 @@
 @keyframes sm-section-in {
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: none;
   }
 }
 

--- a/tests/unit/settingsModalDropdown.test.js
+++ b/tests/unit/settingsModalDropdown.test.js
@@ -1,0 +1,48 @@
+"use strict";
+
+/**
+ * Regression tests for the "publishing repo dropdown doesn't work" bug.
+ *
+ * Root cause: .settings-modal__section uses `animation-fill-mode: forwards`
+ * with a final keyframe of `transform: translateY(0)`. Any non-`none`
+ * transform value creates a new containing block for `position: fixed`
+ * descendants, so the custom-select menu (positioned fixed) is constrained
+ * to the section's bounds and gets clipped by .settings-modal's
+ * `overflow: hidden`.
+ *
+ * Fix: end the keyframe at `transform: none` so no containing block is
+ * created after the animation completes.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+describe("settings-modal dropdown CSS — no transform containing block", () => {
+  let css;
+
+  beforeAll(() => {
+    css = fs.readFileSync(
+      path.resolve(__dirname, "../../src/renderer/styles/settings-modal.css"),
+      "utf8"
+    );
+  });
+
+  test("sm-section-in keyframe to-state does not use transform: translateY(0)", () => {
+    // If the keyframe ends at translateY(0), it creates a containing block
+    // for position:fixed descendants, breaking the custom-select dropdown.
+    // The to-state must use `transform: none` (or omit transform entirely).
+    const keyframeBlock = css.match(/@keyframes\s+sm-section-in\s*\{[\s\S]*?\}/)?.[0] || "";
+    expect(keyframeBlock).toBeTruthy();
+
+    // Must NOT contain translateY(0) in the final state
+    const toBlock = keyframeBlock.match(/to\s*\{[\s\S]*?\}/)?.[0] || "";
+    expect(toBlock).not.toMatch(/transform\s*:\s*translateY\s*\(\s*0\s*(px)?\s*\)/);
+  });
+
+  test("sm-section-in keyframe to-state explicitly resets transform to none", () => {
+    const keyframeBlock = css.match(/@keyframes\s+sm-section-in\s*\{[\s\S]*?\}/)?.[0] || "";
+    const toBlock = keyframeBlock.match(/to\s*\{[\s\S]*?\}/)?.[0] || "";
+    // The to-state should set transform: none so no containing block persists
+    expect(toBlock).toMatch(/transform\s*:\s*none/);
+  });
+});


### PR DESCRIPTION
## Summary

When a build lives in a shared folder (org shared library), hitting Publish now always routes to **`{orgName}/axibuilds`** — the org's own public site — regardless of what the user has configured as their personal publishing target.

**Before:** all builds published to `{user's targetOwner}/axibuilds`  
**After:** personal builds → `{targetOwner}/axibuilds` (unchanged), shared builds → `{orgName}/axibuilds`

**Implementation:**
- Added `_findRootSharedFolder(folderId, folders)` helper at module level in `index.js` (mirrors the same logic already in `SharedLibrary`)
- In `builds:publish-build`, after loading the build, walks the folder hierarchy to find a root shared folder
- `ensureAxiForgeRepo` called with `"org"` type for org-owned repos (so the repo is created via the orgs API, not user repos API)
- `patchAuthRecord` is skipped for shared-build publishes — the user's personal `targetOwner` and `pagesUrl` are not overwritten