### PR TITLE
fix: Great Fortitude Strength trait conversion % math slightly off (closes #228)

### DIFF
--- a/packages/gw2-data/src/engine/attributes.js
+++ b/packages/gw2-data/src/engine/attributes.js
@@ -408,11 +408,10 @@ function computeAttributes(ctx, catalogs) {
   }
 
   // -------------------------------------------------------------------------
-  // Step 9: Pre-conversion totals (base + equipment + food + runes + infusions + enrichment + signets)
-  // (Utility is added after — but wait for its conversion to use pre-conv totals)
-  // Note: We compute pre-conv totals without utility first, then add utility (non-conversion parts)
-  // Actually per spec: utility conversion uses preConvTotal. We'll compute pre-conv WITHOUT utility,
-  // parse utility conversions using that, then add utility flat/writ parts separately.
+  // Step 9: Pre-conversion base (base + equipment + food + runes + infusions + enrichment + signets)
+  // Both utility conversions and trait conversions use this snapshot as their source so that
+  // neither can feed into the other (utility-converted stats don't inflate trait conversions
+  // and vice versa). Matches the fix for issue #227 (utility) extended to issue #228 (traits).
   // -------------------------------------------------------------------------
   const preConvBase = zeroStats();
   for (const key of ALL_STAT_KEYS) {
@@ -420,7 +419,7 @@ function computeAttributes(ctx, catalogs) {
       runeStats[key] + infusionStats[key] + enrichmentStats[key] + signetStats[key];
   }
 
-  // Parse utility buff using preConvBase as the "preConvTotal" for conversion
+  // Parse utility buff using preConvBase as the source for % conversions
   const utilityStats = zeroStats();
   if (equipment.utility && catalogs.utilityById) {
     const utility = catalogs.utilityById.get(equipment.utility);
@@ -428,12 +427,6 @@ function computeAttributes(ctx, catalogs) {
       const parsed = parseUtilityBuff(utility.buff, preConvBase);
       for (const key of ALL_STAT_KEYS) utilityStats[key] += parsed[key];
     }
-  }
-
-  // Recompute pre-conv totals including utility (for trait conversions)
-  const preConvTotal = zeroStats();
-  for (const key of ALL_STAT_KEYS) {
-    preConvTotal[key] = preConvBase[key] + utilityStats[key];
   }
 
   // -------------------------------------------------------------------------
@@ -468,11 +461,13 @@ function computeAttributes(ctx, catalogs) {
 
   // -------------------------------------------------------------------------
   // Step 11: Conversions — trait conversion modifiers
+  // Source is preConvBase (same snapshot used for utility conversions, issue #228):
+  // excludes utility stats so utility-derived bonuses don't inflate trait conversions.
   // -------------------------------------------------------------------------
   const conversionStats = zeroStats();
   for (const mod of modifiers) {
     if (mod.type !== "conversion") continue;
-    const sourceVal = preConvTotal[mod.sourceAttr] || 0;
+    const sourceVal = preConvBase[mod.sourceAttr] || 0;
     const bonus = Math.floor(sourceVal * mod.percent / 100);
     if (mod.target in conversionStats) {
       conversionStats[mod.target] += bonus;

--- a/packages/gw2-data/tests/engine/attributes.test.js
+++ b/packages/gw2-data/tests/engine/attributes.test.js
@@ -324,6 +324,76 @@ describe("computeAttributes", () => {
     expect(result.total.Power).toBe(1100);
   });
 
+  test("trait conversion does not include utility stats in source (issue #228)", () => {
+    // Utility adds +100 Power flat. Trait converts 10% Power → Vitality.
+    // The conversion source must be preConvBase (base+gear, no utility), not preConvTotal.
+    // If utility Power were included: floor(1100 * 0.10) = 110 (too much).
+    // Correct: floor(1000 * 0.10) = 100.
+    const catalogs = makeCatalogs({
+      traitById: new Map([[1449, {
+        id: 1449,
+        facts: [{ type: "BuffConversion", source: "Power", target: "Vitality", percent: 10 }],
+      }]]),
+      specializationById: new Map([[4, { id: 4, minorTraits: [] }]]),
+      utilityById: new Map([[99001, { id: 99001, buff: "+100 Power" }]]),
+    });
+    const ctx = makeCtx({
+      specializations: [{ id: 4, majorChoices: { 1: 1449 } }],
+      equipment: {
+        slots: {},
+        weapons: {},
+        runes: {},
+        infusions: {},
+        enrichment: null,
+        food: null,
+        utility: 99001,
+      },
+    });
+    const result = computeAttributes(ctx, catalogs);
+    // preConvBase.Power = 1000 (base only, utility excluded from trait conversion source)
+    expect(result.conversions.Vitality).toBe(100);
+    // Total Vitality = 1000 (base) + 100 (conversion) = 1100
+    expect(result.total.Vitality).toBe(1100);
+    // Utility Power is still present in the total (just excluded from conversion source)
+    expect(result.utility.Power).toBe(100);
+    expect(result.total.Power).toBe(1100); // 1000 base + 100 utility
+  });
+
+  test("Great Fortitude: dual conversion (Power→Vitality and Power→Ferocity) uses preConvBase (issue #228)", () => {
+    // Simulates Great Fortitude trait (id 1449) with a utility that adds Power.
+    // Both conversions must use preConvBase.Power (without utility's +100 Power).
+    const catalogs = makeCatalogs({
+      traitById: new Map([[1449, {
+        id: 1449,
+        facts: [
+          { type: "BuffConversion", source: "Power", target: "Vitality", percent: 10 },
+          { type: "BuffConversion", source: "Power", target: "CritDamage", percent: 10 },
+        ],
+      }]]),
+      specializationById: new Map([[4, { id: 4, minorTraits: [] }]]),
+      utilityById: new Map([[99001, { id: 99001, buff: "+100 Power" }]]),
+    });
+    const ctx = makeCtx({
+      specializations: [{ id: 4, majorChoices: { 1: 1449 } }],
+      equipment: {
+        slots: { chest: "Berserker's" },
+        weapons: {},
+        runes: {},
+        infusions: {},
+        enrichment: null,
+        food: null,
+        utility: 99001,
+      },
+    });
+    const result = computeAttributes(ctx, catalogs);
+    // preConvBase.Power = 1000 (base) + 141 (Berserker's chest) = 1141
+    // Utility adds +100 Power (NOT included in conversion source)
+    // Vitality from conversion: floor(1141 * 0.10) = 114
+    // Ferocity from conversion: floor(1141 * 0.10) = 114
+    expect(result.conversions.Vitality).toBe(114);
+    expect(result.conversions.Ferocity).toBe(114);
+  });
+
   test("berserk-conditional trait bonuses only apply when berserkActive", () => {
     const catalogs = makeCatalogs({
       traitById: new Map([[2046, {

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -1037,3 +1037,105 @@ describe("computeStatBreakdown — signet passive buffs", () => {
     expect(mightEntry.value).toBe(300);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Trait conversion uses preConvBase (issue #228)
+// ---------------------------------------------------------------------------
+
+describe("computeStatBreakdown — Great Fortitude trait conversion uses preConvBase (issue #228)", () => {
+  const TRAIT_ID = 1449;
+
+  const mockCatalog = {
+    skillById: new Map(),
+    traitById: new Map([
+      [TRAIT_ID, {
+        id: TRAIT_ID,
+        name: "Great Fortitude",
+        slot: "Major",
+        facts: [
+          { type: "BuffConversion", source: "Power", target: "Vitality",   percent: 10 },
+          { type: "BuffConversion", source: "Power", target: "CritDamage", percent: 10 },
+        ],
+      }],
+    ]),
+    specializationById: new Map([
+      [4, { id: 4, minorTraits: [] }],
+    ]),
+  };
+
+  beforeEach(() => {
+    state.activeCatalog = mockCatalog;
+    state.upgradeCatalog = {
+      foodById: new Map(),
+      utilityById: new Map([
+        // Utility adds +100 Power flat.
+        // Trait conversion source should be preConvBase (no utility), not preConvTotal.
+        [99001, { id: 99001, name: "Power Oil", buff: "+100 Power" }],
+      ]),
+      runeById: new Map(),
+      infusionById: new Map(),
+      enrichmentById: new Map(),
+    };
+  });
+  afterEach(() => {
+    state.activeCatalog = null;
+    state.upgradeCatalog = null;
+  });
+
+  function makeEditorWithTrait(slots = {}, utilityId = "") {
+    return {
+      profession: "Warrior",
+      gameMode: "pve",
+      equipment: {
+        slots,
+        food: "",
+        utility: utilityId,
+        weapons: {},
+        runes: {},
+        infusions: {},
+      },
+      specializations: [{ specializationId: 4, majorChoices: { 2: TRAIT_ID } }],
+      skills: { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 },
+    };
+  }
+
+  test("trait conversion source is preConvBase — utility flat Power excluded (issue #228)", () => {
+    // Utility adds +100 Power flat.
+    // preConvBase.Power = 1000 (base only, no utility).
+    // Trait conversion (10% Power→Vitality) must use preConvBase → 100, not 110.
+    state.editor = makeEditorWithTrait({}, "99001");
+    const entries = computeStatBreakdown("Vitality");
+    const convEntry = entries.find((e) => e.category === "trait" && e.source === "Trait conversion");
+    expect(convEntry).toBeDefined();
+    // Correct: floor(1000 * 0.10) = 100 (preConvBase.Power)
+    // Bug: floor(1100 * 0.10) = 110 (preConvTotal includes utility +100)
+    expect(convEntry.value).toBe(100);
+  });
+
+  test("trait conversion source is preConvBase — utility flat Power excluded for Ferocity (issue #228)", () => {
+    // Same utility +100 Power. Ferocity conversion also uses preConvBase.Power.
+    state.editor = makeEditorWithTrait({}, "99001");
+    const entries = computeStatBreakdown("Ferocity");
+    const convEntry = entries.find((e) => e.category === "trait" && e.source === "Trait conversion");
+    expect(convEntry).toBeDefined();
+    expect(convEntry.value).toBe(100);
+  });
+
+  test("trait conversion total matches engine — preConvBase used consistently (issue #228)", () => {
+    // With Berserker's chest (+141 Power) and utility +100 Power:
+    // preConvBase.Power = 1000 + 141 = 1141
+    // Vitality conversion = floor(1141 * 0.10) = 114
+    // Ferocity conversion = floor(1141 * 0.10) = 114
+    // Engine total Vitality = 1000 (base) + 114 (conversion) = 1114
+    state.editor = makeEditorWithTrait({ chest: "Berserker's" }, "99001");
+    const vitalityEntries = computeStatBreakdown("Vitality");
+    const vConv = vitalityEntries.find((e) => e.category === "trait" && e.source === "Trait conversion");
+    expect(vConv).toBeDefined();
+    expect(vConv.value).toBe(114);
+
+    const ferocityEntries = computeStatBreakdown("Ferocity");
+    const fConv = ferocityEntries.find((e) => e.category === "trait" && e.source === "Trait conversion");
+    expect(fConv).toBeDefined();
+    expect(fConv.value).toBe(114);
+  });
+});


### PR DESCRIPTION
## Summary

Trait `BuffConversion` modifiers (e.g. Great Fortitude's Power → Vitality and Power → Ferocity at 10%) were computing the source stat value from `preConvTotal`, which includes utility item stats. This caused the conversion to include utility-granted Power in the base, inflating the result. For example, with a base of 1000 Power and +100 Power from a utility item, the conversion yielded `floor(1100 × 10%) = 110` instead of the correct `floor(1000 × 10%) = 100`.

The fix mirrors the same principle applied in #227 for utility conversions: trait conversions now use the `preConvBase` snapshot (base + equipment + food + runes + infusions + enrichment + signets, excluding utility). The unused `preConvTotal` intermediate object was removed.

Closes #228