### PR TITLE
fix: shared build publish uses org owner for URL construction (closes #231)

### DIFF
--- a/src/renderer/modules/render-pages.js
+++ b/src/renderer/modules/render-pages.js
@@ -577,15 +577,41 @@ export function renderEditorMeta() {
   }
 }
 
+/**
+ * Compute the published URL for a build.
+ * For shared builds (in a folder with shared:true), the org's axibuilds repo is the
+ * authoritative host. For personal builds, the personal publishing target is used.
+ *
+ * @param {object} build - Build record with publishedSlug, publishedFileId, publishedKey, folderId
+ * @param {object} onboarding - state.onboarding (targetOwner, repoName)
+ * @param {Array} folders - state.folders array
+ * @param {string|null} theme - current theme param value (or null)
+ * @returns {string|null}
+ */
+export function resolvePublishedUrl(build, onboarding, folders, theme) {
+  if (!build?.publishedSlug || !build?.publishedFileId || !build?.publishedKey) return null;
+
+  // For shared builds, use the org owner; for personal builds, use the personal owner.
+  let owner = onboarding?.targetOwner;
+  if (build.folderId) {
+    let current = (folders || []).find((f) => f.id === build.folderId);
+    while (current) {
+      if (current.shared && current.orgName) { owner = current.orgName; break; }
+      if (!current.parentId) break;
+      current = (folders || []).find((f) => f.id === current.parentId);
+    }
+  }
+
+  const repo = onboarding?.repoName;
+  if (!owner || !repo) return null;
+  return `https://${owner}.github.io/${repo}/?n=${encodeURIComponent(build.publishedSlug)}&b=${build.publishedFileId}.${build.publishedKey}${theme ? `&t=${theme}` : ""}`;
+}
+
 function _getPublishedUrl() {
   if (!state.editor.id) return null;
   const build = state.builds.find((b) => b.id === state.editor.id);
-  if (!build?.publishedSlug || !build?.publishedFileId || !build?.publishedKey) return null;
-  const owner = state.onboarding?.targetOwner;
-  const repo = state.onboarding?.repoName;
-  if (!owner || !repo) return null;
   const theme = document.documentElement.getAttribute("data-theme");
-  return `https://${owner}.github.io/${repo}/?n=${encodeURIComponent(build.publishedSlug)}&b=${build.publishedFileId}.${build.publishedKey}${theme ? `&t=${theme}` : ""}`;
+  return resolvePublishedUrl(build, state.onboarding, state.folders, theme);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -39,6 +39,7 @@ import {
   setPublishStatus, showError, runPagesBuildPoll, getSelectedTarget,
   showPublishProgress, advancePublishStep, completeAllPublishSteps,
   failPublishStep, showPublishResult, getPublishTargetId, syncPublishStatus,
+  resolvePublishedUrl,
 } from "./modules/render-pages.js";
 import { resolveEntityFacts } from "./modules/detail-panel.js";
 import { resetWikiResolution } from "./modules/wiki-updates.js";
@@ -1264,10 +1265,9 @@ function wireEvents() {
         if (!buildId) throw new Error("No build loaded");
         const build = state.builds.find((b) => b.id === buildId);
         if (!build?.publishedFileId) throw new Error("Build not published");
-        const config = await window.desktopApi.getConfig();
-        const slug = build.publishedSlug || "";
         const theme = document.documentElement.getAttribute("data-theme");
-        const url = `${config.pagesUrl}?n=${encodeURIComponent(slug)}&b=${build.publishedFileId}.${build.publishedKey}${theme ? `&t=${theme}` : ""}`;
+        const url = resolvePublishedUrl(build, state.onboarding, state.folders, theme);
+        if (!url) throw new Error("Could not resolve published URL");
         await window.desktopApi.writeClipboardText(url);
         flashItem(pubLinkItem, pubLinkDefault);
       } catch {

--- a/tests/unit/renderer/publish-progress.test.js
+++ b/tests/unit/renderer/publish-progress.test.js
@@ -247,3 +247,70 @@ describe("per-ID publish progress", () => {
     expect(state.publishProgress["comp-2"].currentStep).toBe("repo");
   });
 });
+
+describe("resolvePublishedUrl", () => {
+  let resolvePublishedUrl;
+
+  beforeAll(() => {
+    ({ resolvePublishedUrl } = renderPages);
+  });
+
+  const onboarding = { targetOwner: "personaluser", repoName: "axibuilds" };
+
+  const personalBuild = {
+    id: "b1",
+    folderId: null,
+    publishedSlug: "my-build",
+    publishedFileId: "abc123",
+    publishedKey: "key456",
+  };
+
+  const sharedBuild = {
+    id: "b2",
+    folderId: "folder-shared",
+    publishedSlug: "my-shared-build",
+    publishedFileId: "def789",
+    publishedKey: "orgkey",
+  };
+
+  const folders = [
+    { id: "folder-shared", parentId: null, shared: true, orgName: "myorg" },
+    { id: "folder-sub", parentId: "folder-shared", shared: false },
+  ];
+
+  test("personal build uses personal owner", () => {
+    const url = resolvePublishedUrl(personalBuild, onboarding, [], null);
+    expect(url).toContain("personaluser.github.io/axibuilds");
+    expect(url).toContain("my-build");
+    expect(url).toContain("abc123.key456");
+  });
+
+  test("shared build uses org owner from folder", () => {
+    const url = resolvePublishedUrl(sharedBuild, onboarding, folders, null);
+    expect(url).toContain("myorg.github.io/axibuilds");
+    expect(url).not.toContain("personaluser");
+    expect(url).toContain("my-shared-build");
+    expect(url).toContain("def789.orgkey");
+  });
+
+  test("build in subfolder of shared folder uses org owner", () => {
+    const subBuild = { ...sharedBuild, folderId: "folder-sub" };
+    const url = resolvePublishedUrl(subBuild, onboarding, folders, null);
+    expect(url).toContain("myorg.github.io/axibuilds");
+    expect(url).not.toContain("personaluser");
+  });
+
+  test("theme param is appended when provided", () => {
+    const url = resolvePublishedUrl(personalBuild, onboarding, [], "dark");
+    expect(url).toContain("&t=dark");
+  });
+
+  test("returns null when build has no publishedFileId", () => {
+    const unpublished = { ...personalBuild, publishedFileId: null };
+    expect(resolvePublishedUrl(unpublished, onboarding, [], null)).toBeNull();
+  });
+
+  test("returns null when owner and repo are not available", () => {
+    expect(resolvePublishedUrl(personalBuild, {}, [], null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- `_getPublishedUrl()` and the "copy published link" dropdown handler both used `state.onboarding.targetOwner` (the personal GitHub user) to construct published URLs — but shared builds are published to the **org's** `axibuilds` repo, not the personal one
- The publish result area showed the correct org URL (from `builds:publish-build`'s return value), but "Copy Published Link" from the share dropdown and the editor's published-link button generated URLs with the personal domain — pointing to the wrong repo
- Extracted `resolvePublishedUrl(build, onboarding, folders, theme)` as a testable export that walks the folder hierarchy to find the shared root's `orgName` (falling back to personal owner for non-shared builds), then wired it into both URL construction sites

Closes #231

## Test plan
- [ ] Publish a build in a shared folder → confirm the URL shown in the publish result uses `orgname.github.io`, not your personal domain
- [ ] Click "Copy Published Link" from the share dropdown on a shared build → confirm copied URL uses `orgname.github.io`
- [ ] Publish a personal (non-shared) build → confirm URL still uses personal owner as before
- [ ] All existing tests pass (1632 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)