### PR TITLE
fix(publish): published stats now match the game/app (engine-backed)

### DIFF
--- a/src/main/buildPublish.js
+++ b/src/main/buildPublish.js
@@ -723,8 +723,18 @@ function serializeForPublish(build, catalog, upgradeCatalog, extraCatalogs = [])
 
   const equipmentDisplay = resolveEquipmentDisplay(build.equipment, upgradeCatalog);
   const equipmentIcons = resolveEquipmentIcons(build);
+  // Pass full build context so the engine applies trait flat bonuses/conversions
+  // and excludes the inactive weapon set — matching the in-app Attributes panel.
+  const specializationById = new Map((catalog?.specializations || []).map(s => [s.id, s]));
   const { stats: computedStats, modifiers: statModifiers } = computePublishStats(
-    build.equipment, upgradeCatalog, build.profession, build.gameMode
+    build.equipment, upgradeCatalog, build.profession, build.gameMode,
+    {
+      specializations: enrichedSpecializations,
+      skills: enrichedSkills,
+      activeCatalog: { traitById, skillById, specializationById },
+      underwaterMode: build.underwaterMode,
+      activeWeaponSet: build.activeWeaponSet,
+    }
   );
 
   // Normalize generic @[item:id:name] → @[rune:id:name] etc. before publish

--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -1,7 +1,17 @@
 "use strict";
 
-// Embed static constants
-// For 4-stat combos: first 2 stats are major (0.3 multiplier), last 2 are minor (0.165 multiplier)
+// Published-build stat computation. Delegates to the shared @axiapps/gw2-data
+// engine so the published page matches the in-app Attributes panel exactly —
+// the renderer uses the same engine via engine-bridge.js. A previous hand-rolled
+// reimplementation here diverged from the engine (it double-counted the inactive
+// weapon set, skipped trait flat bonuses/conversions, and double-counted base
+// Vitality in Health), causing published pages to disagree with the game/app.
+const { computeAttributes } = require("@axiapps/gw2-data/engine");
+
+// ---------------------------------------------------------------------------
+// Stat combos + slot weights — retained ONLY for the lightweight estimateRole()
+// heuristic below. The authoritative stat math lives in the engine.
+// For 4-stat combos: first 2 stats are major (p4), last 2 are minor (s4).
 const _STAT_COMBOS_ENTRIES = [
   ["Berserker's", { stats: ["Power", "Precision", "Ferocity"] }],
   ["Marauder's", { stats: ["Power", "Precision", "Vitality", "Ferocity"] }],
@@ -55,9 +65,7 @@ const STAT_COMBOS_BY_LABEL = new Map(
   })
 );
 
