### PR TITLE
fix: Discord webhook URL settings save silently on IPC failure (closes #237)

### DIFF
--- a/src/renderer/modules/settings-modal.js
+++ b/src/renderer/modules/settings-modal.js
@@ -138,7 +138,8 @@ export function initSettingsModal() {
         </div>
       </div>
       <div class="settings-modal__actions">
-        <button class="settings-modal__btn settings-modal__btn--save" id="sm-save">Save</button>
+        <span class="settings-modal__save-status" id="sm-save-status"></span>
+        <button class="settings-modal__btn settings-modal__btn--save" id="sm-save" type="button">Save</button>
       </div>
     </div>
   `;
@@ -161,6 +162,7 @@ export function initSettingsModal() {
     buildThreadId:     document.getElementById("sm-build-thread-id"),
     buildThreadError:  document.getElementById("sm-build-thread-error"),
     save:              document.getElementById("sm-save"),
+    saveStatus:        document.getElementById("sm-save-status"),
     clearCache:        document.getElementById("sm-clear-cache"),
     cacheStatus:       document.getElementById("sm-cache-status"),
     sharedStatus:      document.getElementById("sm-shared-status"),
@@ -232,6 +234,11 @@ export async function openSettingsModal() {
 
   // Themed build pages toggle
   _el.themedBuilds.checked = !!themedBuilds;
+
+  // Reset save button state
+  _el.save.disabled = false;
+  _el.saveStatus.textContent = "";
+  _el.saveStatus.className = "settings-modal__save-status";
 
   // Populate appearance section
   _renderThemeGrid();
@@ -582,15 +589,25 @@ async function _save() {
   _el.buildWebhookError.textContent = "";
   _el.threadError.textContent = "";
   _el.buildThreadError.textContent = "";
-  await Promise.all([
-    window.desktopApi.setSetting("discord.webhookUrl", url || null),
-    window.desktopApi.setSetting("discord.threadMode", mode),
-    window.desktopApi.setSetting("discord.threadId", mode === "custom" ? threadId : null),
-    window.desktopApi.setSetting("discord.buildWebhookUrl", buildUrl || null),
-    window.desktopApi.setSetting("discord.buildThreadMode", bMode),
-    window.desktopApi.setSetting("discord.buildThreadId", bMode === "custom" ? bThreadId : null),
-  ]);
-  _close();
+
+  _el.save.disabled = true;
+  _el.saveStatus.textContent = "";
+  _el.saveStatus.className = "settings-modal__save-status";
+  try {
+    await Promise.all([
+      window.desktopApi.setSetting("discord.webhookUrl", url || null),
+      window.desktopApi.setSetting("discord.threadMode", mode),
+      window.desktopApi.setSetting("discord.threadId", mode === "custom" ? threadId : null),
+      window.desktopApi.setSetting("discord.buildWebhookUrl", buildUrl || null),
+      window.desktopApi.setSetting("discord.buildThreadMode", bMode),
+      window.desktopApi.setSetting("discord.buildThreadId", bMode === "custom" ? bThreadId : null),
+    ]);
+    _close();
+  } catch (err) {
+    _el.saveStatus.textContent = "Save failed — please try again";
+    _el.saveStatus.className = "settings-modal__save-status settings-modal__save-status--error";
+    _el.save.disabled = false;
+  }
 }
 
 function _close() {

--- a/src/renderer/styles/settings-modal.css
+++ b/src/renderer/styles/settings-modal.css
@@ -357,11 +357,21 @@
 
 .settings-modal__actions {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   gap: 8px;
   padding: 14px 20px;
   border-top: 1px solid var(--line);
   flex-shrink: 0;
+}
+
+.settings-modal__save-status {
+  font-size: 0.78rem;
+  margin-right: auto;
+}
+
+.settings-modal__save-status--error {
+  color: var(--danger-text);
 }
 
 .settings-modal__btn {

--- a/tests/unit/settingsModalSave.test.js
+++ b/tests/unit/settingsModalSave.test.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+describe("settings-modal save button — defensive attributes", () => {
+  let src;
+
+  beforeAll(() => {
+    src = fs.readFileSync(
+      path.resolve(__dirname, "../../src/renderer/modules/settings-modal.js"),
+      "utf8"
+    );
+  });
+
+  test("Save button has explicit type='button' to prevent accidental form submission", () => {
+    // The Save button must have type="button". Without it, some browsers/Electron
+    // versions treat a button inside certain layouts as type="submit".
+    const saveButtonMatch = src.match(/id="sm-save"[^>]*>Save<\/button>|>Save<\/button>[^<]*id="sm-save"/);
+    // Find the sm-save button in the HTML template
+    const smSaveBtn = src.match(/<button[^>]+id="sm-save"[^>]*>Save<\/button>/);
+    expect(smSaveBtn).not.toBeNull();
+    expect(smSaveBtn[0]).toMatch(/type="button"/);
+  });
+});
+
+describe("settings-modal _save — error handling", () => {
+  let src;
+
+  beforeAll(() => {
+    src = fs.readFileSync(
+      path.resolve(__dirname, "../../src/renderer/modules/settings-modal.js"),
+      "utf8"
+    );
+  });
+
+  test("_save function contains try/catch around the setSetting calls", () => {
+    // Extract the _save function body and check for try/catch.
+    // This guards against silent failures where the modal stays open with no
+    // user feedback when IPC calls fail.
+    const saveFnMatch = src.match(/async function _save\(\)\s*\{([\s\S]*?)(?=\n(?:function|async function|\/\/ ─))/);
+    expect(saveFnMatch).not.toBeNull();
+    const saveFnBody = saveFnMatch[1];
+    expect(saveFnBody).toMatch(/try\s*\{/);
+    expect(saveFnBody).toMatch(/catch\s*\(/);
+  });
+
+  test("_save shows a user-visible error when setSetting fails", () => {
+    // Verify the catch block in _save sets a visible error, not just logs to console.
+    const saveFnMatch = src.match(/async function _save\(\)\s*\{([\s\S]*?)(?=\n(?:function|async function|\/\/ ─))/);
+    expect(saveFnMatch).not.toBeNull();
+    const saveFnBody = saveFnMatch[1];
+    // Should have some error display in catch (not just console.error)
+    const catchBlock = saveFnBody.match(/catch\s*\([^)]*\)\s*\{([^}]*)\}/s);
+    expect(catchBlock).not.toBeNull();
+    // The catch block should reference an error display element, not just log
+    expect(catchBlock[1]).not.toMatch(/^\s*\/\//); // not just a comment
+    expect(catchBlock[0]).toMatch(/textContent|showError|err/);
+  });
+});


### PR DESCRIPTION
## Summary

`_save()` in the settings modal had no error handling around the `Promise.all([...setSetting calls...])`. When any IPC call failed:
- `_save` threw an unhandled promise rejection
- `_close()` was never reached — modal stayed open
- No error was shown to the user
- User clicked X to dismiss, thinking save worked, losing their input

**Changes:**
- Wraps the `setSetting` calls in `try/catch` — shows "Save failed — please try again" in the footer on error, re-enables the Save button
- Disables the Save button while saving (prevents double-click races)
- Resets save status on modal open so state is clean each time
- Adds `type="button"` to the Save button (defensive best practice)
- Adds CSS for the new `.settings-modal__save-status` element

Closes #237

## Test plan

- [ ] Open Settings → Discord section → enter a valid webhook URL → click Save → modal closes cleanly (existing behavior)
- [ ] Re-open Settings → webhook URL is still populated
- [ ] Try to reproduce a save failure (e.g. disconnect from internet, then save) — should now see "Save failed — please try again" in the footer instead of nothing happening

🤖 Generated with [Claude Code](https://claude.com/claude-code)