### PR TITLE
fix: show actual GitHub author in build history and list all changes per sync (closes #235)

### DIFF
--- a/src/main/buildHistoryStore.js
+++ b/src/main/buildHistoryStore.js
@@ -68,39 +68,78 @@ class BuildHistoryStore {
 }
 
 /**
- * Returns a human-readable single-line summary of what changed between two
- * build objects. Checks fields in priority order and returns the first match.
+ * Returns a human-readable summary of every field that changed between two
+ * build objects. All differences are listed (not just the first).
  */
 function summarizeBuildChange(before, after) {
   if (!before) return "build created";
+  const changes = [];
+
   if (before.title !== after.title) {
-    return `title: "${before.title}" → "${after.title}"`;
+    changes.push(`title: "${before.title}" → "${after.title}"`);
   }
   if (before.profession !== after.profession) {
-    return `profession: ${before.profession} → ${after.profession}`;
+    changes.push(`profession: ${before.profession} → ${after.profession}`);
   }
   if ((before.gameMode || "pve") !== (after.gameMode || "pve")) {
-    return `gameMode: ${before.gameMode || "pve"} → ${after.gameMode || "pve"}`;
+    changes.push(`game mode: ${before.gameMode || "pve"} → ${after.gameMode || "pve"}`);
   }
   if (JSON.stringify(before.specializations) !== JSON.stringify(after.specializations)) {
-    return "specializations changed";
+    changes.push("specializations changed");
   }
   if (JSON.stringify(before.skills) !== JSON.stringify(after.skills)) {
-    return "skills changed";
+    changes.push(_describeSkillChanges(before.skills, after.skills));
   }
   if (JSON.stringify(before.underwaterSkills) !== JSON.stringify(after.underwaterSkills)) {
-    return "underwater skills changed";
+    changes.push(_describeSkillChanges(before.underwaterSkills, after.underwaterSkills, true));
   }
   if (JSON.stringify(before.equipment) !== JSON.stringify(after.equipment)) {
-    return "equipment changed";
+    changes.push(_describeEquipmentChanges(before.equipment, after.equipment));
   }
   if (before.notes !== after.notes) {
-    return "notes updated";
+    changes.push("notes updated");
   }
   if (JSON.stringify(before.tags) !== JSON.stringify(after.tags)) {
-    return "tags changed";
+    changes.push("tags changed");
   }
-  return "build updated";
+
+  return changes.length > 0 ? changes.join("; ") : "build updated";
+}
+
+function _describeSkillChanges(before, after, underwater = false) {
+  const prefix = underwater ? "underwater " : "";
+  if (!before || !after) return `${prefix}skills changed`;
+  const slots = [];
+  if (JSON.stringify(before.heal) !== JSON.stringify(after.heal)) slots.push("heal");
+  const utilBefore = before.utility || [];
+  const utilAfter = after.utility || [];
+  for (let i = 0; i < 3; i++) {
+    if (JSON.stringify(utilBefore[i]) !== JSON.stringify(utilAfter[i])) {
+      slots.push(`utility ${i + 1}`);
+    }
+  }
+  if (JSON.stringify(before.elite) !== JSON.stringify(after.elite)) slots.push("elite");
+  if (slots.length === 0) return `${prefix}skills changed`;
+  return `${prefix}${slots.join(", ")} skill${slots.length > 1 ? "s" : ""} changed`;
+}
+
+function _describeEquipmentChanges(before, after) {
+  if (!before || !after) return "equipment changed";
+  const parts = [];
+  if (before.statPackage !== after.statPackage) {
+    parts.push(`stat package: ${before.statPackage || "none"} → ${after.statPackage || "none"}`);
+  }
+  if (JSON.stringify(before.slots) !== JSON.stringify(after.slots)) parts.push("armor/trinkets");
+  if (JSON.stringify(before.weapons) !== JSON.stringify(after.weapons)) parts.push("weapons");
+  if (JSON.stringify(before.runes) !== JSON.stringify(after.runes)) parts.push("runes");
+  if (JSON.stringify(before.sigils) !== JSON.stringify(after.sigils)) parts.push("sigils");
+  if (before.relic !== after.relic) parts.push("relic");
+  if (before.food !== after.food) parts.push("food");
+  if (before.utility !== after.utility) parts.push("utility consumable");
+  if (before.enrichment !== after.enrichment) parts.push("enrichment");
+  if (JSON.stringify(before.infusions) !== JSON.stringify(after.infusions)) parts.push("infusions");
+  if (parts.length === 0) return "equipment changed";
+  return `${parts.join(", ")} changed`;
 }
 
 module.exports = { BuildHistoryStore, summarizeBuildChange };

--- a/src/main/sharedLibrary.js
+++ b/src/main/sharedLibrary.js
@@ -47,6 +47,7 @@ class SharedLibrary {
       token: auth.token,
       org: auth.sharedLibrary.orgName,
       repo: auth.sharedLibrary.repoName || "axibuilds-shared",
+      viewerLogin: auth.viewer?.login || null,
     };
   }
 
