### PR TITLE
fix(updater): full installers + logging + visible install errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "dependencies": {
         "@axiapps/code": "*",
         "dotenv": "^17.3.1",
+        "electron-log": "^5.4.4",
         "electron-updater": "^6.8.3",
         "gw2-class-icons": "^0.3.0",
         "gw2buildlink": "^0.3.0",
@@ -6872,6 +6873,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.4.tgz",
+      "integrity": "sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-publish": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     },
     "nsis": {
       "oneClick": true,
-      "differentialPackage": true,
+      "differentialPackage": false,
       "runAfterFinish": false
     },
     "mac": {
@@ -145,6 +145,7 @@
   "dependencies": {
     "@axiapps/code": "*",
     "dotenv": "^17.3.1",
+    "electron-log": "^5.4.4",
     "electron-updater": "^6.8.3",
     "gw2-class-icons": "^0.3.0",
     "gw2buildlink": "^0.3.0",

--- a/src/main/autoUpdate.js
+++ b/src/main/autoUpdate.js
@@ -11,6 +11,24 @@ function getAutoUpdater() {
   return _autoUpdater;
 }
 
+// Persistent updater log. Writes to the app's userData/logs directory so users can
+// share it when an update silently fails to install (e.g. ~/AppData/Roaming/AxiForge/
+// logs/auto-update.log on Windows). Lazy-loaded for the same init-order reason above.
+let _log = null;
+function getLog() {
+  if (!_log) {
+    _log = require("electron-log");
+    try {
+      _log.transports.file.fileName = "auto-update.log";
+      _log.transports.file.level = "info";
+    } catch { /* electron-log not fully initialized in some test envs */ }
+  }
+  return _log;
+}
+function log(...args) {
+  try { getLog().info("[auto-update]", ...args); } catch { /* never let logging throw */ }
+}
+
 const RETRY_ERRORS = [
   "ECONNRESET", "ETIMEDOUT", "ENOTFOUND", "EPIPE",
   "socket hang up", "ERR_HTTP2_SERVER_REFUSED_STREAM",
@@ -99,14 +117,23 @@ function initAutoUpdate(getWindow) {
 
   const autoUpdater = getAutoUpdater();
 
+  autoUpdater.logger = getLog();
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
+  log(`initialized — current version ${app.getVersion()}, platform ${process.platform}`);
+
+  // Tracks whether a download finished this session. An error AFTER this point is an
+  // install/apply failure (the download succeeded), not a check/download failure — the
+  // two are surfaced differently so a post-download failure isn't silently swallowed.
+  let downloadCompleted = false;
 
   autoUpdater.on("checking-for-update", () => {
+    log("checking for update");
     send("update-checking", {});
   });
 
   autoUpdater.on("update-available", (info) => {
+    log(`update available: ${info.version}`);
     send("update-available", {
       version: info.version,
       releaseDate: info.releaseDate,
@@ -114,18 +141,29 @@ function initAutoUpdate(getWindow) {
   });
 
   autoUpdater.on("update-not-available", (info) => {
+    log(`no update available (latest is ${info.version})`);
     send("update-not-available", { version: info.version });
   });
 
   autoUpdater.on("error", (err) => {
+    const message = String(err?.message || err);
     if (isRetryableError(err) && retryAttempts < 1) {
       retryAttempts++;
+      log(`retryable error, retrying once: ${message}`);
       setTimeout(() => {
         checkWithTimeout().catch(() => {});
       }, RETRY_DELAY_MS);
       return;
     }
-    send("update-error", { message: String(err?.message || err) });
+    if (downloadCompleted) {
+      // Download succeeded but install/apply failed — this is the silent
+      // "downloads then does nothing, re-downloads next launch" failure mode.
+      log(`install failed after successful download: ${message}`);
+      send("update-install-error", { message });
+      return;
+    }
+    log(`update error: ${message}`);
+    send("update-error", { message });
   });
 
   autoUpdater.on("download-progress", (progress) => {
@@ -137,6 +175,8 @@ function initAutoUpdate(getWindow) {
   });
 
   autoUpdater.on("update-downloaded", (info) => {
+    downloadCompleted = true;
+    log(`update downloaded: ${info.version} — staged for install on quit/restart`);
     send("update-downloaded", {
       version: info.version,
       releaseNotes: info.releaseNotes,
@@ -150,6 +190,7 @@ function initAutoUpdate(getWindow) {
   });
 
   ipcMain.on("updater:restart", () => {
+    log("user requested restart-to-install — calling quitAndInstall()");
     getAutoUpdater().quitAndInstall();
   });
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -6,7 +6,7 @@ require("dotenv").config({ path: path.resolve(__dirname, "../../.env") });
 for (const stream of [process.stdout, process.stderr]) {
   stream?.on?.("error", (err) => { if (err.code !== "EPIPE") throw err; });
 }
-const { app, BrowserWindow, ipcMain, dialog, clipboard, nativeTheme, nativeImage, screen } = require("electron");
+const { app, BrowserWindow, ipcMain, dialog, clipboard, nativeTheme, nativeImage, screen, shell } = require("electron");
 
 // Taskbar identity on X11 — give AxiForge its own WM_CLASS so KDE/GNOME
 // don't group it with whatever process launched electron (e.g. a VS Code
@@ -496,6 +496,15 @@ const readyWork = app.whenReady().then(async () => {
   handle("window:close", (event) => {
     BrowserWindow.fromWebContents(event.sender)?.close();
     return true;
+  });
+
+  handle("app:open-external", (_event, url) => {
+    // Only open http(s) links externally — never file:// or other schemes from the renderer.
+    if (typeof url === "string" && /^https?:\/\//i.test(url)) {
+      shell.openExternal(url);
+      return true;
+    }
+    return false;
   });
 
   handle("window:open-preview", (_event, url, opts = {}) => {

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld("desktopApi", {
   isMaximizedWindow: () => ipcRenderer.invoke("window:is-maximized"),
   closeWindow: () => ipcRenderer.invoke("window:close"),
   openPreviewWindow: (url, opts) => ipcRenderer.invoke("window:open-preview", url, opts),
+  openExternal: (url) => ipcRenderer.invoke("app:open-external", url),
   writeClipboardText: (text) => ipcRenderer.invoke("clipboard:write-text", text),
   readClipboardText: () => ipcRenderer.invoke("clipboard:read-text"),
   getSession: () => ipcRenderer.invoke("auth:get-session"),
@@ -114,6 +115,10 @@ contextBridge.exposeInMainWorld("desktopApi", {
   onUpdateError: (cb) => {
     ipcRenderer.removeAllListeners("update-error");
     ipcRenderer.on("update-error", (_e, info) => cb(info));
+  },
+  onUpdateInstallError: (cb) => {
+    ipcRenderer.removeAllListeners("update-install-error");
+    ipcRenderer.on("update-install-error", (_e, info) => cb(info));
   },
   onDownloadProgress: (cb) => {
     ipcRenderer.removeAllListeners("download-progress");

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -363,6 +363,10 @@ initSettingsCallbacks({
     if (!el.updateStatusPill || !el.updateStatusPillText) return;
     el.updateStatusPillText.textContent = text;
     el.updateStatusPill.classList.remove("hidden", "titlebar__pill--muted", "titlebar__pill--error", "titlebar__pill--static");
+    // Clear any click affordance left over from the install-error state.
+    el.updateStatusPill.onclick = null;
+    el.updateStatusPill.style.cursor = "";
+    el.updateStatusPill.title = "";
     if (variant === "muted") el.updateStatusPill.classList.add("titlebar__pill--muted");
     else if (variant === "error") el.updateStatusPill.classList.add("titlebar__pill--error");
     else if (variant === "static") el.updateStatusPill.classList.add("titlebar__pill--static");
@@ -413,6 +417,23 @@ initSettingsCallbacks({
         hideRestartBtn();
         errorResetTimer = setTimeout(() => applyState("idle"), 5000);
         break;
+      case "install-error":
+        // Download succeeded but the install couldn't be applied. Unlike a transient
+        // check/download error this is sticky — the user needs to act (reinstall
+        // manually), so it stays visible and points them at the releases page.
+        setPill("Update couldn't install — click to download", "error");
+        if (el.updateStatusPill) {
+          el.updateStatusPill.title =
+            "The update downloaded but couldn't be installed automatically. " +
+            "Click to open the downloads page and reinstall manually.";
+          el.updateStatusPill.classList.add("no-drag");
+          el.updateStatusPill.style.cursor = "pointer";
+          el.updateStatusPill.onclick = () => {
+            window.desktopApi.openExternal?.("https://github.com/darkharasho/axiforge/releases/latest");
+          };
+        }
+        hideRestartBtn();
+        break;
       case "unsupported": {
         const reason = payload?.reason;
         setPill("Auto-updates disabled", "static");
@@ -454,6 +475,12 @@ initSettingsCallbacks({
   window.desktopApi.onUpdateError?.(() => {
     if (state === "downloaded") return; // already have a working download
     applyState("error");
+  });
+
+  window.desktopApi.onUpdateInstallError?.(() => {
+    // Download succeeded but applying it failed — surface a sticky, actionable pill
+    // instead of the transient "Update failed" so the user can reinstall manually.
+    applyState("install-error");
   });
 
   window.desktopApi.onUpdateUnsupported?.((info) => {

--- a/tests/unit/autoUpdate.test.js
+++ b/tests/unit/autoUpdate.test.js
@@ -30,6 +30,13 @@ jest.mock("electron-updater", () => ({
   get autoUpdater() { return _autoUpdaterMock; },
 }));
 
+// Stub electron-log so updater logging is exercised without writing files or
+// spamming the test console.
+jest.mock("electron-log", () => ({
+  info: jest.fn(),
+  transports: { file: {} },
+}));
+
 // ── Test helpers ───────────────────────────────────────────────────────────
 
 function makeAutoUpdaterMock() {
@@ -219,6 +226,21 @@ describe("autoUpdate — normal packaged flow", () => {
     _autoUpdaterMock.emit("error", new Error("boom"));
 
     expect(sentData(win.webContents, "update-error")).toEqual({ message: "boom" });
+  });
+
+  test("error AFTER a completed download emits update-install-error, not update-error", () => {
+    const win = makeWindowMock();
+    loadModule().initAutoUpdate(win);
+
+    // Download finished, then the install/apply step fails.
+    _autoUpdaterMock.emit("update-downloaded", { version: "1.2.4" });
+    win.webContents.send.mockClear();
+    _autoUpdaterMock.emit("error", new Error("Cannot run installer"));
+
+    expect(sentData(win.webContents, "update-install-error")).toEqual({
+      message: "Cannot run installer",
+    });
+    expect(sentChannels(win.webContents)).not.toContain("update-error");
   });
 
   test("retryable network error retries once before emitting update-error", async () => {


### PR DESCRIPTION
## Problem

Users reported the auto-updater **downloads to 100% then does nothing** — the new version never installs, and it **re-downloads on every launch**. The install step was failing silently, with no logging anywhere to diagnose it.

## Changes

1. **Disable `nsis.differentialPackage`** — ship full installers instead of differential/blockmap packages. Differential reconstruction across large version gaps (e.g. a user on `0.6.25` → `0.9.x`) is the prime suspect for "downloads but won't install / re-downloads next launch."
2. **Add updater logging** — added `electron-log` and wired `autoUpdater.logger`, plus `[auto-update]` lifecycle lines. Writes to `auto-update.log` in userData (e.g. `%AppData%\AxiForge\logs\` on Windows). Previously the entire update process was silent and undiagnosable.
3. **Surface install errors in the UI** — an `error` that fires *after* a completed download is now distinguished from a check/download error: it emits a new `update-install-error` channel. The renderer shows a sticky, clickable **"Update couldn't install — click to download"** pill that opens the releases page, instead of swallowing the error. Backed by a new `app:open-external` IPC (http(s)-only).

## Caveats

- The differential theory is **not yet confirmed via logs** (no logging existed). The new `auto-update.log` will confirm the real cause on the next occurrence; we can revisit if it points elsewhere.
- This only helps from the **next release forward** — clients already stuck on an old version (e.g. `0.6.25`) need to manually reinstall the latest `.exe` from the releases page to get unstuck.

## Tests

All 1919 tests pass, including a new case covering the post-download `update-install-error` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)