### PR TITLE
fix: Weapon Swapping Adds 1 infusion (closes #226)

### DIFF
--- a/packages/gw2-data/src/engine/attributes.js
+++ b/packages/gw2-data/src/engine/attributes.js
@@ -313,6 +313,12 @@ function computeAttributes(ctx, catalogs) {
   if (equipment.infusions && catalogs.infusionById) {
     for (const [slotKey, infusionIds] of Object.entries(equipment.infusions)) {
       if (excluded.has(slotKey)) continue;
+      // Skip offhand infusions when the corresponding mainhand has a two-handed weapon
+      // (offhand is locked/empty when mainhand is 2H, so its infusions shouldn't count)
+      if (slotKey.startsWith("offhand") && !slotKey.startsWith("aquatic")) {
+        const mainhandKey = slotKey.replace("offhand", "mainhand");
+        if (TWO_HAND_WEAPON_TYPES.has(weapons[mainhandKey] || "")) continue;
+      }
       const ids = Array.isArray(infusionIds) ? infusionIds : [infusionIds];
       // Cap infusion slots for mainhand weapons: 2H = 2, 1H = 1
       let maxSlots = ids.length;

--- a/packages/gw2-data/tests/engine/attributes.test.js
+++ b/packages/gw2-data/tests/engine/attributes.test.js
@@ -235,6 +235,50 @@ describe("computeAttributes", () => {
     expect(result2.infusions.Power).toBe(10);  // 2 infusions × 5 Power (not 3!)
   });
 
+  test("offhand infusion not counted when mainhand has two-handed weapon (issue #226)", () => {
+    const catalogs = makeCatalogs({
+      infusionById: new Map([[49431, { name: "+5 Power", infixUpgrade: { attributes: [{ attribute: "Power", modifier: 5 }] } }]]),
+    });
+    // mainhand1 = greatsword (2H), offhand1 weapon is empty (locked) but has leftover infusion
+    const ctx = makeCtx({
+      activeWeaponSet: 1,
+      equipment: {
+        slots: {},
+        weapons: { mainhand1: "greatsword" },
+        runes: {},
+        infusions: {
+          mainhand1: [49431, 49431],
+          offhand1: [49431],  // ghost infusion from previous 1H+offhand setup
+        },
+      },
+    });
+    const result = computeAttributes(ctx, catalogs);
+    // Should count only 2 infusions (greatsword mainhand1), not 3 (+ ghost offhand)
+    expect(result.infusions.Power).toBe(10);
+  });
+
+  test("offhand infusion counted normally when mainhand is one-handed (issue #226)", () => {
+    const catalogs = makeCatalogs({
+      infusionById: new Map([[49431, { name: "+5 Power", infixUpgrade: { attributes: [{ attribute: "Power", modifier: 5 }] } }]]),
+    });
+    // mainhand1 = axe (1H), offhand1 = axe (1H), both with infusions
+    const ctx = makeCtx({
+      activeWeaponSet: 1,
+      equipment: {
+        slots: {},
+        weapons: { mainhand1: "axe", offhand1: "axe" },
+        runes: {},
+        infusions: {
+          mainhand1: [49431, ""],
+          offhand1: [49431],
+        },
+      },
+    });
+    const result = computeAttributes(ctx, catalogs);
+    // Both mainhand and offhand infusions should count
+    expect(result.infusions.Power).toBe(10);
+  });
+
   test("assumed Might boons add Power and ConditionDamage", () => {
     const ctx = makeCtx({ assumedBoons: { might: 25 } });
     const result = computeAttributes(ctx, makeCatalogs());

--- a/src/renderer/modules/editor.js
+++ b/src/renderer/modules/editor.js
@@ -3,7 +3,7 @@
 import { state, createEmptyEditor } from "./state.js";
 import { parseTags, simplifyTrait, simplifySkill } from "./utils.js";
 import { getMajorTraitsByTier } from "./specializations.js";
-import { ANTIQUARY_PROLIFIC_PLUNDERER_TRAIT_ID, UNDERWATER_BLOCKED_LEGENDS } from "./constants.js";
+import { ANTIQUARY_PROLIFIC_PLUNDERER_TRAIT_ID, UNDERWATER_BLOCKED_LEGENDS, GW2_WEAPONS_BY_ID } from "./constants.js";
 
 // Normalize sigil array to correct shape for a given slot key.
 export function normalizeSigilArray(value, slotKey) {
@@ -308,6 +308,18 @@ export function enforceEditorConsistency(options = {}) {
         }
         if (equip.infusions?.[key] !== undefined) equip.infusions[key] = "";
       }
+    }
+
+    // Clear offhand infusions/sigils when the corresponding mainhand has a two-handed
+    // weapon equipped (offhand slot is locked — ghost upgrades contribute phantom stats).
+    for (const [mainKey, ofKey] of [["mainhand1", "offhand1"], ["mainhand2", "offhand2"]]) {
+      const mainWeapon = equip.weapons?.[mainKey] || "";
+      if (!mainWeapon) continue;
+      const isTwoHand = (profWeapons[mainWeapon]?.flags || []).includes("TwoHand")
+        || GW2_WEAPONS_BY_ID.get(mainWeapon)?.hand === "two";
+      if (!isTwoHand) continue;
+      if (equip.sigils?.[ofKey]?.some(Boolean)) equip.sigils[ofKey] = [""];
+      if (equip.infusions?.[ofKey]?.some?.(Boolean)) equip.infusions[ofKey] = [""];
     }
   }
 }

--- a/src/renderer/modules/equipment.js
+++ b/src/renderer/modules/equipment.js
@@ -613,6 +613,9 @@ export function renderEquipmentPanel() {
                 const ofKey = slotDef.key.replace("mainhand", "offhand");
                 equip.weapons[ofKey] = "";
                 equip.slots[ofKey] = "";
+                // Also clear offhand upgrades — locked offhand must not contribute ghost stats
+                if (equip.sigils?.[ofKey]) equip.sigils[ofKey] = [""];
+                if (Array.isArray(equip.infusions?.[ofKey])) equip.infusions[ofKey] = [""];
               }
               // Clear second sigil/infusion on the mainhand when swapping to one-handed
               if (!newFlags.includes("TwoHand") && equip.sigils?.[slotDef.key]) {

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -193,6 +193,11 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
       .filter(([k]) => !EXCLUDED_SLOTS.has(k))
       .flatMap(([slotKey, v]) => {
         const ids = Array.isArray(v) ? v : [v];
+        // Skip offhand infusions when the corresponding mainhand has a two-handed weapon
+        if (slotKey.startsWith("offhand") && !slotKey.startsWith("aquatic")) {
+          const mainhandKey = slotKey.replace("offhand", "mainhand");
+          if (TWO_HAND_TYPES.has(weapons[mainhandKey] || "")) return [];
+        }
         if (slotKey.startsWith("mainhand") && !slotKey.startsWith("aquatic")) {
           const weaponType = weapons[slotKey] || "";
           if (weaponType && !TWO_HAND_TYPES.has(weaponType)) return ids.slice(0, 1);

--- a/tests/unit/renderer/save-weapons.test.js
+++ b/tests/unit/renderer/save-weapons.test.js
@@ -197,3 +197,51 @@ describe("save round-trip — weapons survive", () => {
     expect(state.editor.equipment.weapons.mainhand2).toBe("axe");
   });
 });
+
+describe("enforceEditorConsistency — offhand infusion cleared when mainhand is two-handed (issue #226)", () => {
+  test("clears offhand1 infusion when mainhand1 has a TwoHand weapon", () => {
+    state.activeCatalog = makeWarriorCatalog();
+    state.editor.equipment.weapons.mainhand1 = "greatsword";
+    state.editor.equipment.weapons.offhand1 = ""; // locked by TwoHand
+    state.editor.equipment.infusions.mainhand1 = ["", ""];
+    state.editor.equipment.infusions.offhand1 = ["49431"]; // ghost infusion
+
+    enforceEditorConsistency();
+
+    expect(state.editor.equipment.infusions.offhand1).toEqual([""]);
+  });
+
+  test("clears offhand2 infusion when mainhand2 has a TwoHand weapon", () => {
+    state.activeCatalog = makeWarriorCatalog();
+    state.editor.equipment.weapons.mainhand2 = "hammer";
+    state.editor.equipment.weapons.offhand2 = ""; // locked by TwoHand
+    state.editor.equipment.infusions.mainhand2 = ["", ""];
+    state.editor.equipment.infusions.offhand2 = ["49431"]; // ghost infusion
+
+    enforceEditorConsistency();
+
+    expect(state.editor.equipment.infusions.offhand2).toEqual([""]);
+  });
+
+  test("preserves offhand1 infusion when mainhand1 is one-handed", () => {
+    state.activeCatalog = makeWarriorCatalog();
+    state.editor.equipment.weapons.mainhand1 = "sword";
+    state.editor.equipment.weapons.offhand1 = "axe";
+    state.editor.equipment.infusions.offhand1 = ["49431"];
+
+    enforceEditorConsistency();
+
+    expect(state.editor.equipment.infusions.offhand1).toEqual(["49431"]);
+  });
+
+  test("clears offhand sigil when mainhand has a TwoHand weapon", () => {
+    state.activeCatalog = makeWarriorCatalog();
+    state.editor.equipment.weapons.mainhand1 = "greatsword";
+    state.editor.equipment.weapons.offhand1 = "";
+    state.editor.equipment.sigils.offhand1 = ["12345"]; // ghost sigil
+
+    enforceEditorConsistency();
+
+    expect(state.editor.equipment.sigils.offhand1).toEqual([""]);
+  });
+});


### PR DESCRIPTION
## Summary

When a two-handed weapon is equipped in a mainhand slot, the offhand weapon/slots are cleared, but the offhand's infusion and sigil values were silently retained. These ghost values then contributed phantom stats through the engine — effectively counting an extra infusion that shouldn't exist. This manifested as inflated stats when using two-handed weapons in either weapon set.

The fix is applied at three layers:
- **Engine (`attributes.js`)**: Skip offhand infusion stats when the corresponding mainhand has a two-handed weapon, preventing phantom stat contributions from stale data
- **`enforceEditorConsistency`**: Clear offhand infusion/sigil when the mainhand is two-handed, cleaning up stale data when builds are loaded
- **Equipment picker handler**: Immediately clear offhand infusion/sigil when a two-handed weapon is selected, preventing ghost data from being stored in the first place

Closes #226