### PR TITLE
fix: Revenant builds can't generate chatlinks; skills don't show on published build (closes #283)

### DIFF
--- a/src/main/buildChatLink.js
+++ b/src/main/buildChatLink.js
@@ -8,6 +8,30 @@ function parseLegendCode(legendStr) {
   return match ? Number(match[1]) : undefined;
 }
 
+// Revenant skill slots use a FIXED set of palette IDs regardless of legend —
+// the active legend is what determines which concrete skill each palette shows
+// in-game. GW2's API never maps legend skills (e.g. Enchanted Daggers 26937)
+// into Revenant's skills_by_palette, so passing the skill IDs makes gw2buildlink
+// throw "Skill <id> is not available for profession Revenant" (no link at all),
+// while leaving the slots empty drops the skills from the imported build — both
+// were issue #283. These are the only heal/utility/elite palettes Revenant
+// exposes; the utility order is canonical.
+// Source: https://wiki.guildwars2.com/wiki/Chat_link_format/skill_palette_table
+const REVENANT_HEAL_PALETTE = 4572;
+const REVENANT_UTILITY_PALETTES = [4564, 4614, 4651];
+const REVENANT_ELITE_PALETTE = 4554;
+
+function revenantPaletteSkillSet(hasActiveLegend) {
+  if (!hasActiveLegend) {
+    return { heal: undefined, utilities: [undefined, undefined, undefined], elite: undefined };
+  }
+  return {
+    heal: REVENANT_HEAL_PALETTE,
+    utilities: [...REVENANT_UTILITY_PALETTES],
+    elite: REVENANT_ELITE_PALETTE,
+  };
+}
+
 /**
  * Map an axiforge build object to gw2buildlink's BuildTemplateInput.
  */
@@ -45,16 +69,19 @@ function mapBuildToTemplateInput(build) {
     };
   };
 
-  // Revenant skill slots are determined by the active legend in-game — the
-  // legend's heal/utility/elite skill IDs are NOT part of the profession's
-  // skills_by_palette, so passing them makes gw2buildlink throw "Skill <id> is
-  // not available for profession Revenant" and no chat link is produced (#283).
-  // The legend codes (revenantLegends below) already encode the skill bar, so
-  // leave the palette slots empty for Revenant.
   const profLower = (build.profession || "").toLowerCase();
