### PR TITLE
fix: Cannot find module '@axiapps/gw2-data/engine' when starting AxiForge v0.11.0 (AppImage) (closes #288)

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
   "license": "MIT",
   "dependencies": {
     "@axiapps/code": "*",
+    "@axiapps/gw2-data": "*",
     "dotenv": "^17.3.1",
     "electron-log": "^5.4.4",
     "electron-updater": "^6.8.3",

--- a/tests/unit/mainProcessDeps.test.js
+++ b/tests/unit/mainProcessDeps.test.js
@@ -1,0 +1,58 @@
+/**
+ * Guards against a class of packaging bug (issue #288):
+ *
+ * The renderer is bundled by Vite, so any `@axiapps/*` workspace package it
+ * imports gets inlined at build time. The Electron MAIN process, however,
+ * resolves `require()` at runtime against the packaged asar's node_modules.
+ * electron-builder only copies workspace packages that are declared as
+ * production `dependencies` in package.json — anything required by main but
+ * left undeclared is silently dropped from the build and throws
+ * "Cannot find module '@axiapps/...'" only in the packaged app.
+ *
+ * This test scans src/main for runtime `require("@axiapps/...")` calls and
+ * asserts every referenced package is declared in dependencies, so the next
+ * main-process require of a workspace package can't ship broken.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const MAIN_DIR = path.join(REPO_ROOT, "src", "main");
+
+function collectJsFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectJsFiles(full));
+    else if (entry.isFile() && entry.name.endsWith(".js")) out.push(full);
+  }
+  return out;
+}
+
+// Match require("@axiapps/<pkg>") and require("@axiapps/<pkg>/<subpath>"),
+// capturing just the bare package name "@axiapps/<pkg>".
+const REQUIRE_RE = /require\(\s*["'](@axiapps\/[^"'/]+)(?:\/[^"']*)?["']\s*\)/g;
+
+describe("main-process @axiapps requires are declared dependencies", () => {
+  const pkg = require(path.join(REPO_ROOT, "package.json"));
+  const declared = new Set(Object.keys(pkg.dependencies || {}));
+
+  const required = new Set();
+  for (const file of collectJsFiles(MAIN_DIR)) {
+    const src = fs.readFileSync(file, "utf8");
+    let m;
+    while ((m = REQUIRE_RE.exec(src)) !== null) required.add(m[1]);
+  }
+
+  it("finds at least one @axiapps require in src/main (sanity)", () => {
+    expect(required.size).toBeGreaterThan(0);
+  });
+
+  it.each([...required])(
+    "%s is listed in package.json dependencies",
+    (name) => {
+      expect(declared.has(name)).toBe(true);
+    }
+  );
+});


### PR DESCRIPTION
## Summary

The packaged **v0.11.0 AppImage** crashed on startup with `Error: Cannot find module '@axiapps/gw2-data/engine'` (require stack: `statsCompute.js` → `buildPublish.js` → `index.js`).

**Root cause:** `src/main/statsCompute.js` (introduced in #285) does a runtime `require("@axiapps/gw2-data/engine")` in the Electron main process, but `@axiapps/gw2-data` was never declared in `package.json` `dependencies`. electron-builder only copies workspace packages that are declared production dependencies into the packaged asar's `node_modules`, so the build shipped without it. It worked in dev (node_modules symlink present) and in the renderer (Vite bundles the engine at build time), which is why it slipped through — only the packaged main process failed.

**Fix:** Declare `@axiapps/gw2-data` in `dependencies` (parity with `@axiapps/code`, which is required by main and already declared).

**Systemic guard:** Adds `tests/unit/mainProcessDeps.test.js`, which scans `src/main` for runtime `require("@axiapps/...")` calls and asserts each package is declared in `dependencies` — so the next undeclared main-process workspace require fails CI instead of only the packaged app.

Closes #288