### PR TITLE
fix: Fierce Blow tooltip missing bonus damage (closes #271)

### DIFF
--- a/packages/gw2-data/src/wiki/parser.js
+++ b/packages/gw2-data/src/wiki/parser.js
@@ -199,9 +199,13 @@ function mapWikiFactToApiFact(factType, positional, params, isWvw, isUniversal) 
     const rawCoefficient = params.coefficient || positional[0] || "0";
     const coefficient = parseFloat(stripWikiMarkup(rawCoefficient));
     const hits = parseInt(stripWikiMarkup(params.hits) || "1", 10);
+    // `alt=` carries the conditional damage label (e.g. "Damage to Controlled Foes").
+    // Without this, the conditional variant collapses with the base "Damage" fact
+    // during dedup, hiding bonus-damage values from the tooltip.
+    const label = params.alt ? stripWikiMarkup(params.alt).trim() : "Damage";
     return {
       type: "Damage",
-      text: "Damage",
+      text: label,
       dmg_multiplier: coefficient,
       hit_count: hits,
     };

--- a/packages/gw2-data/tests/parser.test.js
+++ b/packages/gw2-data/tests/parser.test.js
@@ -64,6 +64,23 @@ describe("mapWikiFactToApiFact", () => {
     });
   });
 
+  test("damage with alt label uses alt as text (Fierce Blow bonus)", () => {
+    // {{skill fact|Damage|alt=Damage to Controlled Foes|coefficient=2.7|...}}
+    const fact = mapWikiFactToApiFact(
+      "damage",
+      [],
+      { alt: "Damage to Controlled Foes", coefficient: "2.7" },
+      false,
+      false
+    );
+    expect(fact).toEqual({
+      type: "Damage",
+      text: "Damage to Controlled Foes",
+      dmg_multiplier: 2.7,
+      hit_count: 1,
+    });
+  });
+
   test("damage with coefficient and hits", () => {
     const fact = mapWikiFactToApiFact(
       "damage",


### PR DESCRIPTION
## Summary
The wiki parser hardcoded `text: "Damage"` for every `{{skill fact|damage|...}}` template, ignoring the `alt=` label that the wiki uses for conditional damage variants (e.g. Fierce Blow's `alt=Damage to Controlled Foes`). When wiki facts replaced the GW2 API facts in the catalog, the bonus-damage entry became indistinguishable from the base hit and was collapsed by `resolveEntityFacts` dedup — so the tooltip showed only the base damage.

Fix: read `params.alt` as the fact label, mirroring the same pattern other percent/number fact handlers already use. Conditional damage variants now keep their distinct label and survive dedup.

Closes #271