-  const emptySkillSet = () => ({ heal: undefined, utilities: [undefined, undefined, undefined], elite: undefined });
-  const skills = profLower === "revenant"
-    ? { terrestrial: emptySkillSet(), aquatic: emptySkillSet() }
+  const isRevenant = profLower === "revenant";
+  const legends = build.selectedLegends || ["", ""];
+  const uwLegends = build.selectedUnderwaterLegends || ["", ""];
+
+  // For Revenant, fill the skill slots with the fixed legend palettes (see
+  // REVENANT_* constants above) for whichever environment has an active legend.
+  // For every other profession, map the build's selected skill IDs as usual.
+  const skills = isRevenant
+    ? {
+        terrestrial: revenantPaletteSkillSet(parseLegendCode(legends[0]) !== undefined),
+        aquatic: revenantPaletteSkillSet(parseLegendCode(uwLegends[0]) !== undefined),
+      }
     : {
         terrestrial: mapSkillSet(build.skills),
         aquatic: mapSkillSet(build.underwaterSkills),
@@ -74,14 +101,23 @@ function mapBuildToTemplateInput(build) {
 
   // Revenant legends — only for Revenant profession.
   let revenantLegends;
-  if (profLower === "revenant") {
-    const legends = build.selectedLegends || ["", ""];
-    const uwLegends = build.selectedUnderwaterLegends || ["", ""];
+  let revenantInactiveSkills;
+  if (isRevenant) {
     revenantLegends = [
       parseLegendCode(legends[0]),
       parseLegendCode(legends[1]),
       parseLegendCode(uwLegends[0]),
       parseLegendCode(uwLegends[1]),
+    ];
+    // The inactive legend's 3 utility palettes (terrestrial then aquatic) are
+    // stored in the profession-specific bytes so utilities keep their order
+    // across a legend swap. Same fixed palettes; only present when a second
+    // legend is slotted for that environment.
+    const inactiveUtils = (hasSecondLegend) =>
+      hasSecondLegend ? [...REVENANT_UTILITY_PALETTES] : [undefined, undefined, undefined];
+    revenantInactiveSkills = [
+      ...inactiveUtils(parseLegendCode(legends[1]) !== undefined),
+      ...inactiveUtils(parseLegendCode(uwLegends[1]) !== undefined),
     ];
   }
 
@@ -103,6 +139,7 @@ function mapBuildToTemplateInput(build) {
     skills,
     weapons: weapons.length > 0 ? weapons : undefined,
     revenantLegends,
+    revenantInactiveSkills,
     rangerPets,
   };
 }

--- a/src/main/buildChatLink.js
+++ b/src/main/buildChatLink.js
@@ -45,10 +45,20 @@ function mapBuildToTemplateInput(build) {
     };
   };
 
-  const skills = {
-    terrestrial: mapSkillSet(build.skills),
-    aquatic: mapSkillSet(build.underwaterSkills),
-  };
+  // Revenant skill slots are determined by the active legend in-game — the
+  // legend's heal/utility/elite skill IDs are NOT part of the profession's
+  // skills_by_palette, so passing them makes gw2buildlink throw "Skill <id> is
+  // not available for profession Revenant" and no chat link is produced (#283).
+  // The legend codes (revenantLegends below) already encode the skill bar, so
+  // leave the palette slots empty for Revenant.
+  const profLower = (build.profession || "").toLowerCase();
+  const emptySkillSet = () => ({ heal: undefined, utilities: [undefined, undefined, undefined], elite: undefined });
+  const skills = profLower === "revenant"
+    ? { terrestrial: emptySkillSet(), aquatic: emptySkillSet() }
+    : {
+        terrestrial: mapSkillSet(build.skills),
+        aquatic: mapSkillSet(build.underwaterSkills),
+      };
 
   // Weapons — flatten object to array, filter empties.
   const weaponSlots = ["mainhand1", "offhand1", "mainhand2", "offhand2", "aquatic1", "aquatic2"];
@@ -63,7 +73,6 @@ function mapBuildToTemplateInput(build) {
     .filter((w) => KNOWN_WEAPONS.has(w));
 
   // Revenant legends — only for Revenant profession.
-  const profLower = (build.profession || "").toLowerCase();
   let revenantLegends;
   if (profLower === "revenant") {
     const legends = build.selectedLegends || ["", ""];

--- a/src/main/buildPublish.js
+++ b/src/main/buildPublish.js
@@ -711,6 +711,13 @@ function serializeForPublish(build, catalog, upgradeCatalog, extraCatalogs = [])
         name: legend.name || "",
         icon: swapSkill?.icon || "",
         swap: swapSkill ? { id: swapSkill.id, name: swapSkill.name, icon: swapSkill.icon } : null,
+        // Heal/utility/elite skill IDs the active legend grants. The SPA renderer
+        // builds the Revenant skill-bar options from these (skills.js reads
+        // activeLegend.heal/utilities/elite); without them the published build
+        // shows an empty skill bar (#283).
+        heal: legend.heal || 0,
+        utilities: Array.isArray(legend.utilities) ? legend.utilities : [],
+        elite: legend.elite || 0,
       };
     });
 

--- a/src/renderer/modules/skills.js
+++ b/src/renderer/modules/skills.js
@@ -538,9 +538,17 @@ export function buildMechanicSlotsForRender({
         }
         return skill;
       };
