### PR TITLE
fix(release): atomic draft→publish (no empty release window)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
       "provider": "github",
       "owner": "darkharasho",
       "repo": "axiforge",
-      "releaseType": "release"
+      "releaseType": "draft"
     },
     "files": [
       "src/**/*",


### PR DESCRIPTION
## Problem
`package.json` set `build.publish.releaseType: "release"`, so `electron-builder --publish always` in the build job made the release **public immediately** — while its notes were still the empty placeholder from `prepare-release`. The workflow's "set notes → `--draft=false`" step runs after, leaving a ~1-minute window where the release is live and empty. GitHub's `releases.atom` feed (polled by the AxiTools bot) catches it in that window and announces **"No content."**, then never corrects it.

## Fix
One line: `releaseType: "release"` → `"draft"`. electron-builder uploads to the hidden draft; only the final `gh release edit --draft=false` (after notes are set) makes it public. Matches the working `axipulse` / `TopStatsAIO` config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)