### PR TITLE
fix: Dazzling Hammer (Radiant Forge 2) incorrectly shows Alacrity in WvW (closes #269)

### DIFF
--- a/src/renderer/modules/detail-panel.js
+++ b/src/renderer/modules/detail-panel.js
@@ -256,13 +256,17 @@ export function resolveEntityFacts(entity) {
   // PvP falls back to WvW facts (GW2 frequently shares WvW/PvP balance),
   // then to PvE facts as a last resort.
   let baseFacts;
+  let usingPveFacts = true;
   if (gameMode === "wvw" && Array.isArray(entity.wvwFacts)) {
     baseFacts = entity.wvwFacts;
+    usingPveFacts = false;
   } else if (gameMode === "pvp") {
     if (Array.isArray(entity.pvpFacts)) {
       baseFacts = entity.pvpFacts;
+      usingPveFacts = false;
     } else if (Array.isArray(entity.wvwFacts)) {
       baseFacts = entity.wvwFacts;
+      usingPveFacts = false;
     } else {
       baseFacts = Array.isArray(entity.facts) ? entity.facts : [];
     }
@@ -271,9 +275,13 @@ export function resolveEntityFacts(entity) {
   }
   const traitedFacts = Array.isArray(entity.traitedFacts) ? entity.traitedFacts : [];
 
-  // Apply traited_facts overrides when the required trait is active.
+  // Apply traited_facts overrides only when using PvE facts as the base.
+  // The GW2 API's traited_facts carry PvE-balanced values and reference PvE
+  // fact positions via overrides indices — applying them to WvW/PvP fact
+  // arrays misplaces overrides and surfaces PvE-only conditional effects
+  // (e.g. Alacrity) that do not exist in those game modes.
   let result = baseFacts;
-  if (traitedFacts.length) {
+  if (traitedFacts.length && usingPveFacts) {
     // Collect active trait IDs — both major choices and minor traits.
     const activeTraitIds = new Set();
     const catalog = state.activeCatalog;

--- a/tests/unit/renderer/resolveEntityFacts.test.js
+++ b/tests/unit/renderer/resolveEntityFacts.test.js
@@ -308,6 +308,91 @@ describe("resolveEntityFacts — traited_facts overrides", () => {
 // ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
+// WvW mode — traited_facts must NOT be applied to wvwFacts (issue #269)
+// ---------------------------------------------------------------------------
+
+describe("resolveEntityFacts — WvW mode traited_facts isolation", () => {
+  beforeEach(() => {
+    state.editor = { gameMode: "wvw", specializations: [] };
+    state.activeCatalog = null;
+  });
+  afterEach(() => {
+    state.editor = { gameMode: "pve", specializations: [] };
+  });
+
+  test("does not append traited_facts to wvwFacts when in WvW mode", () => {
+    // Mirrors the Dazzling Hammer (Radiant Forge 2) bug: a traited_fact for
+    // Alacrity (overrides: null) was appended to the WvW fact list even though
+    // the wiki's WvW split doesn't include Alacrity.  The GW2 API's traited_facts
+    // reference PvE fact positions and carry PvE-balanced values; they must not
+    // be applied when the base fact set is the WvW split.
+    const entity = {
+      facts: [
+        { type: "Buff", status: "Might", duration: 8, apply_count: 8, text: "Might" },
+        { type: "Buff", status: "Fury",  duration: 6, apply_count: 1, text: "Fury"  },
+      ],
+      wvwFacts: [
+        { type: "Buff", status: "Might", duration: 8, apply_count: 3, text: "Might" },
+        { type: "Buff", status: "Fury",  duration: 6, apply_count: 1, text: "Fury"  },
+      ],
+      traitedFacts: [
+        // Alacrity granted by a trait — no overrides index (appended)
+        { type: "Buff", status: "Alacrity", duration: 4, apply_count: 1, text: "Alacrity", requires_trait: 1234, overrides: null },
+        // Might upgraded by a trait — overrides PvE facts[0]
+        { type: "Buff", status: "Might", duration: 8, apply_count: 4, text: "Might", requires_trait: 1234, overrides: 0 },
+      ],
+    };
+
+    // Simulate trait 1234 being active
+    state.editor.specializations = [{ majorChoices: { 1: 1234 } }];
+
+    const result = resolveEntityFacts(entity);
+
+    // WvW result must be the wiki WvW facts only — no Alacrity, Might stays ×3
+    const statuses = result.map((f) => f.status).filter(Boolean);
+    expect(statuses).not.toContain("Alacrity");
+    expect(result.find((f) => f.status === "Might")?.apply_count).toBe(3);
+  });
+
+  test("does apply traited_facts in PvE mode (control)", () => {
+    state.editor = { gameMode: "pve", specializations: [{ majorChoices: { 1: 1234 } }] };
+
+    const entity = {
+      facts: [
+        { type: "Buff", status: "Might", duration: 8, apply_count: 8, text: "Might" },
+      ],
+      traitedFacts: [
+        { type: "Buff", status: "Alacrity", duration: 4, apply_count: 1, text: "Alacrity", requires_trait: 1234, overrides: null },
+      ],
+    };
+
+    const result = resolveEntityFacts(entity);
+    const statuses = result.map((f) => f.status).filter(Boolean);
+    expect(statuses).toContain("Alacrity");
+  });
+
+  test("does not apply traited_facts in PvP mode when pvpFacts are present", () => {
+    state.editor = { gameMode: "pvp", specializations: [{ majorChoices: { 1: 1234 } }] };
+
+    const entity = {
+      facts: [
+        { type: "Buff", status: "Might", duration: 8, apply_count: 8, text: "Might" },
+      ],
+      pvpFacts: [
+        { type: "Buff", status: "Might", duration: 8, apply_count: 3, text: "Might" },
+      ],
+      traitedFacts: [
+        { type: "Buff", status: "Alacrity", duration: 4, apply_count: 1, text: "Alacrity", requires_trait: 1234, overrides: null },
+      ],
+    };
+
+    const result = resolveEntityFacts(entity);
+    const statuses = result.map((f) => f.status).filter(Boolean);
+    expect(statuses).not.toContain("Alacrity");
+  });
+});
+
+// ---------------------------------------------------------------------------
 
 describe("resolveEntityFacts — edge cases", () => {
   test("returns empty array for entity with no facts", () => {


### PR DESCRIPTION
## Summary

When viewing Dazzling Hammer (Radiant Forge 2) in WvW mode with a Luminary trait active, the reference panel incorrectly showed **Alacrity (4s)** and **Might ×4** — neither of which appear in WvW on the wiki.

Root cause: the GW2 API's `traited_facts` are PvE-only data — their `overrides` indices reference positions in the PvE `facts` array, and their values are PvE-balanced. When the renderer used the wiki-parsed WvW split facts (`wvwFacts`) as the base, these traited_facts were still applied unconditionally: facts without an `overrides` index (like the Alacrity grant) were appended to the WvW fact list, and override-indexed facts landed at wrong positions in the WvW array.

Fix: skip `traited_facts` application whenever the base fact set is `wvwFacts` or `pvpFacts`. traited_facts continue to be applied normally in PvE mode (where their indices and values are correct), or when falling back to PvE facts in modes without split data.

Closes #269