### PR TITLE
fix: utility conversion % math slightly off (closes #227)

### DIFF
--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -219,15 +219,17 @@ function computePublishStats(equipment, upgradeCatalog, profession, gameMode) {
     const utilDef = upgradeCatalog.utilityById?.get(Number(equipment.utility));
     if (utilDef) {
       const UTIL_MAP = { "Power": "Power", "Precision": "Precision", "Toughness": "Toughness", "Vitality": "Vitality", "Ferocity": "Ferocity", "Concentration": "Concentration", "Expertise": "Expertise", "Condition Damage": "ConditionDamage", "Healing Power": "HealingPower" };
-      // Pattern 1: conversion
+      // Pattern 1: conversion — snapshot source values so multiple conversions in the
+      // same buff don't cross-contaminate (e.g. A→B and B→A would inflate results).
+      const convBase = { ...totals };
       const convRe = /Gain (Condition Damage|Healing Power|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise) Equal to (\d+(?:\.\d+)?)% of Your (Condition Damage|Healing Power|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise)/g;
       let m;
       while ((m = convRe.exec(utilDef.buff)) !== null) {
         const targetKey = UTIL_MAP[m[1]];
         const pct = Number(m[2]) / 100;
         const sourceKey = UTIL_MAP[m[3]];
-        if (targetKey && sourceKey && totals[sourceKey] !== undefined) {
-          totals[targetKey] = (totals[targetKey] || 0) + Math.round(totals[sourceKey] * pct);
+        if (targetKey && sourceKey && convBase[sourceKey] !== undefined) {
+          totals[targetKey] = (totals[targetKey] || 0) + Math.round(convBase[sourceKey] * pct);
         }
       }
       // Pattern 2: conditional flat (writs)

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -259,8 +259,17 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
     const utilDef = upgradeCatalog.utilityById?.get(Number(utilityId));
     if (utilDef) {
       const MAP = { "Condition Damage": "ConditionDamage", "Healing Power": "HealingPower" };
-      // Percentage conversions — use engine totals for source stats
-      const totals = computeStats(state, assumedBoons, sigilStacks, activeSignets).total;
+      // Percentage conversions — use pre-utility base stats to match the engine's
+      // preConvBase (base + equipment + food + runes + infusions + enrichment + signets).
+      // Using the full total inflates results because it includes the utility's own flat
+      // bonuses, trait conversions, and boon contributions.
+      const _er = computeStats(state, assumedBoons, sigilStacks, activeSignets);
+      const _STAT_KEYS = ["Power", "Precision", "Toughness", "Vitality", "Ferocity", "ConditionDamage", "Expertise", "Concentration", "HealingPower"];
+      const preUtilBase = {};
+      for (const _k of _STAT_KEYS) {
+        preUtilBase[_k] = (_er.base[_k] || 0) + (_er.equipment[_k] || 0) + (_er.food[_k] || 0) +
+          (_er.runes[_k] || 0) + (_er.infusions[_k] || 0) + (_er.enrichment[_k] || 0) + (_er.signets[_k] || 0);
+      }
       const convRe = /Gain (Condition Damage|Healing Power|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise) Equal to (\d+(?:\.\d+)?)% of Your (Condition Damage|Healing Power|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise)/g;
       let m;
       while ((m = convRe.exec(utilDef.buff)) !== null) {
@@ -268,7 +277,7 @@ export function computeStatBreakdown(statKey, assumedBoons = null, sigilStacks =
         if (targetKey !== statKey) continue;
         const pct = Number(m[2]) / 100;
         const sourceKey = MAP[m[3]] || m[3];
-        const sourceBase = (totals[sourceKey] || 0);
+        const sourceBase = (preUtilBase[sourceKey] || 0);
         const val = Math.round(sourceBase * pct);
         if (val) entries.push({ source: `${utilDef.name} (${m[2]}% of ${m[3]})`, value: val, category: "utility" });
       }

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -859,6 +859,75 @@ describe("computeEquipmentStats — signet passive buffs", () => {
 });
 
 // ---------------------------------------------------------------------------
+// computeStatBreakdown — utility conversion breakdown (issue #227)
+// ---------------------------------------------------------------------------
+
+describe("computeStatBreakdown — utility conversion uses pre-utility base (issue #227)", () => {
+  const mockCatalogConv = {
+    skillById: new Map(),
+    traitById: new Map(),
+    specializationById: new Map(),
+  };
+
+  beforeEach(() => {
+    state.activeCatalog = mockCatalogConv;
+    state.upgradeCatalog = {
+      foodById: new Map(),
+      utilityById: new Map([
+        // Utility with a flat Ferocity bonus AND a conversion from Ferocity to Power.
+        // The conversion must only use pre-utility Ferocity, NOT the flat bonus.
+        [99001, { id: 99001, name: "Test Conversion Oil",
+          buff: "Gain Power Equal to 10% of Your Ferocity | +200 Ferocity" }],
+        // Standard dual-conversion: Gain Power from Precision + Ferocity (no flat bonuses)
+        [99002, { id: 99002, name: "Test Sharpening Stone",
+          buff: "Gain Power Equal to 3% of Your Precision | Gain Power Equal to 6% of Your Ferocity" }],
+      ]),
+      runeById: new Map(),
+      infusionById: new Map(),
+      enrichmentById: new Map(),
+    };
+  });
+  afterEach(() => {
+    state.activeCatalog = null;
+    state.upgradeCatalog = null;
+  });
+
+  test("conversion uses pre-utility Ferocity, not inflated total including utility flat bonus", () => {
+    // Equipment Ferocity = 0 (no gear). Utility adds flat +200 Ferocity.
+    // Engine uses preConvBase.Ferocity = 0 for the conversion → Power += 0.
+    // Buggy code would use total.Ferocity = 200 → Power += 20.
+    state.editor = makeEditor({}, "", "99001");
+    const entries = computeStatBreakdown("Power");
+    const convEntry = entries.find((e) => e.source && e.source.includes("10% of Ferocity"));
+    // No conversion entry should appear (0 * 10% = 0 → filtered out)
+    expect(convEntry).toBeUndefined();
+  });
+
+  test("conversion uses equipment Ferocity correctly when no utility flat bonus", () => {
+    // Berserker's chest: Ferocity = 101. Utility converts 6% of Ferocity to Power.
+    // Correct: Power += round(101 * 0.06) = 6
+    state.editor = makeEditor({ chest: "Berserker's" }, "", "99002");
+    const entries = computeStatBreakdown("Power");
+    const convEntry = entries.find((e) => e.source && e.source.includes("6% of Ferocity"));
+    expect(convEntry).toBeDefined();
+    expect(convEntry.value).toBe(6); // round(101 * 0.06) = 6
+  });
+
+  test("conversion value matches engine total Power contribution", () => {
+    // With Berserker's chest, Precision = 1101, Ferocity = 101.
+    // Utility: +3% of Precision = round(1101 * 0.03) = 33, +6% of Ferocity = round(101 * 0.06) = 6.
+    // Engine total Power = 1000 + 141 (chest) + 33 + 6 = 1180.
+    // Breakdown Power entries must sum to 1180.
+    state.editor = makeEditor({ chest: "Berserker's" }, "", "99002");
+    const entries = computeStatBreakdown("Power");
+    const total = entries.reduce((s, e) => s + e.value, 0);
+    const { computeStats: getStats } = require("../../../src/renderer/modules/engine-bridge");
+    const engineTotal = getStats(state).total.Power;
+    expect(total).toBe(engineTotal);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // computeStatBreakdown — signet passive buff contributions (issue #174)
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/statsCompute.test.js
+++ b/tests/unit/statsCompute.test.js
@@ -392,6 +392,49 @@ describe("computePublishStats", () => {
     expect(result.stats.Power).toBe(1000 + 5);
   });
 
+  // ── Utility conversion (issue #227) ────────────────────────────────────
+
+  test("utility conversion uses pre-utility base stats, not inflated mutated totals", () => {
+    // Utility adds +200 Ferocity flat AND converts 10% of Ferocity to Power.
+    // The conversion must use pre-utility Ferocity (0), not post-flat Ferocity (200).
+    const equipment = { slots: {}, runes: {}, infusions: {}, food: null, utility: "99001" };
+    const upgradeCatalog = {
+      runeById: new Map(), infusionById: new Map(), enrichmentById: new Map(),
+      foodById: new Map(),
+      utilityById: new Map([
+        [99001, { id: 99001, name: "Test Oil",
+          buff: "Gain Power Equal to 10% of Your Ferocity | +200 Ferocity" }],
+      ]),
+    };
+    const result = computePublishStats(equipment, upgradeCatalog, "Warrior");
+    // Engine preConvBase.Ferocity = 0 → Power += round(0 * 0.10) = 0
+    // Flat Ferocity = 200 added AFTER conversion pattern is processed
+    expect(result.stats.Power).toBe(1000);
+    expect(result.stats.Ferocity).toBe(200);
+  });
+
+  test("utility dual-conversion does not cross-contaminate when targets differ", () => {
+    // "Gain Power = 3% of Precision | Gain Ferocity = 3% of Precision"
+    // Both use Precision as source; modifying Power shouldn't affect Ferocity calc.
+    const equipment = {
+      slots: { chest: "Berserker's" }, runes: {}, infusions: {},
+      food: null, utility: "99002",
+    };
+    const upgradeCatalog = {
+      runeById: new Map(), infusionById: new Map(), enrichmentById: new Map(),
+      foodById: new Map(),
+      utilityById: new Map([
+        [99002, { id: 99002, name: "Furious Sharpening Stone",
+          buff: "Gain Power Equal to 3% of Your Precision | Gain Ferocity Equal to 3% of Your Precision" }],
+      ]),
+    };
+    const result = computePublishStats(equipment, upgradeCatalog, "Warrior");
+    // Berserker's chest: Power=141, Precision=101, Ferocity=101. Base Precision = 1000+101=1101.
+    // Power += round(1101 * 0.03) = 33; Ferocity += round(1101 * 0.03) = 33
+    expect(result.stats.Power).toBe(1000 + 141 + 33);
+    expect(result.stats.Ferocity).toBe(101 + 33);
+  });
+
   test("food with 'to All Attributes' adds to every stat", () => {
     const equipment = { slots: {}, runes: {}, infusions: {}, food: "91713", utility: "" };
     const upgradeCatalog = {


### PR DESCRIPTION
## Summary

The stat breakdown tooltip in the Attributes panel was showing inflated Power and Ferocity values from utility consumable conversions (e.g. Sharpening Stones). The root cause was that `computeStatBreakdown` used the full engine total as the source for conversion math, while the engine itself correctly uses a pre-utility base (before utility flat bonuses, trait conversions, and boon contributions are applied).

- **`stats.js`**: Replace `computeStats().total` with a reconstructed pre-utility base (`base + equipment + food + runes + infusions + enrichment + signets`) — matching the engine's internal `preConvBase` — when computing conversion contributions for the breakdown tooltip.
- **`statsCompute.js`** (publish stats): Snapshot conversion source values before the loop so that multiple conversions in the same buff cannot cross-contaminate each other.

Closes #227