### PR TITLE
fix(ci): unblock Data Drift Audit + bump actions off Node 20

### DIFF
--- a/.github/workflows/data-drift-audit.yml
+++ b/.github/workflows/data-drift-audit.yml
@@ -153,7 +153,13 @@ jobs:
           git checkout -B "$BRANCH"
           git add src/main/gw2Data
           git commit -m "chore(data): sync GW2 API/wiki snapshots ($DATE)"
-          git push --force-with-lease origin "$BRANCH"
+          # Plain --force, NOT --force-with-lease: actions/checkout does a shallow
+          # single-branch fetch (main only), so there's no remote-tracking ref for
+          # $BRANCH. --force-with-lease then reads a missing/stale lease and rejects
+          # with "stale info" on every run after the branch first exists remotely.
+          # The branch is bot-owned and recreated each run (runs are serialized by
+          # the concurrency group), so a plain force push is safe and intended.
+          git push --force origin "$BRANCH"
 
           {
             echo "Automated refresh of the GW2 data snapshots from the API and wiki. These ship to users at runtime (remote-first data loading), so merging updates the live data without an app release."

--- a/.github/workflows/data-drift-audit.yml
+++ b/.github/workflows/data-drift-audit.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -98,7 +98,7 @@ jobs:
           cat audit-summary.md
 
       - name: Upload audit reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: wiki-audit-reports
           path: tests/wiki-audit/results/*.json

--- a/.github/workflows/marketing.yml
+++ b/.github/workflows/marketing.yml
@@ -24,15 +24,15 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
       - name: Upload marketing/ as Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: marketing
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -54,10 +54,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload dry-run artifacts
         if: github.event_name == 'workflow_dispatch' && inputs.publish != true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist-${{ matrix.platform }}
           path: |
@@ -109,7 +109,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Publish release
         env:


### PR DESCRIPTION
Two CI-hygiene changes for the workflows.

## 1. Fix the Data Drift Audit push failure
The scheduled **Data Drift Audit** job fails at *"Push data-sync branch and open/update PR"*:

```
git push --force-with-lease origin chore/data-sync
 ! [rejected]  chore/data-sync -> chore/data-sync (stale info)
```

The sync itself succeeds (drift found, gates pass) — only the push fails, so no data PR opens.

**Root cause:** `actions/checkout` does a shallow, single-branch fetch (`main` only), so the runner has **no remote-tracking ref for `chore/data-sync`**. `--force-with-lease` (no explicit value) reads that missing/stale lease and refuses with *"stale info"* — on every run after the branch first exists remotely (it does: `fad9366`, orphaned).

**Fix:** plain `git push --force`. The branch is bot-owned and deliberately recreated each run, and runs are serialized by the `concurrency` group — no concurrent writer for a lease to protect against.

Reproduced locally with a throwaway bare remote: `--force-with-lease` → rejected *(stale info)*; `--force` → *forced update* ✅.

## 2. Bump actions off the deprecated Node 20 runtime
The runner warns that `checkout@v4`, `setup-node@v4`, `upload-artifact@v4` are forced onto Node 24. Bumped the JS actions to **v5** (the first Node 24 major — minimal jump, lowest risk for the installer-signing release workflow) and the GitHub Pages actions to current majors:

| action | before | after |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-node | v4 | v5 |
| actions/upload-artifact | v4 | v5 |
| actions/configure-pages | v5 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |

All usages are vanilla, so no breaking-change surface. Covers `data-drift-audit.yml`, `release.yml`, `marketing.yml`.

## Verification
- Data-sync push mechanism reproduced/fixed locally (above).
- Action bumps: diff is version-pins only; usages checked against each action's supported inputs.
- Not dispatched live — `release.yml` (signs/builds installers) and `marketing.yml` (deploys the site) can't be safely dry-run; they'll validate on their next real trigger. `data-drift-audit` validates on the next scheduled Thursday run or a maintainer dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)