### PR TITLE
fix: Smash Brawler Berserker Trait crit chance applied unconditionally (closes #225)

### DIFF
--- a/packages/gw2-data/data/overrides.json
+++ b/packages/gw2-data/data/overrides.json
@@ -26,6 +26,10 @@
     "berserkConditional": true,
     "description": "Fatal Frenzy: stat bonuses only apply while in berserk mode"
   },
+  "trait:2049": {
+    "berserkConditional": true,
+    "description": "Smash Brawler: crit chance bonus only applies while in berserk mode"
+  },
   "trait:1338": {
     "weaponConditional": { "weapons": ["greatsword", "spear"], "multiplier": 2 },
     "description": "Forceful Greatsword: double Power bonus while wielding greatsword or underwater spear"

--- a/packages/gw2-data/src/engine/attributes.js
+++ b/packages/gw2-data/src/engine/attributes.js
@@ -552,6 +552,14 @@ function computeAttributes(ctx, catalogs) {
       }
     }
   }
+  // Berserk crit bonus (only when berserk mode is active)
+  if (berserkActive) {
+    for (const mod of modifiers) {
+      if (mod.type === "critChance" && mod.condition === "berserk") {
+        critBonus += mod.value;
+      }
+    }
+  }
 
   const critChance = Math.min(100, (total.Precision - 895) / 21 + critBonus);
   const critDamage = 150 + total.Ferocity / 15;

--- a/packages/gw2-data/src/engine/modifiers.js
+++ b/packages/gw2-data/src/engine/modifiers.js
@@ -200,13 +200,14 @@ function collectModifiers(ctx, catalogs, overrides) {
 
     // 6. "Critical Chance Increase" Percent facts — critChance
     //    Fury traits: condition = "fury" (applied only when fury is assumed)
+    //    Berserk traits: condition = "berserk" (applied only when berserk is active)
     //    Non-fury/non-berserk traits: condition = null (passive, always active)
     //    Skip traits with ignoreCritChance (skill-specific crit like Opening Strike, stealth, bursts)
     if (!override?.ignoreCritChance) {
       const critFacts = modeFacts.filter(
         (f) => f.type === "Percent" && f.text === "Critical Chance Increase" && f.percent
       );
-      if (critFacts.length > 0 && (fury || condition === null)) {
+      if (critFacts.length > 0 && (fury || condition === null || condition === "berserk")) {
         const idx = gameMode === "wvw" ? Math.min(1, critFacts.length - 1) : 0;
         modifiers.push({
           source,

--- a/packages/gw2-data/tests/engine/attributes.test.js
+++ b/packages/gw2-data/tests/engine/attributes.test.js
@@ -308,6 +308,35 @@ describe("computeAttributes", () => {
     expect(resultOn.traits.ConditionDamage).toBe(300);
   });
 
+  test("Smash Brawler crit chance only applies when berserkActive (issue #225)", () => {
+    // Trait 2049 must have berserkConditional:true in overrides.json for this test to pass.
+    // Base precision 1000 → crit = (1000-895)/21 = 5%. With Smash Brawler +15% while berserk = 20%.
+    const catalogs = makeCatalogs({
+      traitById: new Map([[2049, {
+        id: 2049,
+        slot: "Major",
+        description: "Smash Brawler",
+        facts: [
+          { type: "Percent", text: "Critical Chance Increase", percent: 15 },
+          { type: "Percent", text: "Critical Chance Increase", percent: 5 },
+        ],
+        specialization: 18,
+      }]]),
+      specializationById: new Map([[18, { id: 18, minorTraits: [] }]]),
+    });
+    const baseCtx = {
+      specializations: [{ id: 18, majorChoices: { 1: 2049 } }],
+    };
+
+    // Without berserk: no crit bonus from trait
+    const resultOff = computeAttributes(makeCtx({ ...baseCtx, berserkActive: false }), catalogs);
+    expect(resultOff.derived.critChance).toBeCloseTo(5, 5);
+
+    // With berserk: +15% crit from trait
+    const resultOn = computeAttributes(makeCtx({ ...baseCtx, berserkActive: true }), catalogs);
+    expect(resultOn.derived.critChance).toBeCloseTo(20, 5);
+  });
+
   test("signet passive buffs added", () => {
     const ctx = makeCtx({
       skills: { healId: null, utilityIds: [], eliteId: null },

--- a/packages/gw2-data/tests/engine/modifiers.test.js
+++ b/packages/gw2-data/tests/engine/modifiers.test.js
@@ -546,4 +546,29 @@ describe("collectModifiers()", () => {
       condition: null,
     });
   });
+
+  it("emits critChance with condition:'berserk' for berserkConditional trait (Smash Brawler)", () => {
+    const traitId = 2049;
+    const trait = {
+      slot: "Major",
+      description: "Smash Brawler",
+      facts: [
+        { type: "Percent", text: "Critical Chance Increase", percent: 15 },
+        { type: "Percent", text: "Critical Chance Increase", percent: 5 },
+      ],
+    };
+    const catalogs = makeCatalogs({ [traitId]: trait });
+    const ctx = makeCtx([{ id: 18, majorChoices: { 1: traitId } }]);
+    const overrides = makeOverrides({ "trait:2049": { berserkConditional: true } });
+
+    const mods = collectModifiers(ctx, catalogs, overrides);
+    const critMods = mods.filter((m) => m.type === "critChance");
+    expect(critMods).toHaveLength(1);
+    expect(critMods[0]).toMatchObject({
+      source: "trait:2049",
+      type: "critChance",
+      value: 15,
+      condition: "berserk",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The Smash Brawler trait (ID 2049) was applying its +15% critical chance bonus unconditionally rather than only while Berserk mode is active. The root cause was two-fold: (1) the trait was missing a `berserkConditional: true` entry in `overrides.json`, so the engine treated its crit chance fact as always-on; (2) the `collectModifiers` function in `modifiers.js` didn't emit `critChance` modifiers for berserk-conditional traits, and `computeAttributes` didn't apply them when berserk is active. This PR adds the override and wires up berserk-conditional crit chance handling end-to-end (mirroring the existing pattern for `flatBonus` stats like Fatal Frenzy).

Closes #225