@@ -278,7 +279,9 @@ class SharedLibrary {
             });
           }
         }
+        const syncAuthor = data._syncAuthor || auth.org;
         delete data._syncSubFolderName;
+        delete data._syncAuthor;
         data.folderId = restoreFolderId;
         if (this.historyStore) {
           const { summarizeBuildChange } = require("./buildHistoryStore");
@@ -287,7 +290,7 @@ class SharedLibrary {
           if (existingBuild) {
             this.historyStore.addEntry({
               buildId: data.id,
-              authorLogin: auth.org,
+              authorLogin: syncAuthor,
               source: "shared-sync",
               summary: summarizeBuildChange(existingBuild, data),
               snapshot: existingBuild,
@@ -372,6 +375,8 @@ class SharedLibrary {
       const subFolder = folders.find((f) => f.id === build.folderId);
       if (subFolder) buildData._syncSubFolderName = subFolder.name;
     }
+    // Embed author so pull-side history entries show who made the change
+    if (auth.viewerLogin) buildData._syncAuthor = auth.viewerLogin;
     const content = JSON.stringify(buildData, null, 2);
 
     const attemptPush = async (sha) => {
@@ -425,6 +430,7 @@ class SharedLibrary {
       const subFolder = folders.find((f) => f.id === comp.folderId);
       if (subFolder) compData._syncSubFolderName = subFolder.name;
     }
+    if (auth.viewerLogin) compData._syncAuthor = auth.viewerLogin;
     const content = JSON.stringify(compData, null, 2);
 
     const attemptPush = async (sha) => {

--- a/tests/unit/buildHistoryStore.test.js
+++ b/tests/unit/buildHistoryStore.test.js
@@ -231,7 +231,7 @@ describe("summarizeBuildChange", () => {
 
   test("detects gameMode change", () => {
     const after = { ...base, gameMode: "wvw" };
-    expect(summarizeBuildChange(base, after)).toBe("gameMode: pve → wvw");
+    expect(summarizeBuildChange(base, after)).toBe("game mode: pve → wvw");
   });
 
   test("treats missing gameMode as 'pve' for comparison", () => {
@@ -275,14 +275,63 @@ describe("summarizeBuildChange", () => {
     expect(summarizeBuildChange(base, after)).toBe("build updated");
   });
 
-  test("title change takes priority over profession change", () => {
+  test("reports all changes when multiple fields differ", () => {
     const after = { ...base, title: "Different", profession: "Warrior" };
-    // title is checked first
-    expect(summarizeBuildChange(base, after)).toBe('title: "My Build" → "Different"');
+    expect(summarizeBuildChange(base, after)).toBe('title: "My Build" → "Different"; profession: Guardian → Warrior');
   });
 
-  test("profession change takes priority over gameMode change", () => {
+  test("reports both profession and game mode when both change", () => {
     const after = { ...base, profession: "Warrior", gameMode: "wvw" };
-    expect(summarizeBuildChange(base, after)).toBe("profession: Guardian → Warrior");
+    expect(summarizeBuildChange(base, after)).toBe("profession: Guardian → Warrior; game mode: pve → wvw");
+  });
+
+  test("specific skill slot changes — heal and elite", () => {
+    const before = {
+      ...base,
+      skills: { heal: { id: 1 }, utility: [null, null, null], elite: { id: 10 } },
+    };
+    const after = {
+      ...base,
+      skills: { heal: { id: 2 }, utility: [null, null, null], elite: { id: 11 } },
+    };
+    expect(summarizeBuildChange(before, after)).toBe("heal, elite skills changed");
+  });
+
+  test("specific skill slot changes — single utility slot", () => {
+    const before = {
+      ...base,
+      skills: { heal: { id: 1 }, utility: [{ id: 5 }, { id: 6 }, { id: 7 }], elite: { id: 10 } },
+    };
+    const after = {
+      ...base,
+      skills: { heal: { id: 1 }, utility: [{ id: 5 }, { id: 99 }, { id: 7 }], elite: { id: 10 } },
+    };
+    expect(summarizeBuildChange(before, after)).toBe("utility 2 skill changed");
+  });
+
+  test("underwater skill changes use 'underwater' prefix", () => {
+    const before = { ...base, underwaterSkills: { heal: { id: 1 }, utility: [null, null, null], elite: { id: 10 } } };
+    const after  = { ...base, underwaterSkills: { heal: { id: 2 }, utility: [null, null, null], elite: { id: 10 } } };
+    expect(summarizeBuildChange(before, after)).toBe("underwater heal skill changed");
+  });
+
+  test("equipment stat package change is reported specifically", () => {
+    const before = { ...base, equipment: { statPackage: "Berserker", slots: {}, weapons: {}, runes: {}, sigils: {}, infusions: {} } };
+    const after  = { ...base, equipment: { statPackage: "Viper", slots: {}, weapons: {}, runes: {}, sigils: {}, infusions: {} } };
+    expect(summarizeBuildChange(before, after)).toBe("stat package: Berserker → Viper changed");
+  });
+
+  test("equipment rune and sigil changes are reported specifically", () => {
+    const before = { ...base, equipment: { slots: {}, weapons: {}, runes: { head: "Rune of X" }, sigils: {}, infusions: {} } };
+    const after  = { ...base, equipment: { slots: {}, weapons: {}, runes: { head: "Rune of Y" }, sigils: {}, infusions: {} } };
+    expect(summarizeBuildChange(before, after)).toBe("runes changed");
+  });
+
+  test("multiple equipment categories listed when multiple change", () => {
+    const before = { ...base, equipment: { slots: { head: "a" }, weapons: { mainhand: "x" }, runes: {}, sigils: {}, infusions: {} } };
+    const after  = { ...base, equipment: { slots: { head: "b" }, weapons: { mainhand: "y" }, runes: {}, sigils: {}, infusions: {} } };
+    const result = summarizeBuildChange(before, after);
+    expect(result).toContain("armor/trinkets");
+    expect(result).toContain("weapons");
   });
 });

--- a/tests/unit/sharedLibrary.test.js
+++ b/tests/unit/sharedLibrary.test.js
@@ -704,6 +704,106 @@ describe("SharedLibrary — unshareFolder timer cancellation", () => {
   });
 });
 
+// ─── _syncAuthor — author attribution across users ───────────────────────────
+
+describe("SharedLibrary — _syncAuthor author attribution", () => {
+  let dir, syncStore, folderStore;
+  beforeEach(async () => {
+    dir = await makeTempDir();
+    syncStore = new SyncStore(dir);
+    folderStore = new FolderStore(dir);
+    await syncStore.init();
+    await folderStore.init();
+  });
+  afterEach(async () => cleanupDir(dir));
+
+  test("pushBuild embeds _syncAuthor when viewerLogin is known", async () => {
+    const folder = await folderStore.upsertFolder({ id: "f1", name: "Shared", shared: true, orgName: "test-org" });
+    const build = { id: "b1", title: "My Build", folderId: folder.id };
+    const buildStore = mockBuildStore([build]);
+    const compStore = mockCompStore([]);
+
+    githubApi.putSharedFile.mockResolvedValue({ sha: "new-sha" });
+
+    const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore });
+    // Simulate auth with viewer login
+    buildStore.getAuth = jest.fn(async () => ({
+      token: "fake-token",
+      sharedLibrary: { orgName: "test-org", repoName: "axibuilds-shared" },
+      viewer: { login: "alice" },
+    }));
+
+    await lib.pushBuild(build);
+
+    const pushedContent = JSON.parse(githubApi.putSharedFile.mock.calls[0][4]);
+    expect(pushedContent._syncAuthor).toBe("alice");
+  });
+
+  test("pullFolder uses _syncAuthor from JSON for history entry, not org name", async () => {
+    const buildStore = mockBuildStore([{ id: "b1", title: "Old Title", folderId: "f1" }]);
+    const compStore = mockCompStore([]);
+    const folder = await folderStore.upsertFolder({ id: "f1", name: "Shared", shared: true, orgName: "test-org" });
+
+    const historyStore = { addEntry: jest.fn(async (e) => e) };
+    githubApi.getRepoTree.mockResolvedValue([
+      { path: "folders/f1/builds/b1.json", sha: "new-sha" },
+    ]);
+    githubApi.getFileContents.mockResolvedValue({
+      content: JSON.stringify({ id: "b1", title: "New Title", folderId: "f1", _syncAuthor: "bob" }),
+      sha: "new-sha",
+    });
+
+    const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore, historyStore });
+    await lib.pullFolder(folder.id);
+
+    expect(historyStore.addEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ authorLogin: "bob" })
+    );
+  });
+
+  test("pullFolder strips _syncAuthor before upserting build", async () => {
+    const buildStore = mockBuildStore([]);
+    const compStore = mockCompStore([]);
+    await folderStore.upsertFolder({ id: "f1", name: "Shared", shared: true, orgName: "test-org" });
+
+    githubApi.getRepoTree.mockResolvedValue([
+      { path: "folders/f1/builds/b1.json", sha: "b1-sha" },
+    ]);
+    githubApi.getFileContents.mockResolvedValue({
+      content: JSON.stringify({ id: "b1", title: "Build", _syncAuthor: "charlie" }),
+      sha: "b1-sha",
+    });
+
+    const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore });
+    await lib.pullFolder("f1");
+
+    const upserted = buildStore.upsertBuild.mock.calls[0][0];
+    expect(upserted._syncAuthor).toBeUndefined();
+  });
+
+  test("pullFolder falls back to org name when _syncAuthor is absent", async () => {
+    const buildStore = mockBuildStore([{ id: "b1", title: "Old", folderId: "f1" }]);
+    const compStore = mockCompStore([]);
+    await folderStore.upsertFolder({ id: "f1", name: "Shared", shared: true, orgName: "test-org" });
+
+    const historyStore = { addEntry: jest.fn(async (e) => e) };
+    githubApi.getRepoTree.mockResolvedValue([
+      { path: "folders/f1/builds/b1.json", sha: "b1-sha" },
+    ]);
+    githubApi.getFileContents.mockResolvedValue({
+      content: JSON.stringify({ id: "b1", title: "New", folderId: "f1" }),
+      sha: "b1-sha",
+    });
+
+    const lib = new SharedLibrary({ buildStore, compStore, folderStore, syncStore, historyStore });
+    await lib.pullFolder("f1");
+
+    expect(historyStore.addEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ authorLogin: "test-org" })
+    );
+  });
+});
+
 // ─── subfolder re-parenting on disconnect-reconnect ──────────────────────────
 
 describe("SharedLibrary — subfolder re-parenting on reconnect", () => {


### PR DESCRIPTION
## Summary

- **Author attribution**: Push now embeds `_syncAuthor: viewerLogin` in each build's synced JSON. On pull, this is stripped from the data before storing and used as the `authorLogin` in the history entry — so history shows the actual GitHub login of who made the change (e.g. `alice`), not the org name. Builds pushed before this change fall back to the org name.

- **Specific change summaries**: `summarizeBuildChange` now collects *all* changed fields instead of returning on the first match, and is more granular:
  - Skills: names which slots changed (e.g. `heal, elite skills changed`, `utility 2 skill changed`)
  - Underwater skills: prefixed (`underwater heal skill changed`)
  - Equipment: names changed categories (`armor/trinkets, runes changed`; `stat package: Berserker → Viper changed`)
  - Multiple top-level changes are joined with `; ` (e.g. `title: "X" → "Y"; profession: Guardian → Warrior; skills changed`)

Closes #235

## Test plan
- [ ] Push a build change from one account; pull on another — history entry should show the pusher's GitHub username, not the org name
- [ ] Change only the heal skill on a build and save — history should say `heal skill changed`
- [ ] Change both equipment stat package and runes — history should list both specifically
- [ ] Change title and game mode together — history should show both in one entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)