### PR TITLE
fix: Ranger Marksmanship Farsighted trait shows duplicate fact labels (closes #216)

### DIFF
--- a/packages/gw2-data/src/wiki/client.js
+++ b/packages/gw2-data/src/wiki/client.js
@@ -9,7 +9,7 @@ const {
 
 const WIKI_API_ROOT = "https://wiki.guildwars2.com/api.php";
 const USER_AGENT = "@axiapps/gw2-data (https://github.com/darkharasho/axiforge)";
-const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const DEFAULT_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const RATE_LIMIT_MS = 200;
 const MISSING_SENTINEL = "__WIKI_MISSING__";
 

--- a/packages/gw2-data/src/wiki/client.js
+++ b/packages/gw2-data/src/wiki/client.js
@@ -9,7 +9,7 @@ const {
 
 const WIKI_API_ROOT = "https://wiki.guildwars2.com/api.php";
 const USER_AGENT = "@axiapps/gw2-data (https://github.com/darkharasho/axiforge)";
-const DEFAULT_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const RATE_LIMIT_MS = 200;
 const MISSING_SENTINEL = "__WIKI_MISSING__";
 

--- a/packages/gw2-data/src/wiki/parser.js
+++ b/packages/gw2-data/src/wiki/parser.js
@@ -392,13 +392,13 @@ function mapWikiFactToApiFact(factType, positional, params, isWvw, isUniversal) 
   // Many wiki fact types carry a percentage value (e.g. "damage reduction|33").
   // Without this, they fall through to generic Number and lose the % suffix.
   if (PERCENT_TYPES.has(type)) {
-    const label = type.replace(/\b\w/g, (c) => c.toUpperCase());
+    const label = params.alt ? stripWikiMarkup(params.alt).trim() : type.replace(/\b\w/g, (c) => c.toUpperCase());
     return { type: "Percent", text: label, percent: pos0Num() };
   }
 
   // ── Unknown but has a numeric value ────────────────────────────────
   if (positional[0] && !isNaN(parseFloat(stripWikiMarkup(positional[0])))) {
-    const label = type.replace(/\b\w/g, (c) => c.toUpperCase());
+    const label = params.alt ? stripWikiMarkup(params.alt).trim() : type.replace(/\b\w/g, (c) => c.toUpperCase());
     // Heuristic: fact type names containing "increase", "reduction", "chance",
     // or "rate" are almost always percentages in GW2 wiki templates.
     if (/(?:increase|reduction|chance|rate|cost|drain)$/.test(type)) {

--- a/packages/gw2-data/tests/parser.test.js
+++ b/packages/gw2-data/tests/parser.test.js
@@ -187,6 +187,25 @@ describe("mapWikiFactToApiFact", () => {
     expect(fact).toEqual({ type: "Percent", text: "Recharge Reduced", percent: 15 });
   });
 
+  test("damage increase with alt label uses alt as text (Farsighted)", () => {
+    // {{skill fact|damage increase|alt=Damage Increase above Threshold|15|game mode=pve wvw}}
+    // The alt param should override the generated label, not be ignored.
+    const fact = mapWikiFactToApiFact(
+      "damage increase",
+      ["15"],
+      { alt: "Damage Increase above Threshold", "game mode": "pve wvw" },
+      false,
+      false
+    );
+    expect(fact).toEqual({ type: "Percent", text: "Damage Increase above Threshold", percent: 15 });
+  });
+
+  test("generic numeric fact with alt label uses alt as text", () => {
+    // alt param should work for generic Number facts too
+    const fact = mapWikiFactToApiFact("range threshold", ["600"], { alt: "Range Threshold" }, false, true);
+    expect(fact).toMatchObject({ text: "Range Threshold" });
+  });
+
   test("attribute gain/conversion", () => {
     const fact = mapWikiFactToApiFact(
       "gain",
@@ -502,5 +521,22 @@ describe("parseAllTaggedFacts", () => {
     const { facts } = parseAllTaggedFacts(wikitext);
     expect(facts).toHaveLength(1);
     expect(facts[0]._modes).toEqual(["pve", "wvw", "pvp"]);
+  });
+
+  test("Farsighted wikitext produces distinct labels for damage increase facts", () => {
+    // Regression test: trait 1000 (Farsighted, Ranger Marksmanship) uses alt= to label
+    // the above-threshold bonus differently from the base bonus.
+    const wikitext = [
+      "{{skill fact|damage increase|10|game mode=pve wvw}}",
+      "{{skill fact|damage increase|5|game mode=pvp}}",
+      "{{skill fact|damage increase|alt=Damage Increase above Threshold|15|game mode=pve wvw}}",
+      "{{skill fact|damage increase|alt=Damage Increase above Threshold|10|game mode=pvp}}",
+      "{{skill fact|Range Threshold|600}}",
+    ].join("\n");
+    const { facts } = parseAllTaggedFacts(wikitext);
+    const pveWvwFacts = facts.filter(f => f._modes.includes("pve") && !f._modes.includes("pvp") || f._modes.length === 3);
+    const labels = facts.filter(f => f._modes.includes("pve")).map(f => f.text);
+    expect(labels).toContain("Damage Increase");
+    expect(labels).toContain("Damage Increase above Threshold");
   });
 });

--- a/src/main/gw2Data/catalog.js
+++ b/src/main/gw2Data/catalog.js
@@ -28,7 +28,7 @@ const _catalogInflight = new Map();
 
 function initWikiClient(cacheDir) {
   const cache = new DiskCache(path.join(cacheDir, "wiki-facts"));
-  _wikiClient = new WikiClient({ cache });
+  _wikiClient = new WikiClient({ cache, cacheTTL: 7 * 24 * 60 * 60 * 1000 });
 }
 
 function getWikiClient() {


### PR DESCRIPTION
## Summary

The Farsighted trait (Ranger Marksmanship, tier Master) uses the wiki template `alt=` parameter to display two distinct damage bonus facts: one for the base bonus ("Damage Increase: 10%") and one for the above-threshold bonus ("Damage Increase above Threshold: 15%"). The wiki parser's `PERCENT_TYPES` handler and generic numeric fallback ignored `params.alt`, so both facts rendered with the same label "Damage Increase", making the tooltip confusing and inaccurate.

The fix applies `params.alt` as the display text override in the two handlers that were missing it, matching how the `effect` handler already uses `alt`.

Closes #216