### PR TITLE
fix(release): publish job matches release by tag, draft or not

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,9 @@ jobs:
             capture { print }
           ' RELEASE_NOTES.md)
 
+          # Match the release for this tag whether electron-builder left it as a draft
+          # or already published it (it publishes non-draft when --publish always). The
+          # PATCH below is idempotent — it just (re)writes the notes and ensures it's live.
           release_id=$(gh api graphql -f query='
             query($owner:String!,$repo:String!){
               repository(owner:$owner,name:$repo){
@@ -131,15 +134,14 @@ jobs:
                 }
               }
             }' -F owner=darkharasho -F repo=axiforge \
-            --jq ".data.repository.releases.nodes[] | select(.tagName==\"$tag\" and .isDraft==true) | .databaseId" | head -1)
+            --jq ".data.repository.releases.nodes[] | select(.tagName==\"$tag\") | .databaseId" | head -1)
 
           if [ -z "$release_id" ]; then
-            echo "No draft found for tag $tag" >&2
+            echo "No release found for tag $tag (expected electron-builder to have created it)" >&2
             exit 1
           fi
 
           gh api -X PATCH "repos/darkharasho/axiforge/releases/$release_id" \
-            -f name="$tag" \
             -f body="$notes" \
             -F draft=false
 


### PR DESCRIPTION
## Problem

On the **v0.7.2** release, all build jobs succeeded but the `publish` job failed with `No draft found for tag v0.7.2`. The release itself was fine — published, marked *Latest*, with every artifact — but it shipped with an **empty body** and **no Discord announcement**, because that job is what writes the notes and posts to Discord.

Root cause: the publish step's query required `isDraft==true`, but electron-builder runs with `--publish always` and publishes the release **non-draft**. So the "find the draft to promote" query returned nothing and the job exited 1. This affects **every** release, not just v0.7.2.

## Fix

- Match the release for the tag **regardless of draft state** (`select(.tagName==$tag)`), so it works whether electron-builder left a draft or already published.
- The PATCH is idempotent — it (re)writes the notes from `RELEASE_NOTES.md` and ensures `draft=false`.
- Dropped the `name="$tag"` override so electron-builder's own naming (`{version}`) is preserved instead of being renamed to `v{version}`.

## Notes

- v0.7.2's body was backfilled manually; this prevents the recurrence.
- No way to unit-test a workflow here; verified the jq filter logic and YAML structure by hand. The real validation is the next tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)