### PR TITLE
fix: Blood Reaction Berserker Trait Conversion % math slightly off (closes #229)

### DIFF
--- a/src/main/gw2Data/overrides.js
+++ b/src/main/gw2Data/overrides.js
@@ -58,6 +58,17 @@ const KNOWN_SKILL_FACTS_OVERRIDES = new Map([
 // Fact list patches for traits the GW2 API returns with incorrect values.
 // Same pattern as KNOWN_SKILL_FACTS_OVERRIDES but keyed by trait ID.
 const KNOWN_TRAIT_FACTS_OVERRIDES = new Map([
+  // Blood Reaction (trait 2011, Berserker spec 18) — GW2 API returns 5 stale BuffConversion
+  // facts [12%, 10%, 5%] for Precision→Ferocity and [10%, 15%] for Power→ConditionDamage.
+  // Correct PvE values (per wiki): 7% Precision→Ferocity, 10% Power→ConditionDamage.
+  // Correct WvW values: 5% Precision→Ferocity, 10% Power→ConditionDamage.
+  // Convention: first fact = PvE (idx 0), second = WvW (idx 1) for dedup in modifiers.js.
+  // Wiki: https://wiki.guildwars2.com/wiki/Blood_Reaction
+  [2011, [
+    { type: "BuffConversion", text: "Attribute Conversion", icon: `${_IC}/0658D833944E69E62E08EB18A0B5407F722125BC/2229320.png`, percent: 7,  source: "Precision", target: "CritDamage"      },
+    { type: "BuffConversion", text: "Attribute Conversion", icon: `${_IC}/0658D833944E69E62E08EB18A0B5407F722125BC/2229320.png`, percent: 5,  source: "Precision", target: "CritDamage"      },
+    { type: "BuffConversion", text: "Attribute Conversion", icon: `${_IC}/0658D833944E69E62E08EB18A0B5407F722125BC/2229320.png`, percent: 10, source: "Power",     target: "ConditionDamage" },
+  ]],
   // Versatile Rage (trait 1415, Discipline spec 51) — GW2 API returns Recharge: 4s,
   // but in-game the skill has a 5s recharge. Wiki: https://wiki.guildwars2.com/wiki/Versatile_Rage
   [1415, [

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -1241,4 +1241,76 @@ describe("Blood Reaction Berserker trait conversion % (issue #229)", () => {
     state.activeCatalog = null;
     state.upgradeCatalog = null;
   });
+
+  function makeBloodReactionCatalog() {
+    return {
+      traitById: new Map([
+        [BLOOD_REACTION_ID, {
+          id: BLOOD_REACTION_ID,
+          name: "Blood Reaction",
+          slot: "Major",
+          facts: [
+            { type: "BuffConversion", source: "Precision", target: "CritDamage",      percent: 7  },
+            { type: "BuffConversion", source: "Precision", target: "CritDamage",      percent: 5  },
+            { type: "BuffConversion", source: "Power",     target: "ConditionDamage",  percent: 10 },
+          ],
+        }],
+      ]),
+      specializationById: new Map([[BERSERKER_SPEC_ID, { id: BERSERKER_SPEC_ID, minorTraits: [] }]]),
+    };
+  }
+
+  function makeBloodReactionEditor(gameMode = "pve") {
+    return {
+      profession: "Warrior",
+      gameMode,
+      equipment: { slots: {}, food: "", utility: "", weapons: {}, runes: {}, infusions: {} },
+      specializations: [{ specializationId: BERSERKER_SPEC_ID, majorChoices: { 1: BLOOD_REACTION_ID } }],
+      skills: { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 },
+    };
+  }
+
+  const emptyUpgrades = {
+    foodById: new Map(), utilityById: new Map(),
+    runeById: new Map(), infusionById: new Map(), enrichmentById: new Map(),
+  };
+
+  test("Blood Reaction WvW picks 5% Precision→Ferocity (idx=1)", () => {
+    state.activeCatalog = makeBloodReactionCatalog();
+    state.upgradeCatalog = emptyUpgrades;
+    state.editor = makeBloodReactionEditor("wvw");
+    // WvW dedup picks idx=1 from [7%, 5%] = 5%. Precision base = 1000. floor(1000 * 0.05) = 50.
+    const entries = computeStatBreakdown("Ferocity");
+    const convEntry = entries.find((e) => e.category === "trait" && e.source === "Trait conversion");
+    expect(convEntry).toBeDefined();
+    expect(convEntry.value).toBe(50);
+    state.activeCatalog = null;
+    state.upgradeCatalog = null;
+  });
+
+  test("Blood Reaction PvE produces 10% Power→ConditionDamage conversion", () => {
+    state.activeCatalog = makeBloodReactionCatalog();
+    state.upgradeCatalog = emptyUpgrades;
+    state.editor = makeBloodReactionEditor("pve");
+    // Power base = 1000. 10% of 1000 = 100 ConditionDamage from conversion.
+    const entries = computeStatBreakdown("ConditionDamage");
+    const convEntry = entries.find((e) => e.category === "trait" && e.source === "Trait conversion");
+    expect(convEntry).toBeDefined();
+    expect(convEntry.value).toBe(100);
+    state.activeCatalog = null;
+    state.upgradeCatalog = null;
+  });
+
+  test("Blood Reaction WvW also produces 10% Power→ConditionDamage conversion", () => {
+    state.activeCatalog = makeBloodReactionCatalog();
+    state.upgradeCatalog = emptyUpgrades;
+    state.editor = makeBloodReactionEditor("wvw");
+    // Only one Power→ConditionDamage fact, so WvW clamps to idx=0 = 10%. floor(1000 * 0.10) = 100.
+    const entries = computeStatBreakdown("ConditionDamage");
+    const convEntry = entries.find((e) => e.category === "trait" && e.source === "Trait conversion");
+    expect(convEntry).toBeDefined();
+    expect(convEntry.value).toBe(100);
+    state.activeCatalog = null;
+    state.upgradeCatalog = null;
+  });
 });

--- a/tests/unit/renderer/stats.test.js
+++ b/tests/unit/renderer/stats.test.js
@@ -1139,3 +1139,106 @@ describe("computeStatBreakdown — Great Fortitude trait conversion uses preConv
     expect(fConv.value).toBe(114);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Blood Reaction (trait 2011) — issue #229
+// The GW2 API returns incorrect facts for Blood Reaction: [12%, 10%, 5%] for
+// Precision→Ferocity and [10%, 15%] for Power→ConditionDamage. The correct
+// PvE values are 7% and 10%. KNOWN_TRAIT_FACTS_OVERRIDES must patch them.
+// ---------------------------------------------------------------------------
+describe("Blood Reaction Berserker trait conversion % (issue #229)", () => {
+  const BLOOD_REACTION_ID = 2011;
+  const BERSERKER_SPEC_ID = 18;
+
+  test("KNOWN_TRAIT_FACTS_OVERRIDES has correct Blood Reaction facts", () => {
+    const { KNOWN_TRAIT_FACTS_OVERRIDES } = require("../../../src/main/gw2Data/overrides");
+    const facts = KNOWN_TRAIT_FACTS_OVERRIDES.get(BLOOD_REACTION_ID);
+    expect(facts).toBeDefined();
+    const precFacts = facts.filter((f) => f.source === "Precision" && f.target === "CritDamage");
+    expect(precFacts).toHaveLength(2);
+    expect(precFacts[0].percent).toBe(7);  // PvE
+    expect(precFacts[1].percent).toBe(5);  // WvW
+    const powerFacts = facts.filter((f) => f.source === "Power" && f.target === "ConditionDamage");
+    expect(powerFacts).toHaveLength(1);
+    expect(powerFacts[0].percent).toBe(10);
+  });
+
+  test("Blood Reaction correct facts produce 7% Precision→Ferocity conversion (issue #229)", () => {
+    const mockCatalog = {
+      traitById: new Map([
+        [BLOOD_REACTION_ID, {
+          id: BLOOD_REACTION_ID,
+          name: "Blood Reaction",
+          slot: "Major",
+          facts: [
+            { type: "BuffConversion", source: "Precision", target: "CritDamage",     percent: 7  },
+            { type: "BuffConversion", source: "Precision", target: "CritDamage",     percent: 5  },
+            { type: "BuffConversion", source: "Power",     target: "ConditionDamage", percent: 10 },
+          ],
+        }],
+      ]),
+      specializationById: new Map([[BERSERKER_SPEC_ID, { id: BERSERKER_SPEC_ID, minorTraits: [] }]]),
+    };
+    state.activeCatalog = mockCatalog;
+    state.upgradeCatalog = {
+      foodById: new Map(), utilityById: new Map(),
+      runeById: new Map(), infusionById: new Map(), enrichmentById: new Map(),
+    };
+    state.editor = {
+      profession: "Warrior",
+      gameMode: "pve",
+      equipment: { slots: {}, food: "", utility: "", weapons: {}, runes: {}, infusions: {} },
+      specializations: [{ specializationId: BERSERKER_SPEC_ID, majorChoices: { 1: BLOOD_REACTION_ID } }],
+      skills: { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 },
+    };
+    // Precision base = 1000. 7% of 1000 = 70 Ferocity from conversion.
+    const entries = computeStatBreakdown("Ferocity");
+    const convEntry = entries.find((e) => e.category === "trait" && e.source === "Trait conversion");
+    expect(convEntry).toBeDefined();
+    // Bug: 12% of 1000 = 120. Correct: 7% of 1000 = 70.
+    expect(convEntry.value).toBe(70);
+
+    state.activeCatalog = null;
+    state.upgradeCatalog = null;
+  });
+
+  test("Blood Reaction bad API facts would produce too much Ferocity (demonstrates bug)", () => {
+    const mockCatalog = {
+      traitById: new Map([
+        [BLOOD_REACTION_ID, {
+          id: BLOOD_REACTION_ID,
+          name: "Blood Reaction",
+          slot: "Major",
+          facts: [
+            { type: "BuffConversion", source: "Precision", target: "CritDamage",     percent: 12 },
+            { type: "BuffConversion", source: "Precision", target: "CritDamage",     percent: 10 },
+            { type: "BuffConversion", source: "Precision", target: "CritDamage",     percent: 5  },
+            { type: "BuffConversion", source: "Power",     target: "ConditionDamage", percent: 10 },
+            { type: "BuffConversion", source: "Power",     target: "ConditionDamage", percent: 15 },
+          ],
+        }],
+      ]),
+      specializationById: new Map([[BERSERKER_SPEC_ID, { id: BERSERKER_SPEC_ID, minorTraits: [] }]]),
+    };
+    state.activeCatalog = mockCatalog;
+    state.upgradeCatalog = {
+      foodById: new Map(), utilityById: new Map(),
+      runeById: new Map(), infusionById: new Map(), enrichmentById: new Map(),
+    };
+    state.editor = {
+      profession: "Warrior",
+      gameMode: "pve",
+      equipment: { slots: {}, food: "", utility: "", weapons: {}, runes: {}, infusions: {} },
+      specializations: [{ specializationId: BERSERKER_SPEC_ID, majorChoices: { 1: BLOOD_REACTION_ID } }],
+      skills: { healId: 0, utilityIds: [0, 0, 0], eliteId: 0 },
+    };
+    // Bad API data: 12% of 1000 = 120 (too much; correct is 7% = 70)
+    const entries = computeStatBreakdown("Ferocity");
+    const convEntry = entries.find((e) => e.category === "trait" && e.source === "Trait conversion");
+    expect(convEntry).toBeDefined();
+    expect(convEntry.value).toBe(120);
+
+    state.activeCatalog = null;
+    state.upgradeCatalog = null;
+  });
+});


### PR DESCRIPTION
## Summary

The GW2 API returns stale/incorrect facts for Blood Reaction (trait 2011, Berserker spec): five `BuffConversion` facts with values `[12%, 10%, 5%]` for Precision→Ferocity and `[10%, 15%]` for Power→ConditionDamage. The modifiers engine picks `idx=0` for PvE, so it was using **12%** Precision→Ferocity instead of the correct **7%**. The fix adds trait 2011 to `KNOWN_TRAIT_FACTS_OVERRIDES` in `overrides.js` with the correct values (7%/5% PvE/WvW for Precision→Ferocity, 10% for Power→ConditionDamage), overriding the bad API data at the catalog layer.

Closes #229