### PR TITLE
fix: Subfolder keeps moving out of shared folder (closes #265)

### DIFF
--- a/src/main/folderStore.js
+++ b/src/main/folderStore.js
@@ -5,8 +5,18 @@ const fs = require("node:fs/promises");
 const crypto = require("node:crypto");
 
 class FolderStore {
+  #writeQueue = Promise.resolve();
+
   constructor(baseDir) {
     this.foldersPath = path.join(baseDir, "folders.json");
+  }
+
+  // Serialize all read-modify-write operations to prevent concurrent calls
+  // from racing on folders.json (last write wins without serialization).
+  #enqueue(fn) {
+    const next = this.#writeQueue.then(() => fn());
+    this.#writeQueue = next.catch(() => {});
+    return next;
   }
 
   async init() {
@@ -18,87 +28,93 @@ class FolderStore {
   }
 
   async upsertFolder(input) {
-    const folders = await this.listFolders();
-    const now = new Date().toISOString();
-    const name = String(input.name || "Untitled Folder").slice(0, 100);
-    const parentId =
-      typeof input.parentId === "string" ? input.parentId : null;
+    return this.#enqueue(async () => {
+      const folders = await this.listFolders();
+      const now = new Date().toISOString();
+      const name = String(input.name || "Untitled Folder").slice(0, 100);
+      const parentId =
+        typeof input.parentId === "string" ? input.parentId : null;
 
-    const shared = input.shared === true;
-    const orgName = typeof input.orgName === "string" ? input.orgName : undefined;
-    const lastSyncedAt = typeof input.lastSyncedAt === "string" ? input.lastSyncedAt : undefined;
+      const shared = input.shared === true;
+      const orgName = typeof input.orgName === "string" ? input.orgName : undefined;
+      const lastSyncedAt = typeof input.lastSyncedAt === "string" ? input.lastSyncedAt : undefined;
 
-    // Shared folders must be top-level
-    if (shared && parentId) {
-      throw new Error("Shared folders must be top-level");
-    }
-
-    // Depth check
-    if (parentId) {
-      const depth = this.#getDepth(folders, parentId);
-      if (depth >= 3) {
-        throw new Error(
-          "Maximum folder nesting depth (3) exceeded",
-        );
+      // Shared folders must be top-level
+      if (shared && parentId) {
+        throw new Error("Shared folders must be top-level");
       }
-    }
 
-    const existing = input.id
-      ? folders.find((f) => f.id === input.id)
-      : null;
-
-    if (existing) {
-      existing.name = name;
-      existing.parentId = parentId;
-      if (input.sortOrder !== undefined) {
-        existing.sortOrder = Number(input.sortOrder) || 0;
+      // Depth check
+      if (parentId) {
+        const depth = this.#getDepth(folders, parentId);
+        if (depth >= 3) {
+          throw new Error(
+            "Maximum folder nesting depth (3) exceeded",
+          );
+        }
       }
-      if (input.shared !== undefined) existing.shared = Boolean(input.shared);
-      if (input.orgName !== undefined) existing.orgName = input.orgName;
-      if (input.lastSyncedAt !== undefined) existing.lastSyncedAt = input.lastSyncedAt;
-      // Ensure updatedAt is strictly greater than the previous value
-      const prevUpdatedAt = existing.updatedAt;
-      existing.updatedAt =
-        now > prevUpdatedAt
-          ? now
-          : new Date(new Date(prevUpdatedAt).getTime() + 1).toISOString();
+
+      const existing = input.id
+        ? folders.find((f) => f.id === input.id)
+        : null;
+
+      if (existing) {
+        existing.name = name;
+        existing.parentId = parentId;
+        if (input.sortOrder !== undefined) {
+          existing.sortOrder = Number(input.sortOrder) || 0;
+        }
+        if (input.shared !== undefined) existing.shared = Boolean(input.shared);
+        if (input.orgName !== undefined) existing.orgName = input.orgName;
+        if (input.lastSyncedAt !== undefined) existing.lastSyncedAt = input.lastSyncedAt;
+        // Ensure updatedAt is strictly greater than the previous value
+        const prevUpdatedAt = existing.updatedAt;
+        existing.updatedAt =
+          now > prevUpdatedAt
+            ? now
+            : new Date(new Date(prevUpdatedAt).getTime() + 1).toISOString();
+        await this.#writeJson(this.foldersPath, folders);
+        return { ...existing };
+      }
+
+      const folder = {
+        id: input.id || crypto.randomUUID(),
+        name,
+        parentId,
+        sortOrder:
+          typeof input.sortOrder === "number" ? input.sortOrder : 0,
+        createdAt: now,
+        updatedAt: now,
+      };
+      if (shared) folder.shared = true;
+      if (orgName) folder.orgName = orgName;
+      if (lastSyncedAt) folder.lastSyncedAt = lastSyncedAt;
+      folders.push(folder);
       await this.#writeJson(this.foldersPath, folders);
-      return { ...existing };
-    }
-
-    const folder = {
-      id: input.id || crypto.randomUUID(),
-      name,
-      parentId,
-      sortOrder:
-        typeof input.sortOrder === "number" ? input.sortOrder : 0,
-      createdAt: now,
-      updatedAt: now,
-    };
-    if (shared) folder.shared = true;
-    if (orgName) folder.orgName = orgName;
-    if (lastSyncedAt) folder.lastSyncedAt = lastSyncedAt;
-    folders.push(folder);
-    await this.#writeJson(this.foldersPath, folders);
-    return { ...folder };
+      return { ...folder };
+    });
   }
 
   async deleteFolder(id) {
-    const folders = await this.listFolders();
-    const toDelete = this.#collectDescendants(folders, id);
-    if (!toDelete.length) return [];
-    const remaining = folders.filter((f) => !toDelete.includes(f.id));
-    await this.#writeJson(this.foldersPath, remaining);
-    return toDelete;
+    return this.#enqueue(async () => {
+      const folders = await this.listFolders();
+      const toDelete = this.#collectDescendants(folders, id);
+      if (!toDelete.length) return [];
+      const remaining = folders.filter((f) => !toDelete.includes(f.id));
+      await this.#writeJson(this.foldersPath, remaining);
+      return toDelete;
+    });
   }
 
   async reorderFolders(updates) {
-    const folders = await this.listFolders();
-    for (const { id, sortOrder } of updates) {
-      const folder = folders.find((f) => f.id === id);
-      if (folder) folder.sortOrder = sortOrder;
-    }
-    await this.#writeJson(this.foldersPath, folders);
+    return this.#enqueue(async () => {
+      const folders = await this.listFolders();
+      for (const { id, sortOrder } of updates) {
+        const folder = folders.find((f) => f.id === id);
+        if (folder) folder.sortOrder = sortOrder;
+      }
+      await this.#writeJson(this.foldersPath, folders);
+    });
   }
 
   async folderExists(id) {
@@ -112,14 +128,16 @@ class FolderStore {
    */
   async touchFolders(ids) {
     if (!ids.length) return;
-    const folders = await this.listFolders();
-    const now = new Date().toISOString();
-    for (const folder of folders) {
-      if (ids.includes(folder.id)) {
-        folder.updatedAt = now;
+    return this.#enqueue(async () => {
+      const folders = await this.listFolders();
+      const now = new Date().toISOString();
+      for (const folder of folders) {
+        if (ids.includes(folder.id)) {
+          folder.updatedAt = now;
+        }
       }
-    }
-    await this.#writeJson(this.foldersPath, folders);
+      await this.#writeJson(this.foldersPath, folders);
+    });
   }
 
   // --- Private helpers ---

--- a/tests/unit/folderStore.test.js
+++ b/tests/unit/folderStore.test.js
@@ -259,3 +259,39 @@ describe("FolderStore — shared folder fields", () => {
     expect(folder.id).toBe("custom-id-123");
   });
 });