-      nextOptions.heal = [ls(activeLegend.heal)].filter(Boolean);
-      nextOptions.utility = (activeLegend.utilities || []).map(ls).filter(Boolean);
-      nextOptions.elite = [ls(activeLegend.elite)].filter(Boolean);
+      // Fall back to the saved active-legend skill IDs when the legend catalog
+      // lacks heal/utilities/elite. Published builds shared before the publish
+      // serializer carried these fields store only the swap skill per legend, so
+      // without this fallback their Revenant skill bar renders empty (#283).
+      const legendSkillSource = underwaterMode ? editor.underwaterSkills : editor.skills;
+      const fbUtilities = (activeLegend.utilities && activeLegend.utilities.length)
+        ? activeLegend.utilities
+        : (legendSkillSource?.utilityIds || []);
+      nextOptions.heal = [ls(activeLegend.heal || legendSkillSource?.healId)].filter(Boolean);
+      nextOptions.utility = fbUtilities.map(ls).filter(Boolean);
+      nextOptions.elite = [ls(activeLegend.elite || legendSkillSource?.eliteId)].filter(Boolean);
     }
   } else if (isRanger) {
     // When underwater, show aquatic pet slots instead of terrestrial

--- a/src/site/render-build.js
+++ b/src/site/render-build.js
@@ -166,9 +166,14 @@ function populateStateFromBuild(build) {
     traitById:          new Map(allTraits.map(t => [t.id, t])),
     legends:            (build.legendDisplay || []).map(l => ({
       id: l.id, name: l.name, icon: l.icon, swap: l.swap?.id || null,
+      heal: l.heal || 0, utilities: Array.isArray(l.utilities) ? l.utilities : [], elite: l.elite || 0,
     })),
+    // heal/utilities/elite drive the Revenant skill-bar options in the shared
+    // renderer (skills.js reads activeLegend.heal/utilities/elite). Without them
+    // the published build renders an empty skill bar (#283).
     legendById:         new Map((build.legendDisplay || []).map(l => [l.id, {
       id: l.id, name: l.name, icon: l.icon, swap: l.swap?.id || null,
+      heal: l.heal || 0, utilities: Array.isArray(l.utilities) ? l.utilities : [], elite: l.elite || 0,
     }])),
     pets:               (build.petDisplay || []).map(p => ({ id: p.id, name: p.name, icon: p.icon, skills: p.skills || [] })),
     petById:            new Map((build.petDisplay || []).map(p => [p.id, p])),

--- a/tests/unit/buildChatLink.test.js
+++ b/tests/unit/buildChatLink.test.js
@@ -106,16 +106,18 @@ describe("mapBuildToTemplateInput", () => {
     expect(input.revenantLegends).toBeUndefined();
   });
 
-  // Revenant skill slots are driven by the active legend in-game; the legend's
-  // heal/utility/elite skill IDs are NOT in the profession's skills_by_palette,
-  // so passing them makes gw2buildlink throw "Skill <id> is not available for
-  // profession Revenant" and no chat link is produced (issue #283).
-  it("omits heal/utility/elite skill palettes for Revenant (legends drive the bar)", () => {
+  // Revenant skill slots use a FIXED set of palette IDs; the active legend
+  // resolves the concrete skill in-game. The legend's actual skill IDs (e.g.
+  // 26937) are NOT in the profession's skills_by_palette, so passing them made
+  // gw2buildlink throw and produce no link; leaving them empty dropped the
+  // skills from the imported build — both were issue #283.
+  it("uses fixed legend palette IDs for Revenant terrestrial skills", () => {
     const build = {
       ...baseBuild,
       profession: "Revenant",
       selectedLegends: ["Legend2", "Legend3"],
-      // Legend skills synced into the selection — must not reach the encoder.
+      selectedUnderwaterLegends: ["", ""],
+      // Legend skill IDs synced into the selection — must NOT reach the encoder.
       skills: {
         heal: { id: 26937 },
         utility: [{ id: 29209 }, { id: 28231 }, { id: 27107 }],
@@ -125,16 +127,39 @@ describe("mapBuildToTemplateInput", () => {
     };
     const input = mapBuildToTemplateInput(build);
     expect(input.revenantLegends).toEqual([2, 3, undefined, undefined]);
+    // Fixed Revenant palettes (heal 4572, utilities 4564/4614/4651, elite 4554).
     expect(input.skills.terrestrial).toEqual({
-      heal: undefined,
-      utilities: [undefined, undefined, undefined],
-      elite: undefined,
+      heal: 4572,
+      utilities: [4564, 4614, 4651],
+      elite: 4554,
     });
+    // No aquatic legend → aquatic slots stay empty.
     expect(input.skills.aquatic).toEqual({
       heal: undefined,
       utilities: [undefined, undefined, undefined],
       elite: undefined,
     });
+    // Second terrestrial legend present → its inactive utility palettes are set;
+    // no aquatic legends → aquatic inactive slots stay empty.
+    expect(input.revenantInactiveSkills).toEqual([4564, 4614, 4651, undefined, undefined, undefined]);
+  });
+
+  it("fills aquatic Revenant palettes when an underwater legend is slotted", () => {
+    const build = {
+      ...baseBuild,
+      profession: "Revenant",
+      selectedLegends: ["Legend2", ""],
+      selectedUnderwaterLegends: ["Legend3", ""],
+      skills: { heal: { id: 26937 }, utility: [], elite: null },
+      underwaterSkills: { heal: { id: 26974 }, utility: [], elite: null },
+    };
+    const input = mapBuildToTemplateInput(build);
+    expect(input.skills.aquatic).toEqual({
+      heal: 4572,
+      utilities: [4564, 4614, 4651],
+      elite: 4554,
+    });
+    expect(input.revenantInactiveSkills).toEqual([undefined, undefined, undefined, undefined, undefined, undefined]);
   });
 
   it("still maps heal/utility/elite skills for non-Revenant professions", () => {

--- a/tests/unit/buildChatLink.test.js
+++ b/tests/unit/buildChatLink.test.js
@@ -106,6 +106,44 @@ describe("mapBuildToTemplateInput", () => {
     expect(input.revenantLegends).toBeUndefined();
   });
 
+  // Revenant skill slots are driven by the active legend in-game; the legend's
+  // heal/utility/elite skill IDs are NOT in the profession's skills_by_palette,
+  // so passing them makes gw2buildlink throw "Skill <id> is not available for
+  // profession Revenant" and no chat link is produced (issue #283).
+  it("omits heal/utility/elite skill palettes for Revenant (legends drive the bar)", () => {
+    const build = {
+      ...baseBuild,
+      profession: "Revenant",
+      selectedLegends: ["Legend2", "Legend3"],
+      // Legend skills synced into the selection — must not reach the encoder.
+      skills: {
+        heal: { id: 26937 },
+        utility: [{ id: 29209 }, { id: 28231 }, { id: 27107 }],
+        elite: { id: 28406 },
+      },
+      underwaterSkills: { heal: { id: 26937 }, utility: [], elite: null },
+    };
+    const input = mapBuildToTemplateInput(build);
+    expect(input.revenantLegends).toEqual([2, 3, undefined, undefined]);
+    expect(input.skills.terrestrial).toEqual({
+      heal: undefined,
+      utilities: [undefined, undefined, undefined],
+      elite: undefined,
+    });
+    expect(input.skills.aquatic).toEqual({
+      heal: undefined,
+      utilities: [undefined, undefined, undefined],
+      elite: undefined,
+    });
+  });
+
+  it("still maps heal/utility/elite skills for non-Revenant professions", () => {
+    const input = mapBuildToTemplateInput(baseBuild);
+    expect(input.skills.terrestrial.heal).toBe(9083);
+    expect(input.skills.terrestrial.utilities).toEqual([9093, 9150, 9153]);
+    expect(input.skills.terrestrial.elite).toBe(30461);
+  });
+
   it("maps ranger pets", () => {
     const build = {
       ...baseBuild,

--- a/tests/unit/buildPublish.test.js
+++ b/tests/unit/buildPublish.test.js
@@ -508,6 +508,61 @@ describe("serializeForPublish", () => {
   });
 });
 
+// ── Revenant legend display ─────────────────────────────────────────────────
+
+describe("serializeForPublish — Revenant legendDisplay", () => {
+  // The published SPA derives the Revenant heal/utility/elite skill bar from the
+  // legend's heal/utilities/elite skill IDs (skills.js builds the slot options
+  // from activeLegend.heal/utilities/elite). If legendDisplay omits those IDs,
+  // the published build shows no skills (issue #283).
+  function makeRevenantBuild() {
+    return {
+      title: "Power Herald",
+      profession: "Revenant",
+      specializations: [],
+      skills: {
+        heal: { id: 26937, name: "Enchanted Daggers", icon: "ed.png" },
+        utility: [{ id: 29209 }, { id: 28231 }, { id: 27107 }],
+        elite: { id: 28406, name: "Jade Winds", icon: "jw.png" },
+      },
+      equipment: { weapons: {}, runes: {}, sigils: {}, slots: {}, infusions: {} },
+      gameMode: "pve",
+      selectedLegends: ["Legend2", "Legend3"],
+      selectedPets: { terrestrial1: 0, terrestrial2: 0, aquatic1: 0, aquatic2: 0 },
+    };
+  }
+
+  function makeRevenantCatalog() {
+    return {
+      professionWeapons: {},
+      weaponSkills: [],
+      skills: [
+        { id: 28134, name: "Legendary Assassin Stance", icon: "shiro.png" },
+        { id: 28419, name: "Legendary Dwarf Stance", icon: "jalis.png" },
+      ],
+      legends: [
+        { id: "Legend2", swap: 28134, heal: 26937, utilities: [29209, 28231, 27107], elite: 28406 },
+        { id: "Legend3", swap: 28419, heal: 26974, utilities: [28379, 29148, 28231], elite: 28287 },
+      ],
+      pets: [],
+      specializations: [],
+    };
+  }
+
+  test("legendDisplay carries heal/utilities/elite skill IDs so the SPA can render the bar", () => {
+    const result = serializeForPublish(makeRevenantBuild(), makeRevenantCatalog(), null);
+    expect(result.legendDisplay).toHaveLength(2);
+    const shiro = result.legendDisplay.find(l => l.id === "Legend2");
+    expect(shiro.heal).toBe(26937);
+    expect(shiro.utilities).toEqual([29209, 28231, 27107]);
+    expect(shiro.elite).toBe(28406);
+    const jalis = result.legendDisplay.find(l => l.id === "Legend3");
+    expect(jalis.heal).toBe(26974);
+    expect(jalis.utilities).toEqual([28379, 29148, 28231]);
+    expect(jalis.elite).toBe(28287);
+  });
+});
+
 // ── _traitChoices resolution and spec enrichment ────────────────────────────
 
 describe("serializeForPublish — axicode _traitChoices resolution", () => {

--- a/tests/unit/renderer/revenant.test.js
+++ b/tests/unit/renderer/revenant.test.js
@@ -33,6 +33,78 @@ describe("renderer Revenant mechanics — Alliance Tactics fallback", () => {
   });
 });
 
+describe("renderer Revenant skill options — published-build legend fallback (#283)", () => {
+  const { buildMechanicSlotsForRender } = require("../../../src/renderer/modules/skills");
+
+  // A published build shared before the publish serializer carried legend
+  // heal/utilities/elite stores only { id, swap } per legend. Without a fallback
+  // to the saved skill IDs, the Revenant skill bar renders no heal/utility/elite.
+  const healSkill = { id: 26937, name: "Enchanted Daggers", icon: "ed.png", slot: "Heal" };
+  const util1 = { id: 29209, name: "Riposting Shadows", icon: "rs.png", slot: "Utility" };
+  const util2 = { id: 28231, name: "Phase Traversal", icon: "pt.png", slot: "Utility" };
+  const util3 = { id: 27107, name: "Impossible Odds", icon: "io.png", slot: "Utility" };
+  const eliteSkill = { id: 28406, name: "Jade Winds", icon: "jw.png", slot: "Elite" };
+  const swapSkill = { id: 28134, name: "Legendary Assassin Stance", icon: "shiro.png" };
+  const allSkills = [healSkill, util1, util2, util3, eliteSkill, swapSkill];
+
+  function makeCatalog(legend) {
+    return {
+      skills: allSkills,
+      legends: [legend],
+      legendById: new Map([[legend.id, legend]]),
+      skillById: new Map(allSkills.map((s) => [s.id, s])),
+      specializationById: new Map(),
+    };
+  }
+
+  function makeEditor() {
+    return {
+      profession: "Revenant",
+      specializations: [],
+      skills: { healId: 26937, utilityIds: [29209, 28231, 27107], eliteId: 28406 },
+      selectedLegends: ["Legend2", "Legend3"],
+      activeLegendSlot: 0,
+      allianceTacticsForm: 0,
+      equipment: { weapons: {} },
+    };
+  }
+
+  function resolveOptions(legend) {
+    const catalog = makeCatalog(legend);
+    const editor = makeEditor();
+    return buildMechanicSlotsForRender({
+      catalog,
+      options: { heal: [], utility: [], elite: [], profession: [] },
+      editor,
+      utilitySelection: editor.skills.utilityIds,
+      equippedWeapons: {},
+      mhKey: "mainhand1",
+      ohKey: "offhand1",
+      activeAttunement: "Fire",
+      activeKit: 0,
+      underwaterMode: false,
+    }).options;
+  }
+
+  test("falls back to saved skill IDs when the legend lacks heal/utilities/elite", () => {
+    // Old published build: legend only has id + swap.
+    const opts = resolveOptions({ id: "Legend2", swap: 28134 });
+    expect(opts.heal.map((s) => s.id)).toEqual([26937]);
+    expect(opts.utility.map((s) => s.id)).toEqual([29209, 28231, 27107]);
+    expect(opts.elite.map((s) => s.id)).toEqual([28406]);
+  });
+
+  test("uses the legend's own skills when present (newly published builds)", () => {
+    const opts = resolveOptions({
+      id: "Legend2", swap: 28134,
+      heal: 26937, utilities: [29209, 28231, 27107], elite: 28406,
+    });
+    expect(opts.heal.map((s) => s.id)).toEqual([26937]);
+    expect(opts.utility.map((s) => s.id)).toEqual([29209, 28231, 27107]);
+    expect(opts.elite.map((s) => s.id)).toEqual([28406]);
+  });
+});
+
 createMechanicsSuite("Revenant", [
   { specId: 0, expected: [] },
   { specId: 52, expected: [] },


### PR DESCRIPTION
## Summary

Two Revenant-specific failures reported from Discord (#283), both root-caused and fixed:

**1. Chatlink generation produced no usable link.** `mapBuildToTemplateInput` passed the active legend's actual skill IDs (e.g. Enchanted Daggers `26937`) into the encoder. GW2's API never maps legend skills into Revenant's `skills_by_palette`, so gw2buildlink threw `Skill 26937 is not available for profession Revenant`. Revenant instead encodes a **fixed set of palette IDs** — heal `4572`, utilities `4564/4614/4651`, elite `4554` — and the *active legend* resolves which concrete skill each palette shows in-game (per the [GW2 wiki skill palette table](https://wiki.guildwars2.com/wiki/Chat_link_format/skill_palette_table)). The fix emits those palettes for each environment that has an active legend, plus the inactive legend's utility palettes in the profession-specific bytes so utilities keep order across a legend swap. Verified the original failing build now encodes to a valid chat link with populated skill bytes.

**2. Skills didn't show on the published build.** The shared renderer builds the Revenant heal/utility/elite slot options from `activeLegend.heal/utilities/elite` (`skills.js`), but the publish serializer only stored `{ id, name, icon, swap }` per legend — so on the SPA those fields were `undefined`, the option lists were empty, and the skill bar rendered blank. Fix carries the legend's `heal/utilities/elite` skill IDs through `serializeForPublish` and into the SPA legend catalog (`render-build.js`), with a renderer fallback to the saved skill IDs so builds **already shared** before this fix still render once the site is redeployed.

## Deploy note
The published-build half requires **redeploying the SPA site** (`render-build.js` + `skills.js` are part of the static bundle). The published `.enc` data is already correct; the live site just needs the updated renderer.

## Tests
- `buildChatLink.test.js` — Revenant emits fixed legend palettes (terrestrial + aquatic) and inactive-legend utility palettes; non-Revenant unchanged.
- `buildPublish.test.js` — `legendDisplay` carries heal/utilities/elite.
- `renderer/revenant.test.js` — published-build legend fallback + new-build path.
- Full suite: 1971 passing.

Closes #283