### PR TITLE
fix: settings auto-save on input — remove explicit Save button (closes #251)

### DIFF
--- a/src/renderer/modules/settings-modal.js
+++ b/src/renderer/modules/settings-modal.js
@@ -178,6 +178,10 @@ export function initSettingsModal() {
   _el.close.addEventListener("click", _close);
   _el.save.addEventListener("click", _save);
   _el.clearCache.addEventListener("click", _clearCache);
+
+  // Pressing Enter in either webhook URL field triggers save, matching user expectation.
+  _el.webhookUrl.addEventListener("keydown", (e) => { if (e.key === "Enter") _save(); });
+  _el.buildWebhookUrl.addEventListener("keydown", (e) => { if (e.key === "Enter") _save(); });
   _el.sharedConnect.addEventListener("click", _connectSharedLibrary);
   _el.sharedDisconnect.addEventListener("click", _disconnectSharedLibrary);
 

--- a/src/renderer/modules/settings-modal.js
+++ b/src/renderer/modules/settings-modal.js
@@ -139,7 +139,6 @@ export function initSettingsModal() {
       </div>
       <div class="settings-modal__actions">
         <span class="settings-modal__save-status" id="sm-save-status"></span>
-        <button class="settings-modal__btn settings-modal__btn--save" id="sm-save" type="button">Save</button>
       </div>
     </div>
   `;
@@ -161,7 +160,6 @@ export function initSettingsModal() {
     buildThreadMode:   document.getElementById("sm-build-thread-mode"),
     buildThreadId:     document.getElementById("sm-build-thread-id"),
     buildThreadError:  document.getElementById("sm-build-thread-error"),
-    save:              document.getElementById("sm-save"),
     saveStatus:        document.getElementById("sm-save-status"),
     clearCache:        document.getElementById("sm-clear-cache"),
     cacheStatus:       document.getElementById("sm-cache-status"),
@@ -175,23 +173,27 @@ export function initSettingsModal() {
   };
   _el.themedBuilds = _overlay.querySelector("#sm-themed-builds");
 
-  _el.close.addEventListener("click", _close);
-  _el.save.addEventListener("click", _save);
-  _el.clearCache.addEventListener("click", _clearCache);
+  const _debouncedSave = _debounce(_save, 600);
 
-  // Pressing Enter in either webhook URL field triggers save, matching user expectation.
-  _el.webhookUrl.addEventListener("keydown", (e) => { if (e.key === "Enter") _save(); });
-  _el.buildWebhookUrl.addEventListener("keydown", (e) => { if (e.key === "Enter") _save(); });
+  _el.close.addEventListener("click", _close);
+  _el.clearCache.addEventListener("click", _clearCache);
   _el.sharedConnect.addEventListener("click", _connectSharedLibrary);
   _el.sharedDisconnect.addEventListener("click", _disconnectSharedLibrary);
 
-  // Toggle thread ID input visibility for comp webhook
+  // Auto-save text inputs after user stops typing
+  _el.webhookUrl.addEventListener("input", _debouncedSave);
+  _el.threadId.addEventListener("input", _debouncedSave);
+  _el.buildWebhookUrl.addEventListener("input", _debouncedSave);
+  _el.buildThreadId.addEventListener("input", _debouncedSave);
+
+  // Toggle thread ID visibility and save immediately on radio change
   _el.threadMode.addEventListener("change", (e) => {
     _el.threadId.classList.toggle("settings-modal__thread-id-input--hidden", e.target.value !== "custom");
+    _save();
   });
-  // Toggle thread ID input visibility for build webhook
   _el.buildThreadMode.addEventListener("change", (e) => {
     _el.buildThreadId.classList.toggle("settings-modal__thread-id-input--hidden", e.target.value !== "custom");
+    _save();
   });
 
   // Toggle themed build pages
@@ -239,8 +241,6 @@ export async function openSettingsModal() {
   // Themed build pages toggle
   _el.themedBuilds.checked = !!themedBuilds;
 
-  // Reset save button state
-  _el.save.disabled = false;
   _el.saveStatus.textContent = "";
   _el.saveStatus.className = "settings-modal__save-status";
 
@@ -551,6 +551,22 @@ async function _clearCache() {
 
 // ─── Discord settings save ───────────────────────────────────────────────────
 
+function _debounce(fn, ms) {
+  let timer;
+  return (...args) => { clearTimeout(timer); timer = setTimeout(() => fn(...args), ms); };
+}
+
+function _showSaved() {
+  _el.saveStatus.textContent = "\u2713 Saved";
+  _el.saveStatus.className = "settings-modal__save-status settings-modal__save-status--ok";
+  setTimeout(() => {
+    if (_el.saveStatus.textContent === "\u2713 Saved") {
+      _el.saveStatus.textContent = "";
+      _el.saveStatus.className = "settings-modal__save-status";
+    }
+  }, 2000);
+}
+
 async function _save() {
   const url = _el.webhookUrl.value.trim();
   const buildUrl = _el.buildWebhookUrl.value.trim();
@@ -594,9 +610,6 @@ async function _save() {
   _el.threadError.textContent = "";
   _el.buildThreadError.textContent = "";
 
-  _el.save.disabled = true;
-  _el.saveStatus.textContent = "";
-  _el.saveStatus.className = "settings-modal__save-status";
   try {
     await Promise.all([
       window.desktopApi.setSetting("discord.webhookUrl", url || null),
@@ -606,11 +619,10 @@ async function _save() {
       window.desktopApi.setSetting("discord.buildThreadMode", bMode),
       window.desktopApi.setSetting("discord.buildThreadId", bMode === "custom" ? bThreadId : null),
     ]);
-    _close();
+    _showSaved();
   } catch (err) {
     _el.saveStatus.textContent = "Save failed — please try again";
     _el.saveStatus.className = "settings-modal__save-status settings-modal__save-status--error";
-    _el.save.disabled = false;
   }
 }
 

--- a/tests/unit/settingsModalSave.test.js
+++ b/tests/unit/settingsModalSave.test.js
@@ -3,7 +3,7 @@
 const fs = require("fs");
 const path = require("path");
 
-describe("settings-modal save button — defensive attributes", () => {
+describe("settings-modal — no explicit Save button (auto-saves)", () => {
   let src;
 
   beforeAll(() => {
@@ -13,14 +13,13 @@ describe("settings-modal save button — defensive attributes", () => {
     );
   });
 
-  test("Save button has explicit type='button' to prevent accidental form submission", () => {
-    // The Save button must have type="button". Without it, some browsers/Electron
-    // versions treat a button inside certain layouts as type="submit".
-    const saveButtonMatch = src.match(/id="sm-save"[^>]*>Save<\/button>|>Save<\/button>[^<]*id="sm-save"/);
-    // Find the sm-save button in the HTML template
-    const smSaveBtn = src.match(/<button[^>]+id="sm-save"[^>]*>Save<\/button>/);
-    expect(smSaveBtn).not.toBeNull();
-    expect(smSaveBtn[0]).toMatch(/type="button"/);
+  test("HTML template does not contain a Save button", () => {
+    // Settings auto-save — there is no explicit Save button to click.
+    expect(src).not.toMatch(/>Save<\/button>/);
+  });
+
+  test("sm-save-status element is present for Saved/error feedback", () => {
+    expect(src).toMatch(/id="sm-save-status"/);
   });
 });
 
@@ -35,7 +34,6 @@ describe("settings-modal _save — error handling", () => {
   });
 
   test("_save function contains try/catch around the setSetting calls", () => {
-    // Extract the _save function body and check for try/catch.
     // This guards against silent failures where the modal stays open with no
     // user feedback when IPC calls fail.
     const saveFnMatch = src.match(/async function _save\(\)\s*\{([\s\S]*?)(?=\n(?:function|async function|\/\/ ─))/);
@@ -50,16 +48,14 @@ describe("settings-modal _save — error handling", () => {
     const saveFnMatch = src.match(/async function _save\(\)\s*\{([\s\S]*?)(?=\n(?:function|async function|\/\/ ─))/);
     expect(saveFnMatch).not.toBeNull();
     const saveFnBody = saveFnMatch[1];
-    // Should have some error display in catch (not just console.error)
     const catchBlock = saveFnBody.match(/catch\s*\([^)]*\)\s*\{([^}]*)\}/s);
     expect(catchBlock).not.toBeNull();
-    // The catch block should reference an error display element, not just log
-    expect(catchBlock[1]).not.toMatch(/^\s*\/\//); // not just a comment
+    expect(catchBlock[1]).not.toMatch(/^\s*\/\//);
     expect(catchBlock[0]).toMatch(/textContent|showError|err/);
   });
 });
 
-describe("settings-modal webhook URL inputs — Enter key triggers save (issue #251)", () => {
+describe("settings-modal — auto-save on input (issue #251)", () => {
   let src;
 
   beforeAll(() => {
@@ -69,25 +65,25 @@ describe("settings-modal webhook URL inputs — Enter key triggers save (issue #
     );
   });
 
-  test("keydown Enter handler is attached to webhook URL inputs in initSettingsModal", () => {
-    // Users expect pressing Enter in a text field to confirm/save. Without this,
-    // they type the URL, press Enter, see nothing happen, close with X, and lose the URL.
-    // The handler must be wired in initSettingsModal (after _el is set) and call _save.
-    const initFnMatch = src.match(/export function initSettingsModal\(\)\s*\{([\s\S]*?)(?=\nexport )/);
-    expect(initFnMatch).not.toBeNull();
-    const initBody = initFnMatch[1];
-    // Must attach a keydown listener to one or both webhook URL inputs
-    expect(initBody).toMatch(/webhookUrl|sm-webhook-url/);
-    expect(initBody).toMatch(/keydown|keypress|key.*Enter/);
+  test("_debounce helper is defined in the module", () => {
+    // Auto-save debounces text input events to avoid firing on every keystroke.
+    expect(src).toMatch(/function _debounce\s*\(/);
   });
 
-  test("Enter key handler references _save (not just the click binding)", () => {
-    // The Enter key handler must be separate from the click handler, referencing _save
-    // in a keydown/keypress context, not just the existing click listener wiring.
+  test("webhook URL inputs are wired with debounced input event listener", () => {
+    // Users expect typing a URL and pausing to trigger a save automatically.
     const initFnMatch = src.match(/export function initSettingsModal\(\)\s*\{([\s\S]*?)(?=\nexport )/);
     expect(initFnMatch).not.toBeNull();
     const initBody = initFnMatch[1];
-    // Should have a keydown/keypress event listener that calls _save
-    expect(initBody).toMatch(/addEventListener\(['"](keydown|keypress)['"]/);
+    expect(initBody).toMatch(/webhookUrl.*addEventListener.*['"](input)['"]/);
+    expect(initBody).toMatch(/_debouncedSave/);
+  });
+
+  test("radio/select changes trigger immediate save", () => {
+    // Thread-mode radio changes should save without debounce delay.
+    const initFnMatch = src.match(/export function initSettingsModal\(\)\s*\{([\s\S]*?)(?=\nexport )/);
+    expect(initFnMatch).not.toBeNull();
+    const initBody = initFnMatch[1];
+    expect(initBody).toMatch(/threadMode.*addEventListener.*['"](change)['"]/);
   });
 });

--- a/tests/unit/settingsModalSave.test.js
+++ b/tests/unit/settingsModalSave.test.js
@@ -58,3 +58,36 @@ describe("settings-modal _save — error handling", () => {
     expect(catchBlock[0]).toMatch(/textContent|showError|err/);
   });
 });
+
+describe("settings-modal webhook URL inputs — Enter key triggers save (issue #251)", () => {
+  let src;
+
+  beforeAll(() => {
+    src = fs.readFileSync(
+      path.resolve(__dirname, "../../src/renderer/modules/settings-modal.js"),
+      "utf8"
+    );
+  });
+
+  test("keydown Enter handler is attached to webhook URL inputs in initSettingsModal", () => {
+    // Users expect pressing Enter in a text field to confirm/save. Without this,
+    // they type the URL, press Enter, see nothing happen, close with X, and lose the URL.
+    // The handler must be wired in initSettingsModal (after _el is set) and call _save.
+    const initFnMatch = src.match(/export function initSettingsModal\(\)\s*\{([\s\S]*?)(?=\nexport )/);
+    expect(initFnMatch).not.toBeNull();
+    const initBody = initFnMatch[1];
+    // Must attach a keydown listener to one or both webhook URL inputs
+    expect(initBody).toMatch(/webhookUrl|sm-webhook-url/);
+    expect(initBody).toMatch(/keydown|keypress|key.*Enter/);
+  });
+
+  test("Enter key handler references _save (not just the click binding)", () => {
+    // The Enter key handler must be separate from the click handler, referencing _save
+    // in a keydown/keypress context, not just the existing click listener wiring.
+    const initFnMatch = src.match(/export function initSettingsModal\(\)\s*\{([\s\S]*?)(?=\nexport )/);
+    expect(initFnMatch).not.toBeNull();
+    const initBody = initFnMatch[1];
+    // Should have a keydown/keypress event listener that calls _save
+    expect(initBody).toMatch(/addEventListener\(['"](keydown|keypress)['"]/);
+  });
+});


### PR DESCRIPTION
## Summary

Replaced the explicit Save button in the settings modal with auto-save: Discord webhook URL and Thread ID text inputs debounce-save 600ms after the user stops typing; thread-mode radio changes save immediately. A brief "✓ Saved" status confirms each save. The modal no longer closes after saving — users can adjust settings freely and close with X or Escape.

This eliminates the original bug where users typed a webhook URL, pressed Enter (which did nothing), closed with X, and lost their URL.

Closes #251