### PR TITLE
fix: editing a build in a folder moves it to root (closes #267)

### DIFF
--- a/src/main/buildStore.js
+++ b/src/main/buildStore.js
@@ -4,6 +4,13 @@ const crypto = require("node:crypto");
 
 class BuildStore {
   #settingsQueue = Promise.resolve();
+  #writeQueue = Promise.resolve();
+
+  #enqueue(fn) {
+    const next = this.#writeQueue.then(() => fn());
+    this.#writeQueue = next.catch(() => {});
+    return next;
+  }
 
   constructor(baseDir) {
     this.baseDir = baseDir;
@@ -26,73 +33,85 @@ class BuildStore {
   }
 
   async upsertBuild(input) {
-    const builds = await this.listBuilds();
-    const now = new Date().toISOString();
-    const id = input.id || crypto.randomUUID();
-    const next = normalizeBuild({ ...input, id, updatedAt: now }, input.createdAt || now);
+    return this.#enqueue(async () => {
+      const builds = await this.listBuilds();
+      const now = new Date().toISOString();
+      const id = input.id || crypto.randomUUID();
+      const next = normalizeBuild({ ...input, id, updatedAt: now }, input.createdAt || now);
 
-    const idx = builds.findIndex((b) => b.id === id);
-    if (idx >= 0) {
-      const existing = builds[idx];
-      next.createdAt = existing.createdAt || next.createdAt;
-      // Preserve publish metadata from the existing record when the incoming save
-      // doesn't supply it (e.g. editor saves via serializeEditorToBuild which does
-      // not include these fields, so they would otherwise be wiped to "").
-      if (!next.publishedFileId && existing.publishedFileId) next.publishedFileId = existing.publishedFileId;
-      if (!next.publishedKey && existing.publishedKey) next.publishedKey = existing.publishedKey;
-      if (!next.publishedSlug && existing.publishedSlug) next.publishedSlug = existing.publishedSlug;
-      builds[idx] = next;
-    } else {
-      builds.push(next);
-    }
+      const idx = builds.findIndex((b) => b.id === id);
+      if (idx >= 0) {
+        const existing = builds[idx];
+        next.createdAt = existing.createdAt || next.createdAt;
+        // Preserve fields that the editor save payload does not carry (serializeEditorToBuild
+        // omits folderId when falsy, and never includes publish metadata).
+        if (next.folderId === null && existing.folderId) next.folderId = existing.folderId;
+        if (!next.publishedFileId && existing.publishedFileId) next.publishedFileId = existing.publishedFileId;
+        if (!next.publishedKey && existing.publishedKey) next.publishedKey = existing.publishedKey;
+        if (!next.publishedSlug && existing.publishedSlug) next.publishedSlug = existing.publishedSlug;
+        builds[idx] = next;
+      } else {
+        builds.push(next);
+      }
 
-    await this.#writeJson(this.buildsPath, builds);
-    return next;
+      await this.#writeJson(this.buildsPath, builds);
+      return next;
+    });
   }
 
   async deleteBuild(id) {
-    const builds = await this.listBuilds();
-    const filtered = builds.filter((b) => b.id !== id);
-    await this.#writeJson(this.buildsPath, filtered);
+    return this.#enqueue(async () => {
+      const builds = await this.listBuilds();
+      const filtered = builds.filter((b) => b.id !== id);
+      await this.#writeJson(this.buildsPath, filtered);
+    });
   }
 
   async moveBuilds(ids, folderId) {
-    const builds = await this.#readJson(this.buildsPath, []);
-    for (const build of builds) {
-      if (ids.includes(build.id)) {
-        build.folderId = folderId;
+    return this.#enqueue(async () => {
+      const builds = await this.#readJson(this.buildsPath, []);
+      for (const build of builds) {
+        if (ids.includes(build.id)) {
+          build.folderId = folderId;
+        }
       }
-    }
-    await this.#writeJson(this.buildsPath, builds);
+      await this.#writeJson(this.buildsPath, builds);
+    });
   }
 
   async pinBuilds(ids, pinned) {
-    const builds = await this.#readJson(this.buildsPath, []);
-    for (const build of builds) {
-      if (ids.includes(build.id)) {
-        build.pinned = Boolean(pinned);
+    return this.#enqueue(async () => {
+      const builds = await this.#readJson(this.buildsPath, []);
+      for (const build of builds) {
+        if (ids.includes(build.id)) {
+          build.pinned = Boolean(pinned);
+        }
       }
-    }
-    await this.#writeJson(this.buildsPath, builds);
+      await this.#writeJson(this.buildsPath, builds);
+    });
   }
 
   async reorderBuilds(updates) {
-    const builds = await this.#readJson(this.buildsPath, []);
-    for (const { id, sortOrder } of updates) {
-      const build = builds.find((b) => b.id === id);
-      if (build) build.sortOrder = sortOrder;
-    }
-    await this.#writeJson(this.buildsPath, builds);
+    return this.#enqueue(async () => {
+      const builds = await this.#readJson(this.buildsPath, []);
+      for (const { id, sortOrder } of updates) {
+        const build = builds.find((b) => b.id === id);
+        if (build) build.sortOrder = sortOrder;
+      }
+      await this.#writeJson(this.buildsPath, builds);
+    });
   }
 
   async clearFolderFromBuilds(folderIds) {
-    const builds = await this.#readJson(this.buildsPath, []);
-    for (const build of builds) {
-      if (folderIds.includes(build.folderId)) {
-        build.folderId = null;
+    return this.#enqueue(async () => {
+      const builds = await this.#readJson(this.buildsPath, []);
+      for (const build of builds) {
+        if (folderIds.includes(build.folderId)) {
+          build.folderId = null;
+        }
       }
-    }
-    await this.#writeJson(this.buildsPath, builds);
+      await this.#writeJson(this.buildsPath, builds);
+    });
   }
 
   async clearCompFromBuilds(compIdsToRemove) {

--- a/tests/unit/buildStore.test.js
+++ b/tests/unit/buildStore.test.js
@@ -1216,3 +1216,62 @@ describe("BuildStore — gameMode normalization", () => {
     expect(saved.specializations[0].majorChoices[1]).toBe(634);
   });
 });