-// Ascended/Legendary stat weights per slot.
-// p/s = 3-stat major/minor; p4/s4 = 4-stat major/minor; c = Celestial per-stat.
-// Derived from GW2 API attribute_adjustment × stat multipliers (0.35/0.25/0.3/0.165).
+// Ascended/Legendary stat weights per slot (estimateRole heuristic only).
 const SLOT_WEIGHTS = {
   head:       { p: 63,  s: 45,  p4: 54,  s4: 30, c: 30 },
   shoulders:  { p: 47,  s: 34,  p4: 40,  s4: 22, c: 22 },
@@ -83,207 +91,114 @@ const TWO_HAND_WEAPON_IDS = new Set([
   "greatsword", "hammer", "longbow", "rifle", "shortbow", "staff", "spear",
 ]);
 
-// Base HP at level 80 EXCLUDING the base-Vitality contribution.
-// Health = baseHP + Vitality * 10, where base Vitality (1000) already accounts
-// for 10,000 HP that IS NOT in these numbers. Using the full in-game base HP here
-// (e.g. 19212) would double-count those 10,000 HP. Keep in sync with the renderer's
-// PROFESSION_BASE_HP in src/renderer/modules/constants.js (the source of truth),
-// including elite-spec keys since build.profession may be an elite-spec name.
-// High (9212): Warrior, Necromancer → 9212 + 10000 = 19212
-// Medium (5922): Revenant, Engineer, Ranger, Mesmer → 5922 + 10000 = 15922
-// Low (1645): Guardian, Thief, Elementalist → 1645 + 10000 = 11645
-const PROFESSION_BASE_HP = {
-  Warrior: 9212, Berserker: 9212, Spellbreaker: 9212, Bladesworn: 9212, Paragon: 9212,
-  Necromancer: 9212, Reaper: 9212, Scourge: 9212, Harbinger: 9212,
-  Revenant: 5922, Herald: 5922, Renegade: 5922, Vindicator: 5922,
-  Engineer: 5922, Scrapper: 5922, Holosmith: 5922, Mechanist: 5922,
-  Ranger: 5922, Druid: 5922, Soulbeast: 5922, Untamed: 5922,
-  Mesmer: 5922, Chronomancer: 5922, Mirage: 5922, Virtuoso: 5922,
-  Guardian: 1645, Dragonhunter: 1645, Firebrand: 1645, Willbender: 1645,
-  Thief: 1645, Daredevil: 1645, Deadeye: 1645, Specter: 1645, Antiquary: 1645,
-  Elementalist: 1645, Tempest: 1645, Weaver: 1645, Catalyst: 1645,
-};
-
-// In WvW, Celestial gear does not grant Expertise or Concentration.
-const _WVW_CELESTIAL_EXCLUDED = new Set(["Expertise", "Concentration"]);
-function _getEffectiveStats(comboLabel, combo, gameMode) {
-  if (gameMode === "wvw" && comboLabel === "Celestial") {
-    return combo.stats.filter((s) => !_WVW_CELESTIAL_EXCLUDED.has(s));
-  }
-  return combo.stats;
+// ---------------------------------------------------------------------------
+// Build the engine's `catalogs` shape from the publish-side catalogs.
+// activeCatalog (profession catalog) supplies trait/skill/spec maps; the
+// upgradeCatalog supplies rune/food/utility/infusion/enrichment maps.
+// ---------------------------------------------------------------------------
+function _buildEngineCatalogs(upgradeCatalog, activeCatalog) {
+  return {
+    traitById: activeCatalog?.traitById || new Map(),
+    skillById: activeCatalog?.skillById || new Map(),
+    specializationById: activeCatalog?.specializationById || new Map(),
+    runeById: upgradeCatalog?.runeById || new Map(),
+    foodById: upgradeCatalog?.foodById || new Map(),
+    utilityById: upgradeCatalog?.utilityById || new Map(),
+    infusionById: upgradeCatalog?.infusionById || new Map(),
+    enrichmentById: upgradeCatalog?.enrichmentById || new Map(),
+  };
 }
 
-function computePublishStats(equipment, upgradeCatalog, profession, gameMode) {
+// Map a published skill selection ({ heal, utility:[], elite } of refs/ids) into
+// the engine's ctx.skills shape ({ healId, utilityIds:[], eliteId }) so equipped
+// signets contribute their passive stat buffs. Tolerates plain ids or {id} refs.
+function _toEngineSkills(skills) {
+  if (!skills) return { healId: 0, utilityIds: [], eliteId: 0 };
+  // Already in engine shape.
+  if ("healId" in skills || "utilityIds" in skills || "eliteId" in skills) {
+    return {
+      healId: Number(skills.healId) || 0,
+      utilityIds: (skills.utilityIds || []).map((x) => Number(x) || 0),
+      eliteId: Number(skills.eliteId) || 0,
+    };
+  }
+  const idOf = (ref) => (ref && typeof ref === "object" ? Number(ref.id) : Number(ref)) || 0;
+  return {
+    healId: idOf(skills.heal),
+    utilityIds: (Array.isArray(skills.utility) ? skills.utility : []).map(idOf),
+    eliteId: idOf(skills.elite),
+  };
+}
+
+/**
+ * Compute the stat block embedded in a published build.
+ *
+ * @param {object|null} equipment - build.equipment
+ * @param {object|null} upgradeCatalog - rune/food/utility/infusion/enrichment maps
+ * @param {string} profession - build.profession (may be an elite-spec name)
+ * @param {string} gameMode - "pve" | "wvw" | "pvp"
+ * @param {object} [opts] - additional context so traits/conversions apply:
+ *   { specializations, skills, activeCatalog, underwaterMode, activeWeaponSet }
+ * @returns {{ stats: object, modifiers: array }}
+ *
+ * Published pages show the unbuffed baseline (assumed boons/sigil stacks are not
+ * persisted), which matches the app's default Attributes panel.
+ */
+function computePublishStats(equipment, upgradeCatalog, profession, gameMode, opts = {}) {
   if (!equipment) return { stats: {}, modifiers: [] };
 
-  const gm = gameMode || "pve";
-  const slots = equipment.slots || {};
-  const totals = {
-    Power: 1000, Precision: 1000, Toughness: 1000, Vitality: 1000,
-    Ferocity: 0, ConditionDamage: 0, Expertise: 0, Concentration: 0, HealingPower: 0,
+  const ctx = {
+    profession: profession || "",
+    gameMode: gameMode || "pve",
+    underwaterMode: Boolean(opts.underwaterMode),
+    activeWeaponSet: Number(opts.activeWeaponSet) || 1,
+    specializations: (opts.specializations || []).map((s) => ({
+      id: s?.specializationId || s?.id,
+      specializationId: s?.specializationId,
+      majorChoices: s?.majorChoices || {},
+      minorTraits: s?.minorTraits,
+    })),
+    equipment: {
+      slots: equipment.slots || {},
+      weapons: equipment.weapons || {},
+      runes: equipment.runes || {},
+      sigils: equipment.sigils || {},
+      infusions: equipment.infusions || {},
+      enrichment: equipment.enrichment ? Number(equipment.enrichment) : null,
+      food: equipment.food ? Number(equipment.food) : null,
+      utility: equipment.utility ? Number(equipment.utility) : null,
+    },
+    skills: _toEngineSkills(opts.skills),
+    // Static baseline — no assumed boons / sigil stacks / signet actives.
+    assumedBoons: null,
+    sigilStacks: null,
+    activeSignets: null,
+    berserkActive: false,
   };
 
-  // Equipment slot contributions
-  const weapons = equipment.weapons || {};
-  for (const [slotKey, comboLabel] of Object.entries(slots)) {
-    if (!comboLabel) continue;
-    const combo = STAT_COMBOS_BY_LABEL.get(comboLabel);
-    let w = SLOT_WEIGHTS[slotKey];
-    if (!combo || !w) continue;
-    // Use 2h weights when a two-handed weapon is equipped in a mainhand slot
-    if (slotKey.startsWith("mainhand") && TWO_HAND_WEAPON_IDS.has(weapons[slotKey])) {
-      w = TWO_HAND_WEIGHTS;
-    }
-    const stats = _getEffectiveStats(comboLabel, combo, gm);
-    const n = stats.length;
-    if (n <= 3) {
-      totals[stats[0]] = (totals[stats[0]] || 0) + w.p;
-      for (let i = 1; i < n; i++) totals[stats[i]] = (totals[stats[i]] || 0) + w.s;
-    } else if (n === 4) {
-      // 2-2 pattern: first 2 stats are major, last 2 are minor
-      totals[stats[0]] = (totals[stats[0]] || 0) + w.p4;
-      totals[stats[1]] = (totals[stats[1]] || 0) + w.p4;
-      totals[stats[2]] = (totals[stats[2]] || 0) + w.s4;
-      totals[stats[3]] = (totals[stats[3]] || 0) + w.s4;
-    } else {
-      for (const stat of stats) totals[stat] = (totals[stat] || 0) + w.c;
-    }
-  }
-
-  // Food flat stat contributions
-  if (equipment.food && upgradeCatalog) {
-    const foodDef = upgradeCatalog.foodById?.get(Number(equipment.food));
-    if (foodDef) {
-      const foodStatMap = { "Condition Damage": "ConditionDamage", "Healing Power": "HealingPower", "Healing": "HealingPower" };
-      const ALL_STAT_KEYS = ["Power", "Precision", "Toughness", "Vitality", "Ferocity", "ConditionDamage", "HealingPower", "Concentration", "Expertise"];
-      const re = /\+(\d+)\s+(Condition Damage|Healing Power|Healing|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise|to All Attributes)/g;
-      let m;
-      while ((m = re.exec(foodDef.buff)) !== null) {
-        if (m[2] === "to All Attributes") {
-          for (const key of ALL_STAT_KEYS) totals[key] += Number(m[1]);
-        } else {
-          const key = foodStatMap[m[2]] || m[2];
-          if (totals[key] !== undefined) totals[key] += Number(m[1]);
-        }
-      }
-    }
-  }
-
-  // Infusion/enrichment stat contributions (via infix_upgrade.attributes)
-  if (upgradeCatalog) {
-    const toStatKey = (attr) => attr === "Healing" ? "HealingPower" : attr === "BoonDuration" ? "Concentration" : attr === "ConditionDuration" ? "Expertise" : attr;
-    const addInfixAttributes = (infixUpgrade) => {
-      if (!infixUpgrade?.attributes) return;
-      for (const attr of infixUpgrade.attributes) {
-        const key = toStatKey(attr.attribute);
-        if (totals[key] !== undefined) totals[key] += attr.modifier || 0;
-      }
-    };
-
-    // Infusions — cap mainhand weapon slots to 1 infusion for 1H weapons (issue #201)
-    const infusions = equipment.infusions || {};
-    for (const [slotKey, v] of Object.entries(infusions)) {
-      const ids = Array.isArray(v) ? v : [v];
-      let maxSlots = ids.length;
-      if (slotKey.startsWith("mainhand")) {
-        const weaponType = weapons[slotKey] || "";
-        if (weaponType && !TWO_HAND_WEAPON_IDS.has(weaponType)) maxSlots = 1;
-      }
-      const limit = Math.min(ids.length, maxSlots);
-      for (let i = 0; i < limit; i++) {
-        const id = ids[i];
-        if (!id) continue;
-        const def = upgradeCatalog.infusionById?.get(Number(id));
-        if (def) addInfixAttributes(def.infixUpgrade);
-      }
-    }
-    // Enrichment
-    if (equipment.enrichment) {
-      const def = upgradeCatalog.enrichmentById?.get(Number(equipment.enrichment));
-      if (def) addInfixAttributes(def.infixUpgrade);
-    }
-    // Rune bonuses
-    const runes = equipment.runes || {};
-    const runeCounts = new Map();
-    for (const id of Object.values(runes)) {
-      if (!id) continue;
-      runeCounts.set(String(id), (runeCounts.get(String(id)) || 0) + 1);
-    }
-    const RUNE_STAT_MAP = { "Power": "Power", "Precision": "Precision", "Toughness": "Toughness", "Vitality": "Vitality", "Ferocity": "Ferocity", "Concentration": "Concentration", "Expertise": "Expertise", "Condition Damage": "ConditionDamage", "Healing Power": "HealingPower", "Healing": "HealingPower" };
-    const ALL_STAT_KEYS = ["Power", "Precision", "Toughness", "Vitality", "Ferocity", "ConditionDamage", "HealingPower", "Concentration", "Expertise"];
-    const RUNE_RE = /\+(\d+)\s+(Condition Damage|Healing Power|Healing|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise|to All Stats)/;
-    for (const [runeId, count] of runeCounts) {
-      const runeDef = upgradeCatalog.runeById?.get(Number(runeId));
-      if (!runeDef?.bonuses?.length) continue;
-      for (const bonus of runeDef.bonuses.slice(0, Math.min(count, 6))) {
-        const m = RUNE_RE.exec(bonus);
-        if (!m) continue;
-        const value = Number(m[1]);
-        if (m[2] === "to All Stats") {
-          for (const key of ALL_STAT_KEYS) totals[key] += value;
-        } else {
-          const key = RUNE_STAT_MAP[m[2]];
-          if (key && totals[key] !== undefined) totals[key] += value;
-        }
-      }
-    }
-  }
-
-  // Utility consumable contributions
-  if (equipment.utility && upgradeCatalog) {
-    const utilDef = upgradeCatalog.utilityById?.get(Number(equipment.utility));
-    if (utilDef) {
-      const UTIL_MAP = { "Power": "Power", "Precision": "Precision", "Toughness": "Toughness", "Vitality": "Vitality", "Ferocity": "Ferocity", "Concentration": "Concentration", "Expertise": "Expertise", "Condition Damage": "ConditionDamage", "Healing Power": "HealingPower" };
-      // Pattern 1: conversion — snapshot source values so multiple conversions in the
-      // same buff don't cross-contaminate (e.g. A→B and B→A would inflate results).
-      const convBase = { ...totals };
-      const convRe = /Gain (Condition Damage|Healing Power|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise) Equal to (\d+(?:\.\d+)?)% of Your (Condition Damage|Healing Power|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise)/g;
-      let m;
-      while ((m = convRe.exec(utilDef.buff)) !== null) {
-        const targetKey = UTIL_MAP[m[1]];
-        const pct = Number(m[2]) / 100;
-        const sourceKey = UTIL_MAP[m[3]];
-        if (targetKey && sourceKey && convBase[sourceKey] !== undefined) {
-          totals[targetKey] = (totals[targetKey] || 0) + Math.round(convBase[sourceKey] * pct);
-        }
-      }
-      // Pattern 2: conditional flat (writs)
-      const writRe = /Gain (\d+) (Condition Damage|Healing Power|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise) When Health/g;
-      while ((m = writRe.exec(utilDef.buff)) !== null) {
-        const key = UTIL_MAP[m[2]];
-        if (key) totals[key] = (totals[key] || 0) + Number(m[1]);
-      }
-      // Pattern 3: flat bonuses
-      const flatRe = /\+(\d+)\s+(Condition Damage|Healing Power|Power|Precision|Toughness|Vitality|Ferocity|Concentration|Expertise)/g;
-      while ((m = flatRe.exec(utilDef.buff)) !== null) {
-        const key = UTIL_MAP[m[2]];
-        if (key) totals[key] = (totals[key] || 0) + Number(m[1]);
-      }
-    }
-  }
-
-  // Derived stats
-  const baseHP = PROFESSION_BASE_HP[profession] || 9212;
-  const health = baseHP + totals.Vitality * 10;
-  const critChance = ((totals.Precision - 1000) / 21 + 5).toFixed(2) + "%";
-  const critDamage = (150 + totals.Ferocity / 15).toFixed(1) + "%";
-  const boonDuration = (totals.Concentration / 15).toFixed(1) + "%";
-  const condDuration = (totals.Expertise / 15).toFixed(1) + "%";
+  const catalogs = _buildEngineCatalogs(upgradeCatalog, opts.activeCatalog);
+  const eng = computeAttributes(ctx, catalogs);
+  const t = eng.total;
+  const d = eng.derived;
 
   const stats = {
-    ...totals,
-    Health: health,
-    CritChance: critChance,
-    CritDamage: critDamage,
-    BoonDuration: boonDuration,
-    ConditionDuration: condDuration,
+    Power: t.Power,
+    Precision: t.Precision,
+    Toughness: t.Toughness,
+    Vitality: t.Vitality,
+    Ferocity: t.Ferocity,
+    ConditionDamage: t.ConditionDamage,
+    Expertise: t.Expertise,
+    Concentration: t.Concentration,
+    HealingPower: t.HealingPower,
+    Health: d.health,
+    CritChance: d.critChance.toFixed(2) + "%",
+    CritDamage: d.critDamage.toFixed(1) + "%",
+    BoonDuration: d.boonDuration.toFixed(1) + "%",
+    ConditionDuration: d.conditionDuration.toFixed(1) + "%",
   };
 
-  // Collect modifier text lines (non-stat buffs from upgrades)
-  const modifiers = [];
-  // TODO: parse modifier lines from rune/sigil/food buff text if needed
-
-  return { stats, modifiers };
+  return { stats, modifiers: [] };
 }
 
 // ── Lightweight role estimation (mirrors renderer roleEstimator.js) ──────────

--- a/src/main/statsCompute.js
+++ b/src/main/statsCompute.js
@@ -83,10 +83,25 @@ const TWO_HAND_WEAPON_IDS = new Set([
   "greatsword", "hammer", "longbow", "rifle", "shortbow", "staff", "spear",
 ]);
 
+// Base HP at level 80 EXCLUDING the base-Vitality contribution.
+// Health = baseHP + Vitality * 10, where base Vitality (1000) already accounts
+// for 10,000 HP that IS NOT in these numbers. Using the full in-game base HP here
+// (e.g. 19212) would double-count those 10,000 HP. Keep in sync with the renderer's
+// PROFESSION_BASE_HP in src/renderer/modules/constants.js (the source of truth),
+// including elite-spec keys since build.profession may be an elite-spec name.
+// High (9212): Warrior, Necromancer → 9212 + 10000 = 19212
+// Medium (5922): Revenant, Engineer, Ranger, Mesmer → 5922 + 10000 = 15922
+// Low (1645): Guardian, Thief, Elementalist → 1645 + 10000 = 11645
 const PROFESSION_BASE_HP = {
-  Warrior: 19212, Necromancer: 19212, Revenant: 15922,
-  Engineer: 15922, Ranger: 15922, Mesmer: 15922,
-  Guardian: 11645, Thief: 11645, Elementalist: 11645,
+  Warrior: 9212, Berserker: 9212, Spellbreaker: 9212, Bladesworn: 9212, Paragon: 9212,
+  Necromancer: 9212, Reaper: 9212, Scourge: 9212, Harbinger: 9212,
+  Revenant: 5922, Herald: 5922, Renegade: 5922, Vindicator: 5922,
+  Engineer: 5922, Scrapper: 5922, Holosmith: 5922, Mechanist: 5922,
+  Ranger: 5922, Druid: 5922, Soulbeast: 5922, Untamed: 5922,
+  Mesmer: 5922, Chronomancer: 5922, Mirage: 5922, Virtuoso: 5922,
+  Guardian: 1645, Dragonhunter: 1645, Firebrand: 1645, Willbender: 1645,
+  Thief: 1645, Daredevil: 1645, Deadeye: 1645, Specter: 1645, Antiquary: 1645,
+  Elementalist: 1645, Tempest: 1645, Weaver: 1645, Catalyst: 1645,
 };
 
 // In WvW, Celestial gear does not grant Expertise or Concentration.
@@ -248,7 +263,7 @@ function computePublishStats(equipment, upgradeCatalog, profession, gameMode) {
   }
 
   // Derived stats
-  const baseHP = PROFESSION_BASE_HP[profession] || 11645;
+  const baseHP = PROFESSION_BASE_HP[profession] || 9212;
   const health = baseHP + totals.Vitality * 10;
   const critChance = ((totals.Precision - 1000) / 21 + 5).toFixed(2) + "%";
   const critDamage = (150 + totals.Ferocity / 15).toFixed(1) + "%";

--- a/tests/unit/statsCompute.test.js
+++ b/tests/unit/statsCompute.test.js
@@ -24,22 +24,42 @@ describe("computePublishStats", () => {
     expect(result.modifiers).toEqual([]);
   });
 
+  // NOTE: the fixture fills BOTH weapon sets, but only the active set (set 1)
+  // contributes — the engine excludes mainhand2/offhand2, matching the in-game
+  // stat panel. So totals reflect 14 contributing slots (2 weapon slots, not 4).
   test("full Berserker's gear: Power total", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Necromancer");
-    // Base 1000 + all slot primary contributions (ascended weights)
-    expect(result.stats.Power).toBe(2631);
+    // Base 1000 + primary (p) contributions across active slots = 1381
+    expect(result.stats.Power).toBe(2381);
   });
 
   test("full Berserker's gear: Precision total", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Necromancer");
-    // Base 1000 + all slot secondary contributions (ascended weights)
-    expect(result.stats.Precision).toBe(2141);
+    // Base 1000 + secondary (s) contributions across active slots = 961
+    expect(result.stats.Precision).toBe(1961);
   });
 
   test("full Berserker's gear: Ferocity total", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Necromancer");
-    // Base 0 + all slot secondary contributions (ascended weights)
-    expect(result.stats.Ferocity).toBe(1141);
+    // Base 0 + secondary (s) contributions across active slots = 961
+    expect(result.stats.Ferocity).toBe(961);
+  });
+
+  test("inactive weapon set is excluded (only the active set contributes)", () => {
+    // Set 1 = Berserker's sword/dagger, Set 2 = a Vitality set; with activeWeaponSet 1
+    // the set-2 stats must NOT appear.
+    const equipment = {
+      slots: { mainhand1: "Berserker's", offhand1: "Berserker's", mainhand2: "Soldier's", offhand2: "Soldier's" },
+      runes: {}, infusions: {},
+    };
+    const set1Only = computePublishStats(equipment, null, "Necromancer", "pve", { activeWeaponSet: 1 });
+    // Soldier's grants Vitality; if set 2 leaked in, Vitality would exceed base 1000.
+    expect(set1Only.stats.Vitality).toBe(1000);
+    expect(set1Only.stats.Ferocity).toBe(90 + 90); // both set-1 Berserker's weapons (s)
+    // Switching to set 2 swaps which weapons contribute.
+    const set2Only = computePublishStats(equipment, null, "Necromancer", "pve", { activeWeaponSet: 2 });
+    expect(set2Only.stats.Vitality).toBe(1000 + 90 + 90); // Soldier's Vitality (s) from both set-2 weapons
+    expect(set2Only.stats.Ferocity).toBe(0);
   });
 
   test("full Berserker's gear: Vitality stays at base (no Vitality in Berserker's)", () => {
@@ -72,16 +92,40 @@ describe("computePublishStats", () => {
     expect(result.stats.Health).toBe(1645 + 1000 * 10);
   });
 
+  test("trait conversions flow through to published stats (the Discord condi gap)", () => {
+    // A trait that converts 10% of Vitality into Condition Damage. The old publish
+    // path ignored traits entirely, so published condi stats were under-reported
+    // versus the in-app panel / game. Now they must be included.
+    const activeCatalog = {
+      traitById: new Map([[500, {
+        id: 500, name: "Test Conversion",
+        facts: [{ type: "BuffConversion", source: "Vitality", target: "ConditionDamage", percent: 10 }],
+      }]]),
+      skillById: new Map(),
+      specializationById: new Map([[4, { id: 4, minorTraits: [] }]]),
+    };
+    const opts = {
+      activeCatalog,
+      specializations: [{ id: 4, majorChoices: { 1: 500 } }],
+    };
+    // Base Vitality 1000 → +100 Condition Damage from the conversion.
+    const withTrait = computePublishStats({ slots: {}, runes: {}, infusions: {} }, null, "Necromancer", "pve", opts);
+    expect(withTrait.stats.ConditionDamage).toBe(100);
+    // Without the spec selected, no conversion is applied.
+    const without = computePublishStats({ slots: {}, runes: {}, infusions: {} }, null, "Necromancer");
+    expect(without.stats.ConditionDamage).toBe(0);
+  });
+
   test("derived stat: CritChance computed from Precision", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Necromancer");
-    // Precision = 2141 => (2141 - 1000) / 21 + 5 = 54.333... + 5 = 59.33%
-    expect(result.stats.CritChance).toBe("59.33%");
+    // Precision = 1961 (active set) => (1961 - 895) / 21 = 50.76%
+    expect(result.stats.CritChance).toBe("50.76%");
   });
 
   test("derived stat: CritDamage computed from Ferocity", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Necromancer");
-    // Ferocity = 1141 => 150 + 1141/15 = 150 + 76.066... = 226.1%
-    expect(result.stats.CritDamage).toBe("226.1%");
+    // Ferocity = 961 (active set) => 150 + 961/15 = 150 + 64.066... = 214.1%
+    expect(result.stats.CritDamage).toBe("214.1%");
   });
 
   test("derived stat: BoonDuration is 0.0% for Berserker's (no Concentration)", () => {
@@ -137,9 +181,11 @@ describe("computePublishStats", () => {
     expect(result.stats.ConditionDamage).toBe(0);
   });
 
-  test("unknown profession falls back to 9212 base HP (matches renderer default)", () => {
+  test("unknown profession falls back to 0 base HP (engine default)", () => {
+    // Real builds always carry a valid profession; the engine uses a 0 base for
+    // anything it doesn't recognize (only base-Vitality HP remains).
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "UnknownProf");
-    expect(result.stats.Health).toBe(9212 + 1000 * 10);
+    expect(result.stats.Health).toBe(0 + 1000 * 10);
   });
 
   test("rune bonuses are added when upgradeCatalog is provided", () => {
@@ -187,12 +233,12 @@ describe("computePublishStats", () => {
     for (const slot of ALL_STAT_SLOTS) slots[slot] = "Viper's";
     const equipment = { slots, runes: {}, infusions: {} };
     const result = computePublishStats(equipment, null, "Necromancer");
-    // Major stats (Power, CondDmg) sum of p4 across all 16 slots = 1381
-    expect(result.stats.Power).toBe(1000 + 1381);
-    expect(result.stats.ConditionDamage).toBe(1381);
-    // Minor stats (Precision, Expertise) sum of s4 across all 16 slots = 750
-    expect(result.stats.Precision).toBe(1000 + 750);
-    expect(result.stats.Expertise).toBe(750);
+    // Active set only (14 slots): major (Power, CondDmg) sum of p4 = 1167
+    expect(result.stats.Power).toBe(1000 + 1167);
+    expect(result.stats.ConditionDamage).toBe(1167);
+    // Minor stats (Precision, Expertise) sum of s4 across active slots = 632
+    expect(result.stats.Precision).toBe(1000 + 632);
+    expect(result.stats.Expertise).toBe(632);
   });
 
   test("full Celestial gear: all 9 stats equal", () => {
@@ -200,15 +246,15 @@ describe("computePublishStats", () => {
     for (const slot of ALL_STAT_SLOTS) slots[slot] = "Celestial";
     const equipment = { slots, runes: {}, infusions: {} };
     const result = computePublishStats(equipment, null, "Necromancer");
-    // Celestial: all stats get c weight, sum across 16 slots = 756
-    expect(result.stats.Ferocity).toBe(756);
-    expect(result.stats.ConditionDamage).toBe(756);
-    expect(result.stats.HealingPower).toBe(756);
-    expect(result.stats.Expertise).toBe(756);
-    expect(result.stats.Concentration).toBe(756);
+    // Celestial: all stats get c weight; active set only (14 slots) = 638
+    expect(result.stats.Ferocity).toBe(638);
+    expect(result.stats.ConditionDamage).toBe(638);
+    expect(result.stats.HealingPower).toBe(638);
+    expect(result.stats.Expertise).toBe(638);
+    expect(result.stats.Concentration).toBe(638);
     // Base stats get +1000
-    expect(result.stats.Power).toBe(1000 + 756);
-    expect(result.stats.Precision).toBe(1000 + 756);
+    expect(result.stats.Power).toBe(1000 + 638);
+    expect(result.stats.Precision).toBe(1000 + 638);
   });
 
   // ── New stat sets (issue #133) ──────────────────────────────────────────

--- a/tests/unit/statsCompute.test.js
+++ b/tests/unit/statsCompute.test.js
@@ -49,20 +49,27 @@ describe("computePublishStats", () => {
 
   test("derived stat: Health uses profession base HP + Vitality * 10 (Necromancer)", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Necromancer");
-    // Necromancer base HP = 19212, Vitality = 1000
-    expect(result.stats.Health).toBe(19212 + 1000 * 10);
+    // Necromancer level-80 base HP at 1000 Vitality = 19212 (game truth).
+    // baseHP (excl. base vitality) = 9212; 9212 + 1000*10 = 19212.
+    expect(result.stats.Health).toBe(9212 + 1000 * 10);
   });
 
   test("derived stat: Health uses correct base HP for Warrior", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Warrior");
-    // Warrior base HP = 19212
-    expect(result.stats.Health).toBe(19212 + 1000 * 10);
+    // Warrior level-80 base HP at 1000 Vitality = 19212 (game truth).
+    expect(result.stats.Health).toBe(9212 + 1000 * 10);
   });
 
   test("derived stat: Health uses correct base HP for Elementalist", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "Elementalist");
-    // Elementalist base HP = 11645
-    expect(result.stats.Health).toBe(11645 + 1000 * 10);
+    // Elementalist level-80 base HP at 1000 Vitality = 11645 (game truth).
+    expect(result.stats.Health).toBe(1645 + 1000 * 10);
+  });
+
+  test("derived stat: Health for an elite-spec profession name (Specter, issue from Discord)", () => {
+    // build.profession may be an elite-spec name; Specter is a Thief spec → 11645 at 1000 Vitality.
+    const result = computePublishStats(makeFullBerserkerEquipment(), null, "Specter");
+    expect(result.stats.Health).toBe(1645 + 1000 * 10);
   });
 
   test("derived stat: CritChance computed from Precision", () => {
@@ -130,9 +137,9 @@ describe("computePublishStats", () => {
     expect(result.stats.ConditionDamage).toBe(0);
   });
 
-  test("unknown profession falls back to Elementalist base HP (11645)", () => {
+  test("unknown profession falls back to 9212 base HP (matches renderer default)", () => {
     const result = computePublishStats(makeFullBerserkerEquipment(), null, "UnknownProf");
-    expect(result.stats.Health).toBe(11645 + 1000 * 10);
+    expect(result.stats.Health).toBe(9212 + 1000 * 10);
   });
 
   test("rune bonuses are added when upgradeCatalog is provided", () => {


### PR DESCRIPTION
## Problem

A Discord report (condi support Spectre, full Plague Doctor) showed AxiForge's **published** build page not matching in-game stats. Root cause: the publish path (`src/main/statsCompute.js`) was a hand-rolled reimplementation of the attribute math that diverged from the shared `@axiapps/gw2-data` engine the in-app Attributes panel uses. It:

1. **Double-counted base vitality in Health** — used FULL base HP (Thief 11645, which already includes the 1000 base vitality) *and* added `Vitality × 10`. A Specter at 2172 Vitality showed **33,365** vs the game's **23,365** (+10,000 on every published build).
2. **Counted both weapon sets** — the game/app only count the *active* set, inflating weapon-derived stats when both sets were filled.
3. **Ignored trait flat bonuses and conversions entirely** — under-reporting e.g. condition damage on condi builds (the actual Discord complaint).

## Fix

Make `computePublishStats` a thin wrapper over the engine's `computeAttributes` — the exact code the renderer runs via `engine-bridge.js`. `buildPublish.js` now feeds it the build context it already had (specializations, skills, profession catalog maps, active weapon set), so trait bonuses/conversions and weapon-set exclusion all apply automatically and the published page matches the app/game.

- **Output shape preserved exactly** — `computedStats` is a contract consumed by the external published-build SPA (`gw2eww/axibuilds`).
- Published pages show the **unbuffed baseline** (assumed boons aren't persisted), matching the app's default panel.
- `estimateRole` keeps its own lightweight heuristic.

## Tests

- New: trait-conversion pass-through, weapon-set exclusion (active-set-only + set switch), corrected Health incl. the Specter elite-spec case.
- Updated old expectations that had encoded the bugs (both-weapon-set totals, double-counted Health) to engine truth.
- `statsCompute` 41/41 · full unit suite 1759/1759 · engine suite 38/38.
- Smoke check: Specter Plague Doctor chest → Vitality 1121, CondDmg 121, Health 12855 ✓.

## Known remaining gap (pre-existing, not a regression)

Crit% from rune/sigil *text* (e.g. "+X% Critical Chance") still isn't in published crit — the engine only parses stat attributes; the renderer adds those via `computeUpgradeModifiers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)