+
+// ---------------------------------------------------------------------------
+// FolderStore — concurrent write safety
+// ---------------------------------------------------------------------------
+
+describe("FolderStore — concurrent write safety", () => {
+  let store, dir;
+  beforeEach(async () => ({ store, dir } = await makeTempStore()));
+  afterEach(async () => cleanupDir(dir));
+
+  test("concurrent upsertFolder calls do not lose subfolder changes", async () => {
+    // Simulate the race between pullAll updating the root shared folder
+    // (lastSyncedAt) and the user creating a subfolder via folders:save.
+    // Without write serialization the last write wins and the subfolder
+    // created by the IPC handler is silently dropped.
+    await store.upsertFolder({
+      id: "shared-root",
+      name: "Shared Root",
+      shared: true,
+      orgName: "test-org",
+    });
+
+    // Fire N concurrent subfolder creations. Without a write queue each call
+    // reads the same initial state and the last write clobbers the rest.
+    const N = 20;
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        store.upsertFolder({ name: `Sub${i}`, parentId: "shared-root" }),
+      ),
+    );
+
+    const folders = await store.listFolders();
+    const subs = folders.filter((f) => f.parentId === "shared-root");
+    expect(subs).toHaveLength(N);
+  });
+});


### PR DESCRIPTION
## Summary

`FolderStore` had no write serialization. When `pullAll` runs its 60-second background sync, `_pullFolderWithTree` calls `upsertFolder` to update the root shared folder's `lastSyncedAt`. If the user simultaneously creates a subfolder (triggering `folders:save` IPC, which also calls `upsertFolder`), both calls race on `folders.json` using a read-modify-write pattern with no locking. The last writer wins, silently overwriting the other's change — typically dropping the newly created subfolder.

The fix adds a `#writeQueue` promise chain to `FolderStore` that serializes all write operations (`upsertFolder`, `deleteFolder`, `reorderFolders`, `touchFolders`). Concurrent callers queue behind each other so every read sees the result of all previous writes, eliminating the race.

Closes #265