+
+// ---------------------------------------------------------------------------
+// BuildStore — folderId preservation (issue #267)
+// ---------------------------------------------------------------------------
+
+describe("BuildStore — folderId preservation on update", () => {
+  let store, dir;
+
+  beforeEach(async () => { ({ store, dir } = await makeTempStore()); });
+  afterEach(async () => { await cleanupDir(dir); });
+
+  test("preserves folderId when update payload omits it", async () => {
+    // Simulates editor save: build is in a folder, editor serializes without
+    // folderId (serializeEditorToBuild returns folderId: undefined when state
+    // is falsy), so normalizeBuild turns it into null — the store must not
+    // clobber the stored folderId with null.
+    const created = await store.upsertBuild(makeBuild({ folderId: "folder-abc" }));
+    expect(created.folderId).toBe("folder-abc");
+
+    // Save without folderId (as the editor does)
+    const updated = await store.upsertBuild({ ...created, folderId: undefined, title: "Edited" });
+    expect(updated.folderId).toBe("folder-abc");
+
+    const builds = await store.listBuilds();
+    expect(builds[0].folderId).toBe("folder-abc");
+  });
+
+  test("allows explicitly moving a build to root (null folderId) via moveBuilds", async () => {
+    const created = await store.upsertBuild(makeBuild({ folderId: "folder-abc" }));
+    await store.moveBuilds([created.id], null);
+    const builds = await store.listBuilds();
+    expect(builds[0].folderId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BuildStore — concurrent write safety (issue #267)
+// ---------------------------------------------------------------------------
+
+describe("BuildStore — concurrent write safety", () => {
+  let store, dir;
+
+  beforeEach(async () => { ({ store, dir } = await makeTempStore()); });
+  afterEach(async () => { await cleanupDir(dir); });
+
+  test("concurrent upsertBuild calls do not lose builds", async () => {
+    // Without write serialization, concurrent reads of builds.json all see the
+    // same initial state, and the last write wins — earlier builds are dropped.
+    const N = 20;
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        store.upsertBuild(makeBuild({ title: `Build ${i}` })),
+      ),
+    );
+
+    const builds = await store.listBuilds();
+    expect(builds).toHaveLength(N);
+  });
+});


### PR DESCRIPTION
## Summary

When editing and saving a build that lives inside a folder, the build was being silently moved to the root level. Two concurrent-write races in `BuildStore` caused this:

1. **folderId not preserved**: `upsertBuild` did not carry the stored `folderId` forward when the incoming payload omitted it. The editor's `serializeEditorToBuild` returns `folderId: undefined` when the editor state field is falsy — `normalizeBuild` then coerces that to `null`, overwriting the real folder assignment.
2. **No write serialization**: All write methods (`upsertBuild`, `deleteBuild`, `moveBuilds`, etc.) read-then-wrote `builds.json` with no locking, so concurrent calls (e.g. two rapid saves) could clobber each other — same class of race fixed in FolderStore by PR #266.

Fix: added a `#writeQueue` promise chain (same pattern as FolderStore) to serialize all writes, and added `folderId` preservation alongside the existing publish-metadata preservation in `upsertBuild`.

Closes #267